### PR TITLE
fix(dflash): handle prefill chunks larger than local window

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/dflash_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/dflash_impl.h
@@ -13,6 +13,7 @@
 #include "ninfer/ops/prepare_masked_block.h"
 #include "ninfer/ops/rmsnorm.h"
 #include "ninfer/ops/rope.h"
+#include "ninfer/ops/scalar.h"
 #include "ninfer/ops/speculative_round.h"
 #include "ninfer/ops/swa.h"
 
@@ -63,6 +64,26 @@ void dflash_append_context_impl(State& state, const Tensor& features, const Tens
             commit_count.ne[0] != 1) {
             throw std::invalid_argument("DFlash context append inputs are invalid");
         }
+        const bool replace_local_window = tokens > Config::local_capacity;
+        if (replace_local_window &&
+            (envelope.min_count != static_cast<std::uint32_t>(tokens) ||
+             envelope.max_count != static_cast<std::uint32_t>(tokens))) {
+            throw std::invalid_argument(
+                "DFlash oversized local append requires an exact full-prefix commit");
+        }
+        const int local_offset = replace_local_window ? tokens - Config::local_capacity : 0;
+        const int local_tokens =
+            replace_local_window ? Config::local_capacity : tokens;
+        const ops::KVCacheAppendPrefixExecutionEnvelope local_envelope{
+            replace_local_window ? static_cast<std::uint32_t>(Config::local_capacity)
+                                 : envelope.min_count,
+            replace_local_window ? static_cast<std::uint32_t>(Config::local_capacity)
+                                 : envelope.max_count,
+        };
+        Tensor append_count = commit_count;
+        if (replace_local_window) {
+            ops::set_i32_scalar(append_count, Config::local_capacity, state.device.stream);
+        }
 
         state.work.reset();
         Tensor projected = state.work.alloc(DType::BF16, {Config::hidden, tokens});
@@ -75,26 +96,36 @@ void dflash_append_context_impl(State& state, const Tensor& features, const Tens
         for (int layer = 0; layer < Config::layers; ++layer) {
             auto layer_scope   = state.work.scope();
             const auto& weight = state.model.dflash->layers.at(static_cast<std::size_t>(layer));
+            const bool local_layer = layer < Config::local_layers;
+            const int layer_tokens = local_layer ? local_tokens : tokens;
+            Tensor layer_context =
+                local_layer ? context.slice(1, local_offset, local_tokens) : context;
+            Tensor layer_positions =
+                local_layer ? positions.slice(0, local_offset, local_tokens) : positions;
             Tensor key_raw =
-                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, tokens});
+                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, layer_tokens});
             Tensor value =
-                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, tokens});
-            Tensor key_flat   = key_raw.view({Config::kv_size, tokens});
-            Tensor value_flat = value.view({Config::kv_size, tokens});
-            ops::linear_pair(context, weight.context_key, weight.context_value, key_flat,
+                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, layer_tokens});
+            Tensor key_flat   = key_raw.view({Config::kv_size, layer_tokens});
+            Tensor value_flat = value.view({Config::kv_size, layer_tokens});
+            ops::linear_pair(layer_context, weight.context_key, weight.context_value, key_flat,
                              value_flat, state.work, state.device.stream);
             Tensor key =
-                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, tokens});
+                state.work.alloc(DType::BF16, {Config::head_dim, Config::kv_heads, layer_tokens});
             ops::rmsnorm(key_raw, weight.key_norm, Config::rms_epsilon, false, key,
                          state.device.stream);
-            ops::rope(positions, Config::head_dim, Config::rope_theta, key, state.device.stream);
-            if (layer < Config::local_layers) {
+            ops::rope(layer_positions, Config::head_dim, Config::rope_theta, key,
+                      state.device.stream);
+            if (local_layer) {
                 ops::kv_cache_append_prefix(
-                    key, value, positions, commit_count, envelope,
+                    key, value, layer_positions, append_count, local_envelope,
                     state.dflash->local_layer(static_cast<std::uint32_t>(layer)),
                     state.device.stream);
             } else {
-                ops::kv_cache_append_prefix(key, value, positions, commit_count, envelope,
+                if (replace_local_window && layer == Config::local_layers) {
+                    ops::set_i32_scalar(append_count, tokens, state.device.stream);
+                }
+                ops::kv_cache_append_prefix(key, value, positions, append_count, envelope,
                                             state.dflash->full_layer(), state.device.stream);
             }
         }


### PR DESCRIPTION
## Problem

DFlash prefill publishes each captured feature chunk into both its five 4,096-token local cyclic caches and its full-context cache. With `--prefill-chunk 8192`, any prompt chunk larger than 4,096 tokens passes an append envelope larger than the cyclic capacity and fails with:

```
kv_cache_append_prefix: invalid cyclic cache
```

This is platform-independent and was reproduced with the unmodified Linux/WSL build from `0c28c9c`.

## Design

For an exact prefill commit larger than the local window:

- project and publish only the newest 4,096 feature rows for each local DFlash layer;
- set the device commit scalar to the local capacity for those cyclic-cache appends;
- restore the full token count before publishing the full-context DFlash layer; and
- reject oversized dynamic/non-exact append envelopes rather than silently changing their semantics.

The local projections now consume the sliced context directly, so K/V values that cannot remain in the cyclic window are not computed. Decode-time DFlash appends and chunks at or below 4,096 tokens retain their existing path.

No public CLI or serving contract changes. The fix makes the existing `--prefill-chunk 8192` configuration valid for long DFlash prompts.

## Verification

Hardware: NVIDIA GeForce RTX 5090 (`sm_120a`).

Toolchains:

- native Windows: CUDA 13.3, MSVC 19.51, Release build;
- WSL2 Ubuntu: CUDA 13.1.115, GCC 13.3, Release build.

Unpatched WSL reproduction:

```text
35B-A3B, max-context=262144, prefill-chunk=8192, INT8 KV,
DFlash15, streaming, 4 messages, 21 tools, thinking enabled,
prompt > 4096 tokens
```

The stream returned `internal_error`, and the server logged `kv_cache_append_prefix: invalid cyclic cache`.

Fixed real-model serving checks:

- native Windows, INT8 KV, 9,758-token prompt: HTTP 200, 64 generated tokens, DFlash 2.88 tokens/round;
- WSL2, INT8 KV, 8,622-token prompt: HTTP 200, 64 generated tokens, DFlash 2.38 tokens/round;
- native Windows, BF16 KV at 131,072 context, 7,464-token prompt: HTTP 200, 64 generated tokens, DFlash 2.88 tokens/round.

All used `--prefill-chunk 8192`, DFlash15, streaming, 4 messages, 21 tools, and thinking enabled. No cyclic-cache error occurred after the fix.

A full 262,144-context BF16 startup could not be tested because the memory planner correctly rejected the 34,274,939,392-byte requirement with 32,499,564,544 bytes free. This is unrelated to the changed DFlash auxiliary cache path.

## AI assistance

The implementation was produced with OpenAI Codex based on GPT-5 and reviewed and validated through the reproductions above.