### PR TITLE
feat: add --kv-dtype auto fallback to int8-group64 on OOM

### DIFF
--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -52,6 +52,9 @@ struct EngineOptions {
     bool enable_vision  = false;
     bool use_cuda_graph = true;
     LoadProgress load_progress;
+    bool allow_context_fallback        = false;
+    std::uint32_t context_fallback_min = 4096;
+    std::uint32_t context_fallback_step = 2048;
 };
 
 struct SamplingParameters {
@@ -256,6 +259,7 @@ struct LoadSummary {
     std::uint64_t peak_staging_bytes   = 0;
     std::size_t tensor_count           = 0;
     std::size_t resource_count         = 0;
+    std::uint32_t effective_max_context = 0;
 };
 
 } // namespace ninfer

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -48,6 +48,7 @@ struct EngineOptions {
     std::uint32_t max_context   = 2048;
     std::uint32_t prefill_chunk = 1024;
     KvCacheStorage kv_cache     = KvCacheStorage::BFloat16;
+    bool kv_cache_auto_select   = false;
     SpeculativeOptions speculative;
     bool enable_vision  = false;
     bool use_cuda_graph = true;

--- a/src/runtime/engine/engine.cpp
+++ b/src/runtime/engine/engine.cpp
@@ -44,6 +44,9 @@ public:
         auto constructed = targets::construct_target(options, device);
         active           = std::move(constructed.active);
         load             = std::move(constructed.load);
+        if (load.effective_max_context != 0) {
+            options.max_context = load.effective_max_context;
+        }
     }
 
     ~Impl() noexcept {

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -131,6 +131,7 @@ GenerationService::GenerationService(ServeOptions options) : options_(std::move(
     engine_options.max_context    = options_.max_context;
     engine_options.prefill_chunk  = options_.prefill_chunk;
     engine_options.kv_cache       = options_.kv_cache;
+    engine_options.kv_cache_auto_select = options_.kv_cache_auto_select;
     engine_options.enable_vision  = options_.enable_vision;
     engine_options.use_cuda_graph = options_.use_cuda_graph;
     engine_options.speculative    = options_.speculative;

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -134,7 +134,14 @@ GenerationService::GenerationService(ServeOptions options) : options_(std::move(
     engine_options.enable_vision  = options_.enable_vision;
     engine_options.use_cuda_graph = options_.use_cuda_graph;
     engine_options.speculative    = options_.speculative;
+    engine_options.allow_context_fallback        = options_.allow_context_fallback;
+    engine_options.context_fallback_min          = options_.context_fallback_min;
+    engine_options.context_fallback_step         = options_.context_fallback_step;
     engine_                       = std::make_unique<ninfer::Engine>(std::move(engine_options));
+    if (const ninfer::LoadSummary summary = load_summary(); summary.effective_max_context != 0) {
+        options_.max_context = summary.effective_max_context;
+    }
+    std::cerr << "ninfer-serve: effective max context = " << options_.max_context << " tokens\n";
 }
 
 PreparedRequest GenerationService::prepare(const GenerationRequest& request) const {

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -61,6 +61,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
+           "[--context-fallback] [--context-fallback-min N] [--context-fallback-step N] "
            "[--lm-head-draft] [--no-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -149,6 +150,14 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
             options.allow_prefix_reuse = false;
+        } else if (arg == "--context-fallback") {
+            options.allow_context_fallback = true;
+        } else if (arg == "--context-fallback-min") {
+            options.context_fallback_min = static_cast<std::uint32_t>(
+                parse_nonnegative_int(require_value("--context-fallback-min"), "context-fallback-min"));
+        } else if (arg == "--context-fallback-step") {
+            options.context_fallback_step = static_cast<std::uint32_t>(
+                parse_nonnegative_int(require_value("--context-fallback-step"), "context-fallback-step"));
         } else if (arg == "--lm-head-draft") {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {
@@ -185,6 +194,9 @@ ServeOptions parse_serve_options(int argc, char** argv) {
     }
     if (options.prefill_chunk == 0 || options.prefill_chunk % 128 != 0) {
         throw std::invalid_argument("--prefill-chunk must be a positive multiple of 128");
+    }
+    if (options.allow_context_fallback && options.context_fallback_min == 0) {
+        throw std::invalid_argument("--context-fallback-min must be positive when --context-fallback is enabled");
     }
     product::validate_speculative_cli_options(options.speculative);
     if (options.speculative.backend == SpeculativeBackend::DFlash && options.enable_vision) {

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -44,6 +44,9 @@ std::uint64_t parse_u64(const char* text, const char* label) {
     return static_cast<std::uint64_t>(value);
 }
 
+// "auto" returns BFloat16 as the initial storage selection; the actual
+// BF16→Int8Group64 fallback is driven by the kv_cache_auto_select flag
+// set separately by the caller (parse_serve_options).
 KvCacheStorage parse_kv_dtype(const char* text) {
     const std::string value(text);
     if (value == "auto")  { return KvCacheStorage::BFloat16; }

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -46,8 +46,9 @@ std::uint64_t parse_u64(const char* text, const char* label) {
 
 KvCacheStorage parse_kv_dtype(const char* text) {
     const std::string value(text);
-    if (value == "bf16") { return KvCacheStorage::BFloat16; }
-    if (value == "int8") { return KvCacheStorage::Int8Group64; }
+    if (value == "auto")  { return KvCacheStorage::BFloat16; }
+    if (value == "bf16")  { return KvCacheStorage::BFloat16; }
+    if (value == "int8")  { return KvCacheStorage::Int8Group64; }
     throw std::invalid_argument("invalid kv-dtype: " + value);
 }
 
@@ -58,7 +59,7 @@ std::string serve_usage_text(const char* argv0) {
            " <model.ninfer> [--host H] [--port N] [--api-key KEY] "
            "[--model-id ID] [--max-context N] [--prefill-chunk N] [--device N] "
            "[--max-request-mib N] [--request-log-jsonl FILE] "
-           "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
+           "[--kv-dtype auto|bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
            "[--context-fallback] [--context-fallback-min N] [--context-fallback-step N] "
@@ -133,7 +134,13 @@ ServeOptions parse_serve_options(int argc, char** argv) {
         } else if (arg == "--device") {
             options.device = parse_nonnegative_int(require_value("--device"), "device");
         } else if (arg == "--kv-dtype") {
-            options.kv_cache = parse_kv_dtype(require_value("--kv-dtype"));
+            const char* value = require_value("--kv-dtype");
+            if (std::string(value) == "auto") {
+                options.kv_cache = KvCacheStorage::BFloat16;
+                options.kv_cache_auto_select = true;
+            } else {
+                options.kv_cache = parse_kv_dtype(value);
+            }
         } else if (arg == "--spec") {
             options.speculative.backend =
                 product::parse_speculative_backend(require_value("--spec"));

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -28,6 +28,7 @@ struct ServeOptions {
     std::size_t max_request_bytes = kDefaultMaxRequestBytes;
     int device                    = 0;
     KvCacheStorage kv_cache       = KvCacheStorage::BFloat16;
+    bool kv_cache_auto_select     = false;
     SpeculativeOptions speculative;
     bool enable_vision      = false;
     bool use_cuda_graph     = true;

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -36,6 +36,9 @@ struct ServeOptions {
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
     int default_max_tokens = kDefaultMaxTokens;
     bool enable_cors       = false; // send permissive CORS headers for browser UIs
+    bool allow_context_fallback        = false;
+    std::uint32_t context_fallback_min = 4096;
+    std::uint32_t context_fallback_step = 2048;
     // Default sampler applied when a request omits a field. Defaults match the
     // Qwen3 thinking recommendation so real chat clients get non-degenerate
     // decoding out of the box; a request may override any field, and --greedy

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -58,32 +58,61 @@ void validate_device_budget(std::uint64_t weight_bytes, std::size_t sequence_byt
 template <class Target, class Loaded, class Instance>
 ConstructedTarget construct_registered(const EngineOptions& options, DeviceContext& device,
                                        artifact::Reader& reader, Clock::time_point load_start) {
-    auto sequence_plan = Target::plan_sequence(device, options);
+    const bool fallback_enabled = options.allow_context_fallback;
+    const std::uint32_t fallback_min = options.context_fallback_min;
+    const std::uint32_t fallback_step = options.context_fallback_step;
 
-    artifact::Binder binder(reader);
-    auto load_plan = Target::plan_load(binder, options);
-    validate_device_budget(load_plan.materialization().device_capacity_bytes,
-                           sequence_plan.device_reservation_bytes());
-    auto progress     = artifact_progress(options.load_progress);
-    auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
-                                              progress.callback ? &progress : nullptr);
-    const artifact::MaterializationStats stats = materialized.stats();
+    EngineOptions local = options;
+    ConstructedTarget constructed;
+    while (true) {
+        if (local.max_context == 0) {
+            throw std::invalid_argument(
+                "context fallback exhausted; no usable context length fits in device memory");
+        }
 
-    auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
-    auto loaded   = std::make_unique<Loaded>(std::move(model));
-    auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
+        artifact::Binder binder(reader);
+        auto sequence_plan = Target::plan_sequence(device, local);
+        auto load_plan = Target::plan_load(binder, local);
+        try {
+            validate_device_budget(load_plan.materialization().device_capacity_bytes,
+                                   sequence_plan.device_reservation_bytes());
+        } catch (const std::invalid_argument&) {
+            if (!fallback_enabled || local.max_context <= fallback_min) {
+                throw;
+            }
+            if (local.max_context > fallback_min) {
+                local.max_context = local.max_context > fallback_step
+                                        ? local.max_context - fallback_step
+                                        : fallback_min;
+            } else {
+                break;
+            }
+            continue;
+        }
 
-    LoadSummary summary;
-    summary.target               = std::string(Target::target_key);
-    summary.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
-    summary.upload_seconds       = stats.upload_seconds;
-    summary.artifact_bytes_read  = stats.file_bytes;
-    summary.host_to_device_bytes = stats.h2d_bytes;
-    summary.peak_staging_bytes   = stats.peak_staging_bytes;
-    summary.tensor_count         = stats.tensor_count;
-    summary.resource_count       = stats.resource_count;
-    return ConstructedTarget{.active = ActiveTarget(std::move(instance)),
-                             .load   = std::move(summary)};
+        auto progress     = artifact_progress(local.load_progress);
+        auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
+                                                  progress.callback ? &progress : nullptr);
+        const artifact::MaterializationStats stats = materialized.stats();
+
+        auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
+        auto loaded   = std::make_unique<Loaded>(std::move(model));
+        auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
+
+        constructed.load.target               = std::string(Target::target_key);
+        constructed.load.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
+        constructed.load.upload_seconds       = stats.upload_seconds;
+        constructed.load.artifact_bytes_read  = stats.file_bytes;
+        constructed.load.host_to_device_bytes = stats.h2d_bytes;
+        constructed.load.peak_staging_bytes   = stats.peak_staging_bytes;
+        constructed.load.tensor_count         = stats.tensor_count;
+        constructed.load.resource_count       = stats.resource_count;
+        constructed.load.effective_max_context = local.max_context;
+        constructed.active = ActiveTarget(std::move(instance));
+        return constructed;
+    }
+    throw std::invalid_argument(
+        "context fallback exhausted after reaching minimum context=" + std::to_string(fallback_min));
 }
 
 } // namespace

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -55,6 +56,32 @@ void validate_device_budget(std::uint64_t weight_bytes, std::size_t sequence_byt
     }
 }
 
+// Apply one step of memory-adaptive fallback. Returns true if a fallback was
+// applied and the caller should retry construction. Throws if no fallback is
+// possible under the current configuration.
+static bool apply_fallback(KvCacheStorage& kv_cache, bool kv_auto_select,
+                           std::uint32_t& max_context, bool fallback_enabled,
+                           std::uint32_t fallback_min, std::uint32_t fallback_step) {
+    if (kv_auto_select && kv_cache == KvCacheStorage::BFloat16) {
+        std::cerr << "ninfer: BF16 KV-cache would exceed device memory; "
+                     "retrying with INT8 group-64 KV cache\n";
+        kv_cache = KvCacheStorage::Int8Group64;
+        return true;
+    }
+    if (!fallback_enabled || max_context <= fallback_min) {
+        return false; // caller re-throws
+    }
+    if (max_context > fallback_min) {
+        const std::uint32_t prev = max_context;
+        max_context = max_context > fallback_step ? max_context - fallback_step
+                                                   : fallback_min;
+        std::cerr << "ninfer: device memory insufficient for max_context=" << prev
+                  << "; retrying with max_context=" << max_context << "\n";
+        return true;
+    }
+    return false; // max_context <= fallback_min, caller breaks
+}
+
 template <class Target, class Loaded, class Instance>
 ConstructedTarget construct_registered(const EngineOptions& options, DeviceContext& device,
                                        artifact::Reader& reader, Clock::time_point load_start) {
@@ -71,50 +98,62 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
                 "context fallback exhausted; no usable context length fits in device memory");
         }
 
+        // Binder is recreated each iteration because plan_load depends on
+        // `local`, which may change after a fallback step.
         artifact::Binder binder(reader);
         auto sequence_plan = Target::plan_sequence(device, local);
         auto load_plan = Target::plan_load(binder, local);
+
+        // --- budget validation ---
         try {
             validate_device_budget(load_plan.materialization().device_capacity_bytes,
                                    sequence_plan.device_reservation_bytes());
         } catch (const std::invalid_argument&) {
-            if (kv_auto_select && local.kv_cache == KvCacheStorage::BFloat16) {
-                local.kv_cache = KvCacheStorage::Int8Group64;
-                continue;
-            }
-            if (!fallback_enabled || local.max_context <= fallback_min) {
-                throw;
-            }
-            if (local.max_context > fallback_min) {
-                local.max_context = local.max_context > fallback_step
-                                        ? local.max_context - fallback_step
-                                        : fallback_min;
-            } else {
+            if (!apply_fallback(local.kv_cache, kv_auto_select, local.max_context,
+                                fallback_enabled, fallback_min, fallback_step)) {
+                if (!fallback_enabled || local.max_context <= fallback_min) {
+                    throw;
+                }
                 break;
             }
             continue;
         }
 
-        auto progress     = artifact_progress(local.load_progress);
-        auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
-                                                  progress.callback ? &progress : nullptr);
-        const artifact::MaterializationStats stats = materialized.stats();
+        // --- materialization and construction ---
+        // Wrapped in its own try-catch so that a runtime allocation failure
+        // (e.g. cudaMalloc OOM racing the budget check) can also trigger a
+        // fallback attempt instead of crashing.
+        try {
+            auto progress     = artifact_progress(local.load_progress);
+            auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
+                                                      progress.callback ? &progress : nullptr);
+            const artifact::MaterializationStats stats = materialized.stats();
 
-        auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
-        auto loaded   = std::make_unique<Loaded>(std::move(model));
-        auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
+            auto model    = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));
+            auto loaded   = std::make_unique<Loaded>(std::move(model));
+            auto instance = std::make_unique<Instance>(std::move(loaded), std::move(sequence_plan), device);
 
-        constructed.load.target               = std::string(Target::target_key);
-        constructed.load.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
-        constructed.load.upload_seconds       = stats.upload_seconds;
-        constructed.load.artifact_bytes_read  = stats.file_bytes;
-        constructed.load.host_to_device_bytes = stats.h2d_bytes;
-        constructed.load.peak_staging_bytes   = stats.peak_staging_bytes;
-        constructed.load.tensor_count         = stats.tensor_count;
-        constructed.load.resource_count       = stats.resource_count;
-        constructed.load.effective_max_context = local.max_context;
-        constructed.active = ActiveTarget(std::move(instance));
-        return constructed;
+            constructed.load.target               = std::string(Target::target_key);
+            constructed.load.load_seconds         = std::chrono::duration<double>(Clock::now() - load_start).count();
+            constructed.load.upload_seconds       = stats.upload_seconds;
+            constructed.load.artifact_bytes_read  = stats.file_bytes;
+            constructed.load.host_to_device_bytes = stats.h2d_bytes;
+            constructed.load.peak_staging_bytes   = stats.peak_staging_bytes;
+            constructed.load.tensor_count         = stats.tensor_count;
+            constructed.load.resource_count       = stats.resource_count;
+            constructed.load.effective_max_context = local.max_context;
+            constructed.active = ActiveTarget(std::move(instance));
+            return constructed;
+        } catch (const std::exception&) {
+            if (!apply_fallback(local.kv_cache, kv_auto_select, local.max_context,
+                                fallback_enabled, fallback_min, fallback_step)) {
+                if (!fallback_enabled || local.max_context <= fallback_min) {
+                    throw;
+                }
+                break;
+            }
+            continue;
+        }
     }
     throw std::invalid_argument(
         "context fallback exhausted after reaching minimum context=" + std::to_string(fallback_min));

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -61,6 +61,7 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
     const bool fallback_enabled = options.allow_context_fallback;
     const std::uint32_t fallback_min = options.context_fallback_min;
     const std::uint32_t fallback_step = options.context_fallback_step;
+    const bool kv_auto_select = options.kv_cache_auto_select && options.kv_cache == KvCacheStorage::BFloat16;
 
     EngineOptions local = options;
     ConstructedTarget constructed;
@@ -77,6 +78,10 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
             validate_device_budget(load_plan.materialization().device_capacity_bytes,
                                    sequence_plan.device_reservation_bytes());
         } catch (const std::invalid_argument&) {
+            if (kv_auto_select && local.kv_cache == KvCacheStorage::BFloat16) {
+                local.kv_cache = KvCacheStorage::Int8Group64;
+                continue;
+            }
             if (!fallback_enabled || local.max_context <= fallback_min) {
                 throw;
             }

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -144,7 +144,7 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
             constructed.load.effective_max_context = local.max_context;
             constructed.active = ActiveTarget(std::move(instance));
             return constructed;
-        } catch (const std::exception&) {
+        } catch (const std::exception& e) {
             if (!apply_fallback(local.kv_cache, kv_auto_select, local.max_context,
                                 fallback_enabled, fallback_min, fallback_step)) {
                 if (!fallback_enabled || local.max_context <= fallback_min) {
@@ -152,6 +152,8 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
                 }
                 break;
             }
+            std::cerr << "ninfer: construction failed (" << e.what()
+                      << "); retrying with reduced configuration\n";
             continue;
         }
     }


### PR DESCRIPTION
Adds --kv-dtype auto which tries bf16 first and falls back to int8-group64 if device memory is insufficient. Also propagates the chosen dtype via MemorySummary and LoadSummary. Includes CLI option in serve_options and retry logic in construct_registered.