### PR TITLE
feat: Memory-adaptive startup with context fallback

### DIFF
--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -52,6 +52,9 @@ struct EngineOptions {
     bool enable_vision  = false;
     bool use_cuda_graph = true;
     LoadProgress load_progress;
+    bool allow_context_fallback        = false;
+    std::uint32_t context_fallback_min = 4096;
+    std::uint32_t context_fallback_step = 2048;
 };
 
 struct SamplingParameters {
@@ -256,6 +259,7 @@ struct LoadSummary {
     std::uint64_t peak_staging_bytes   = 0;
     std::size_t tensor_count           = 0;
     std::size_t resource_count         = 0;
+    std::uint32_t effective_max_context = 0;
 };
 
 } // namespace ninfer

--- a/src/runtime/engine/engine.cpp
+++ b/src/runtime/engine/engine.cpp
@@ -44,6 +44,9 @@ public:
         auto constructed = targets::construct_target(options, device);
         active           = std::move(constructed.active);
         load             = std::move(constructed.load);
+        if (load.effective_max_context != 0) {
+            options.max_context = load.effective_max_context;
+        }
     }
 
     ~Impl() noexcept {

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -134,7 +134,14 @@ GenerationService::GenerationService(ServeOptions options) : options_(std::move(
     engine_options.enable_vision  = options_.enable_vision;
     engine_options.use_cuda_graph = options_.use_cuda_graph;
     engine_options.speculative    = options_.speculative;
+    engine_options.allow_context_fallback        = options_.allow_context_fallback;
+    engine_options.context_fallback_min          = options_.context_fallback_min;
+    engine_options.context_fallback_step         = options_.context_fallback_step;
     engine_                       = std::make_unique<ninfer::Engine>(std::move(engine_options));
+    if (const ninfer::LoadSummary summary = load_summary(); summary.effective_max_context != 0) {
+        options_.max_context = summary.effective_max_context;
+    }
+    std::cerr << "ninfer-serve: effective max context = " << options_.max_context << " tokens\n";
 }
 
 PreparedRequest GenerationService::prepare(const GenerationRequest& request) const {

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -61,6 +61,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
+           "[--context-fallback] [--context-fallback-min N] [--context-fallback-step N] "
            "[--lm-head-draft] [--no-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -149,6 +150,14 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
             options.allow_prefix_reuse = false;
+        } else if (arg == "--context-fallback") {
+            options.allow_context_fallback = true;
+        } else if (arg == "--context-fallback-min") {
+            options.context_fallback_min = static_cast<std::uint32_t>(
+                parse_nonnegative_int(require_value("--context-fallback-min"), "context-fallback-min"));
+        } else if (arg == "--context-fallback-step") {
+            options.context_fallback_step = static_cast<std::uint32_t>(
+                parse_nonnegative_int(require_value("--context-fallback-step"), "context-fallback-step"));
         } else if (arg == "--lm-head-draft") {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {
@@ -185,6 +194,9 @@ ServeOptions parse_serve_options(int argc, char** argv) {
     }
     if (options.prefill_chunk == 0 || options.prefill_chunk % 128 != 0) {
         throw std::invalid_argument("--prefill-chunk must be a positive multiple of 128");
+    }
+    if (options.allow_context_fallback && options.context_fallback_min == 0) {
+        throw std::invalid_argument("--context-fallback-min must be positive when --context-fallback is enabled");
     }
     product::validate_speculative_cli_options(options.speculative);
     if (options.speculative.backend == SpeculativeBackend::DFlash && options.enable_vision) {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -36,6 +36,9 @@ struct ServeOptions {
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
     int default_max_tokens = kDefaultMaxTokens;
     bool enable_cors       = false; // send permissive CORS headers for browser UIs
+    bool allow_context_fallback        = false;
+    std::uint32_t context_fallback_min = 4096;
+    std::uint32_t context_fallback_step = 2048;
     // Default sampler applied when a request omits a field. Defaults match the
     // Qwen3 thinking recommendation so real chat clients get non-degenerate
     // decoding out of the box; a request may override any field, and --greedy

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -58,32 +58,61 @@ void validate_device_budget(std::uint64_t weight_bytes, std::size_t sequence_byt
 template <class Target, class Loaded, class Instance>
 ConstructedTarget construct_registered(const EngineOptions& options, DeviceContext& device,
                                        artifact::Reader& reader, Clock::time_point load_start) {
-    auto sequence_plan = Target::plan_sequence(device, options);
+    const bool fallback_enabled = options.allow_context_fallback;
+    const std::uint32_t fallback_min = options.context_fallback_min;
+    const std::uint32_t fallback_step = options.context_fallback_step;
 
-    artifact::Binder binder(reader);
-    auto load_plan = Target::plan_load(binder, options);
-    validate_device_budget(load_plan.materialization().device_capacity_bytes,
-                           sequence_plan.device_reservation_bytes());
-    auto progress     = artifact_progress(options.load_progress);
-    auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
-                                              progress.callback ? &progress : nullptr);
-    const artifact::MaterializationStats stats = materialized.stats();
+    EngineOptions local = options;
+    ConstructedTarget constructed;
+    while (true) {
+        if (local.max_context == 0) {
+            throw std::invalid_argument(
+                "context fallback exhausted; no usable context length fits in device memory");
+        }
 
-    auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
-    auto loaded   = std::make_unique<Loaded>(std::move(model));
-    auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
+        artifact::Binder binder(reader);
+        auto sequence_plan = Target::plan_sequence(device, local);
+        auto load_plan = Target::plan_load(binder, local);
+        try {
+            validate_device_budget(load_plan.materialization().device_capacity_bytes,
+                                   sequence_plan.device_reservation_bytes());
+        } catch (const std::invalid_argument&) {
+            if (!fallback_enabled || local.max_context <= fallback_min) {
+                throw;
+            }
+            if (local.max_context > fallback_min) {
+                local.max_context = local.max_context > fallback_step
+                                        ? local.max_context - fallback_step
+                                        : fallback_min;
+            } else {
+                break;
+            }
+            continue;
+        }
 
-    LoadSummary summary;
-    summary.target               = std::string(Target::target_key);
-    summary.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
-    summary.upload_seconds       = stats.upload_seconds;
-    summary.artifact_bytes_read  = stats.file_bytes;
-    summary.host_to_device_bytes = stats.h2d_bytes;
-    summary.peak_staging_bytes   = stats.peak_staging_bytes;
-    summary.tensor_count         = stats.tensor_count;
-    summary.resource_count       = stats.resource_count;
-    return ConstructedTarget{.active = ActiveTarget(std::move(instance)),
-                             .load   = std::move(summary)};
+        auto progress     = artifact_progress(local.load_progress);
+        auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
+                                                  progress.callback ? &progress : nullptr);
+        const artifact::MaterializationStats stats = materialized.stats();
+
+        auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
+        auto loaded   = std::make_unique<Loaded>(std::move(model));
+        auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
+
+        constructed.load.target               = std::string(Target::target_key);
+        constructed.load.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
+        constructed.load.upload_seconds       = stats.upload_seconds;
+        constructed.load.artifact_bytes_read  = stats.file_bytes;
+        constructed.load.host_to_device_bytes = stats.h2d_bytes;
+        constructed.load.peak_staging_bytes   = stats.peak_staging_bytes;
+        constructed.load.tensor_count         = stats.tensor_count;
+        constructed.load.resource_count       = stats.resource_count;
+        constructed.load.effective_max_context = local.max_context;
+        constructed.active = ActiveTarget(std::move(instance));
+        return constructed;
+    }
+    throw std::invalid_argument(
+        "context fallback exhausted after reaching minimum context=" + std::to_string(fallback_min));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- Adds an opt-in `--context-fallback` path for `ninfer-serve` models that cannot fit a requested `--max-context` on the target GPU.
- Retries target construction with progressively smaller context lengths when the initial allocation exceeds available VRAM.
- Propagates the realized effective context limit through `EngineOptions`, `LoadSummary`, and serve-side metadata so `/v1/models` reports the true built capacity.

## Test Plan
- [x] Build succeeds after CMake + Ninja rebuild
- [x] `ninfer-serve` accepts new flags: `--context-fallback`, `--context-fallback-min`, `--context-fallback-step`
- [x] Verified on a 27B model with requested 262144-token context, requesting DAO to `227328` tokens instead of hard failing on a partially loaded desktop GPU
- [x] End-to-end request returns real completions on the reduced context (`ttft=22ms`, `prefill=502.7tok/s`, `decode=84.2tok/s`)
- [x] Default behavior unchanged when `--context-fallback` is not provided

## Affected files
- `include/ninfer/types.h`
- `src/runtime/engine/engine.cpp`
- `src/serve/generation_service.cpp`
- `src/serve/serve_options.cpp`
- `src/serve/serve_options.h`
- `src/targets/registry.cpp`

## Notes
- Keeps changes minimal and opt-in so existing benchmarking behavior remains unchanged.
- The fallback already validated against the live desktop GPU with both a smaller context and the oversized 262K target.