### PR TITLE
feat(kv-cache): support independent key and value formats

### DIFF
--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -93,10 +93,6 @@ std::string format_finish(ninfer::FinishReason reason) {
     return "unknown";
 }
 
-std::string format_kv_cache(ninfer::KvCacheStorage storage) {
-    return storage == ninfer::KvCacheStorage::BFloat16 ? "bf16" : "int8-group64";
-}
-
 void print_stage(std::string_view group, std::string_view detail, double seconds) {
     std::cerr << std::left << std::setw(12) << group << std::setw(26) << detail << std::right
               << std::setw(12) << format_seconds(seconds) << '\n';
@@ -186,7 +182,7 @@ void print_generation_summary(const ninfer::GenerationResult& result,
     print_metric("max context", std::to_string(memory.max_context));
     print_metric("gpu weights used", format_arena_used(memory.weights));
     print_metric("gpu sequence used", format_arena_used(memory.sequence));
-    print_metric("kv cache dtype", format_kv_cache(memory.kv_cache));
+    print_metric("kv cache dtype", ninfer::kv_cache_storage_name(memory.kv_cache));
     print_metric("kv cache payload", format_bytes(memory.kv_payload_bytes));
     print_metric("gpu workspace peak", format_arena_peak(memory.workspace));
     print_metric("gpu reserved total", format_bytes(reserved));

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -52,10 +52,24 @@ float parse_float(const char* text, std::string_view label, float minimum, float
     return static_cast<float>(value);
 }
 
-KvCacheStorage parse_kv_cache(std::string_view text) {
-    if (text == "bf16") { return KvCacheStorage::BFloat16; }
-    if (text == "int8") { return KvCacheStorage::Int8Group64; }
+KvCacheFormat parse_kv_format(std::string_view text) {
+    if (text == "bf16") { return KvCacheFormat::BFloat16; }
+    if (text == "int8") { return KvCacheFormat::Int8Group64; }
     throw std::invalid_argument("invalid kv-dtype: " + std::string(text));
+}
+
+// K/V formats are selected independently as "<k>:<v>" (e.g. "bf16:int8" keeps K in
+// BF16 and quantizes V to INT8-G64); a bare value selects the same format for both.
+KvCacheStorage parse_kv_cache(std::string_view text) {
+    const std::size_t separator = text.find(':');
+    if (separator == std::string_view::npos) {
+        return kv_cache_uniform(parse_kv_format(text));
+    }
+    if (separator == 0 || separator + 1 >= text.size()) {
+        throw std::invalid_argument("invalid kv-dtype: " + std::string(text));
+    }
+    return KvCacheStorage{parse_kv_format(text.substr(0, separator)),
+                          parse_kv_format(text.substr(separator + 1))};
 }
 
 } // namespace
@@ -64,7 +78,8 @@ std::string usage_text(const char* argv0) {
     return std::string("usage: ") + argv0 +
            " <model.ninfer> (--prompt <text>|--messages <messages.json>)\n"
            "       [--max-context N] [--prefill-chunk N] [--max-new N] [--device N]\n"
-           "       [--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N]\n"
+           "       [--kv-dtype bf16|int8|bf16:int8|int8:bf16]\n"
+           "       [--spec mtp|dflash --draft-tokens N]\n"
            "       [--lm-head-draft]\n"
            "       [--temperature F] [--top-p F] [--top-k N] [--min-p F]\n"
            "       [--presence-penalty F] [--frequency-penalty F] [--seed N] [--greedy]\n"

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -21,7 +21,7 @@ struct Options {
     std::uint32_t prefill_chunk = 1024;
     int device                  = 0;
 
-    KvCacheStorage kv_cache = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     SpeculativeOptions speculative;
     bool enable_vision  = false;
     bool use_cuda_graph = true;

--- a/bench/README.md
+++ b/bench/README.md
@@ -44,7 +44,7 @@ ninfer_bench --weights <artifact.ninfer>
           [-pg, --prompt-gen <P,G;P,G...>]
           [-r, --repetitions <n>] [--warmup <n>]
           [--max-ctx <tokens>] [--prefill-chunk <tokens>]
-          [--kv-dtype <bf16|int8>]
+          [--kv-dtype <bf16|int8|bf16:int8|int8:bf16>]
           [--mtp-draft-tokens <0..5>] [--lm-head-draft]
           [--device <id>] [--no-cuda-graph] [--profile-measured]
           [-o, --output <table|json|csv>] [--output-file <path>]

--- a/bench/ops/attention_layer_bench.cu
+++ b/bench/ops/attention_layer_bench.cu
@@ -540,7 +540,7 @@ Result run_case(Resources<Geometry>& resources, KVCache& cache, ninfer::DeviceBu
                             ? "prompt_control"
                             : ops::detail::gqa_attention_route_name(selected_route);
     const std::string attention_route =
-        std::string("gqa.") + route + ".append." + kv_dtype_name(cache.dtype);
+        std::string("gqa.") + route + ".append." + kv_dtype_name(cache.k_dtype);
     const std::string input_route   = options.input == InputSelection::Dv07Control
                                           ? Geometry::input_control_route(tokens)
                                           : Geometry::input_route(tokens);
@@ -554,7 +554,7 @@ Result run_case(Resources<Geometry>& resources, KVCache& cache, ninfer::DeviceBu
                                           ? "sigmoid_mul.candidate.bf16x8_b128"
                                           : "sigmoid_mul.production";
     return {Geometry::name,
-            kv_dtype_name(cache.dtype),
+            kv_dtype_name(cache.k_dtype),
             context,
             tokens,
             graph.nodes(),
@@ -577,9 +577,10 @@ void run_geometry(const Options& options, cudaStream_t stream, ninfer::DeviceBuf
     const DType kv_dtype = select_kv_dtype(options.kv, Geometry::default_kv_dtype);
 
     LayoutBuilder cache_builder;
-    const KVCacheLayout cache_layout =
-        plan_kv_cache(cache_builder, 1, static_cast<std::uint32_t>(max_context), Geometry::kv_heads,
-                      kHeadDim, kv_dtype, kv_dtype == DType::I8 ? kKvQuantGroup : 0);
+    const KVCacheLayout cache_layout = plan_kv_cache(
+        cache_builder, 1, static_cast<std::uint32_t>(max_context), Geometry::kv_heads, kHeadDim,
+        kv_dtype, kv_dtype, kv_dtype == DType::I8 ? kKvQuantGroup : 0,
+        kv_dtype == DType::I8 ? kKvQuantGroup : 0);
     DeviceArena cache_arena(cache_builder.finish(256));
     KVCache cache(cache_arena.alloc_bytes(cache_arena.capacity()), cache_layout);
     CUDA_CHECK(cudaMemset(cache_arena.base(), 0, cache_arena.capacity()));

--- a/bench/ops/bidirectional_gqa_attention_bench.cu
+++ b/bench/ops/bidirectional_gqa_attention_bench.cu
@@ -151,8 +151,10 @@ KVCacheLayerView make_context(DeviceBuffer& k, DeviceBuffer& v, int maximum, int
         .padded_context = static_cast<std::uint32_t>(padded),
         .num_kv_heads   = kKVHeads,
         .head_dim       = kD,
-        .dtype          = DType::BF16,
-        .quant_group    = 0,
+        .k_dtype        = DType::BF16,
+        .v_dtype        = DType::BF16,
+        .k_quant_group  = 0,
+        .v_quant_group  = 0,
     };
 }
 

--- a/bench/ops/gqa_attention_bench.cu
+++ b/bench/ops/gqa_attention_bench.cu
@@ -769,7 +769,7 @@ void run_decode(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Tensor& 
     DeviceBuffer pos_buf = make_i32(pos_value);
     Tensor pos(pos_buf.p, DType::I32, {1});
 
-    const DecodeBytes bytes  = decode_bytes(pos_value, kv.dtype);
+    const DecodeBytes bytes  = decode_bytes(pos_value, kv.k_dtype);
     std::uint32_t next_layer = 0;
 
     const Result r = bench_loop(
@@ -784,8 +784,8 @@ void run_decode(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Tensor& 
 
     char tag[96];
     std::snprintf(tag, sizeof(tag), "gqa_attention decode combined pos=%d kv=%s", pos_value,
-                  kv_dtype_name(kv.dtype));
-    print_decode_result(tag, r, bytes, pos_value, kv.dtype, round_robin_layers,
+                  kv_dtype_name(kv.k_dtype));
+    print_decode_result(tag, r, bytes, pos_value, kv.k_dtype, round_robin_layers,
                         (round_robin_layers == 1u) ? " hot_cache_info" : "");
 }
 
@@ -794,7 +794,7 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
                       DeviceBuffer* cold_cache) {
     DeviceBuffer pos_buf = make_i32(pos_value);
     Tensor pos(pos_buf.p, DType::I32, {1});
-    const DecodeBytes bytes = decode_bytes(pos_value, kv.dtype);
+    const DecodeBytes bytes = decode_bytes(pos_value, kv.k_dtype);
 
     cudaStream_t stream = nullptr;
     if (cold_cache != nullptr) {
@@ -808,12 +808,13 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
 
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention decode pos=%d", pos_value);
-        print_decode_result(tag, r, bytes, pos_value, kv.dtype, 1u, " cold_cache");
+        print_decode_result(tag, r, bytes, pos_value, kv.k_dtype, 1u, " cold_cache");
         std::printf("PROFILE_COLD_METADATA pos=%d kv_dtype=%s splits=%d kps=%d "
                     "cold_cache_bytes=%zu "
                     "useful_kv_bytes=%zu scratch_bytes=%zu total_modeled_bytes=%zu repeats=%d\n",
-                    pos_value, kv_dtype_name(kv.dtype), decode_active_splits(pos_value, kv.dtype),
-                    decode_kps(pos_value, kv.dtype), cold_cache->bytes, bytes.useful_kv,
+                    pos_value, kv_dtype_name(kv.k_dtype),
+                    decode_active_splits(pos_value, kv.k_dtype),
+                    decode_kps(pos_value, kv.k_dtype), cold_cache->bytes, bytes.useful_kv,
                     bytes.scratch, bytes.total, r.n_runs);
         return;
     }
@@ -824,8 +825,9 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
 
     std::printf("PROFILE_ONCE gqa_attention decode combined pos=%d kv_dtype=%s splits=%d kps=%d "
                 "useful_kv_bytes=%zu scratch_bytes=%zu total_modeled_bytes=%zu\n",
-                pos_value, kv_dtype_name(kv.dtype), decode_active_splits(pos_value, kv.dtype),
-                decode_kps(pos_value, kv.dtype), bytes.useful_kv, bytes.scratch, bytes.total);
+                pos_value, kv_dtype_name(kv.k_dtype),
+                decode_active_splits(pos_value, kv.k_dtype), decode_kps(pos_value, kv.k_dtype),
+                bytes.useful_kv, bytes.scratch, bytes.total);
 }
 
 void run_append_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) {
@@ -846,7 +848,7 @@ void run_append_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.dtype);
+    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.k_dtype);
     const Result r          = bench_loop(
         [&](cudaStream_t s) {
             ops::gqa_attention(tq, tk, tv, tpos, kScale, kv.layer_view(0),
@@ -856,8 +858,9 @@ void run_append_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
         static_cast<double>(bytes.total));
 
     char tag[96];
-    std::snprintf(tag, sizeof(tag), "gqa_attention append-small-T kv=%s", kv_dtype_name(kv.dtype));
-    print_append_small_t_result(tag, r, bytes, tokens, context, kv.dtype, "");
+    std::snprintf(tag, sizeof(tag), "gqa_attention append-small-T kv=%s",
+                  kv_dtype_name(kv.k_dtype));
+    print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, "");
 }
 
 void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t context,
@@ -879,7 +882,7 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.dtype);
+    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.k_dtype);
     cudaStream_t stream     = nullptr;
     if (cold_cache != nullptr) {
         const Result r = bench_cold_cache_loop(
@@ -891,22 +894,22 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
             *cold_cache, static_cast<double>(bytes.total));
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention append-small-T kv=%s",
-                      kv_dtype_name(kv.dtype));
-        print_append_small_t_result(tag, r, bytes, tokens, context, kv.dtype, " cold_cache");
+                      kv_dtype_name(kv.k_dtype));
+        print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, " cold_cache");
         const VerifyRoute route = verify_route(tokens, context);
         std::printf("PROFILE_COLD_METADATA mode=append-small-t T=%d context=%d kv_dtype=%s "
                     "route=%s chunks=%d "
                     "cold_cache_bytes=%zu useful_kv_bytes=%zu scratch_bytes=%zu "
                     "total_modeled_bytes=%zu redundancy=%.6f repeats=%d "
                     "ncu_kernel_regex='%s'\n",
-                    tokens, context, kv_dtype_name(kv.dtype),
+                    tokens, context, kv_dtype_name(kv.k_dtype),
                     ops::detail::gqa_attention_route_name(route),
                     verify_route_chunks(tokens, route), cold_cache->bytes, bytes.useful_kv,
                     bytes.scratch, bytes.total,
                     bytes.useful_kv > 0
                         ? static_cast<double>(bytes.total) / static_cast<double>(bytes.useful_kv)
                         : 0.0,
-                    r.n_runs, verify_route_ncu_kernel_regex(route, kv.dtype));
+                    r.n_runs, verify_route_ncu_kernel_regex(route, kv.k_dtype));
         return;
     }
 
@@ -919,13 +922,13 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
                 "chunks=%d "
                 "useful_kv_bytes=%zu scratch_bytes=%zu total_model_bytes=%zu redundancy=%.6f "
                 "ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.dtype),
+                tokens, context, kv_dtype_name(kv.k_dtype),
                 ops::detail::gqa_attention_route_name(route), verify_route_chunks(tokens, route),
                 bytes.useful_kv, bytes.scratch, bytes.total,
                 bytes.useful_kv > 0
                     ? static_cast<double>(bytes.total) / static_cast<double>(bytes.useful_kv)
                     : 0.0,
-                verify_route_ncu_kernel_regex(route, kv.dtype));
+                verify_route_ncu_kernel_regex(route, kv.k_dtype));
 }
 
 void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) {
@@ -940,7 +943,7 @@ void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.dtype);
+    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.k_dtype);
     const Result r          = bench_loop(
         [&](cudaStream_t s) {
             ops::gqa_attention_cached(tq, tpos, kScale, kv.layer_view(0),
@@ -950,8 +953,9 @@ void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
         static_cast<double>(bytes.total));
 
     char tag[96];
-    std::snprintf(tag, sizeof(tag), "gqa_attention cached-small-T kv=%s", kv_dtype_name(kv.dtype));
-    print_append_small_t_result(tag, r, bytes, tokens, context, kv.dtype, "");
+    std::snprintf(tag, sizeof(tag), "gqa_attention cached-small-T kv=%s",
+                  kv_dtype_name(kv.k_dtype));
+    print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, "");
 }
 
 void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t context,
@@ -966,7 +970,7 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     Tensor tq(q.p, DType::BF16, {kHeadDim, kQHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
-    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.dtype);
+    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.k_dtype);
 
     const auto launch = [&](cudaStream_t s) {
         ops::gqa_attention_cached(tq, tpos, kScale, kv.layer_view(0),
@@ -978,16 +982,17 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
             bench_cold_cache_loop(launch, *cold_cache, static_cast<double>(bytes.total));
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention cached-small-T kv=%s",
-                      kv_dtype_name(kv.dtype));
-        print_append_small_t_result(tag, r, bytes, tokens, context, kv.dtype, " cold_cache");
+                      kv_dtype_name(kv.k_dtype));
+        print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, " cold_cache");
         const VerifyRoute route = verify_route(tokens, context);
         std::printf(
             "PROFILE_COLD_METADATA mode=cached-small-t T=%d context=%d kv_dtype=%s "
             "route=%s chunks=%d cold_cache_bytes=%zu useful_kv_bytes=%zu scratch_bytes=%zu "
             "total_modeled_bytes=%zu repeats=%d ncu_kernel_regex='%s'\n",
-            tokens, context, kv_dtype_name(kv.dtype), ops::detail::gqa_attention_route_name(route),
+            tokens, context, kv_dtype_name(kv.k_dtype),
+            ops::detail::gqa_attention_route_name(route),
             verify_route_chunks(tokens, route), cold_cache->bytes, bytes.useful_kv, bytes.scratch,
-            bytes.total, r.n_runs, verify_route_ncu_kernel_regex(route, kv.dtype));
+            bytes.total, r.n_runs, verify_route_ncu_kernel_regex(route, kv.k_dtype));
         return;
     }
 
@@ -997,10 +1002,10 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     std::printf("PROFILE_ONCE gqa_attention cached-small-T T=%d context=%d kv_dtype=%s "
                 "route=%s chunks=%d useful_kv_bytes=%zu scratch_bytes=%zu total_model_bytes=%zu "
                 "ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.dtype),
+                tokens, context, kv_dtype_name(kv.k_dtype),
                 ops::detail::gqa_attention_route_name(route), verify_route_chunks(tokens, route),
                 bytes.useful_kv, bytes.scratch, bytes.total,
-                verify_route_ncu_kernel_regex(route, kv.dtype));
+                verify_route_ncu_kernel_regex(route, kv.k_dtype));
 }
 
 void launch_kv_append_control(DType kv_dtype, const DeviceBuffer& k, const DeviceBuffer& v,
@@ -1035,23 +1040,23 @@ KvAppendMetrics run_kv_append(KVCache& kv, std::int32_t tokens, std::int32_t con
     DeviceBuffer v   = make_bf16(kvn);
     DeviceBuffer pos = make_i32_sequence(context, tokens);
     const std::size_t control_bytes =
-        kv.dtype == DType::I8 ? kv_append_bytes(tokens, kv.dtype).cache_write / 2u : k.bytes;
+        kv.k_dtype == DType::I8 ? kv_append_bytes(tokens, kv.k_dtype).cache_write / 2u : k.bytes;
     DeviceBuffer control_k = make_zeros(control_bytes);
     DeviceBuffer control_v = make_zeros(control_bytes);
     Tensor tk(k.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tv(v.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
 
-    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.dtype);
+    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.k_dtype);
     const Result r            = bench_loop(
         [&](cudaStream_t s) { ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), s); },
         static_cast<double>(bytes.total), timing.warmup, timing.repeat, timing.min_time_ms);
     const Result control = bench_loop(
         [&](cudaStream_t s) {
-            launch_kv_append_control(kv.dtype, k, v, control_k, control_v, tokens, s);
+            launch_kv_append_control(kv.k_dtype, k, v, control_k, control_v, tokens, s);
         },
         static_cast<double>(bytes.total), timing.warmup, timing.repeat, timing.min_time_ms);
-    KvAppendMetrics metrics   = kv_append_metrics_from_result(tokens, context, kv.dtype, r);
+    KvAppendMetrics metrics = kv_append_metrics_from_result(tokens, context, kv.k_dtype, r);
     metrics.control_median_us = control.median_us;
     metrics.control_interval_ratio_pct =
         r.median_us > 0.0 ? control.median_us / r.median_us * 100.0 : 0.0;
@@ -1067,39 +1072,41 @@ void run_kv_append_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t c
     DeviceBuffer v   = make_bf16(kvn);
     DeviceBuffer pos = make_i32_sequence(context, tokens);
     const std::size_t control_bytes =
-        kv.dtype == DType::I8 ? kv_append_bytes(tokens, kv.dtype).cache_write / 2u : k.bytes;
+        kv.k_dtype == DType::I8 ? kv_append_bytes(tokens, kv.k_dtype).cache_write / 2u : k.bytes;
     DeviceBuffer control_k = make_zeros(control_bytes);
     DeviceBuffer control_v = make_zeros(control_bytes);
     Tensor tk(k.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tv(v.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
-    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.dtype);
+    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.k_dtype);
 
     cudaStream_t stream = nullptr;
     if (cold_cache != nullptr) {
         const Result r = bench_cold_cache_loop(
             [&](cudaStream_t s) { ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), s); },
             *cold_cache, static_cast<double>(bytes.total));
-        const KvAppendMetrics metrics = kv_append_metrics_from_result(tokens, context, kv.dtype, r);
+        const KvAppendMetrics metrics =
+            kv_append_metrics_from_result(tokens, context, kv.k_dtype, r);
         print_kv_append_result(metrics, " cold_cache");
         std::printf("PROFILE_COLD_METADATA mode=kv-append T=%d context=%d kv_dtype=%s CTAs=%d "
                     "cold_cache_bytes=%zu input_read_bytes=%zu cache_write_bytes=%zu "
                     "total_modeled_bytes=%zu repeats=%d ncu_kernel_regex='%s'\n",
-                    tokens, context, kv_dtype_name(kv.dtype), metrics.ctas, cold_cache->bytes,
+                    tokens, context, kv_dtype_name(kv.k_dtype), metrics.ctas, cold_cache->bytes,
                     bytes.input_read, bytes.cache_write, bytes.total, r.n_runs,
-                    kv_append_ncu_kernel_regex(kv.dtype));
+                    kv_append_ncu_kernel_regex(kv.k_dtype));
         return;
     }
 
     ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), stream);
-    launch_kv_append_control(kv.dtype, k, v, control_k, control_v, tokens, stream);
+    launch_kv_append_control(kv.k_dtype, k, v, control_k, control_v, tokens, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     std::printf("PROFILE_ONCE mode=kv-append T=%d context=%d kv_dtype=%s CTAs=%d "
                 "input_read_bytes=%zu cache_write_bytes=%zu total_model_bytes=%zu "
                 "ncu_kernel_regex='%s' control_ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.dtype), kv_append_ctas(tokens, kv.dtype),
+                tokens, context, kv_dtype_name(kv.k_dtype), kv_append_ctas(tokens, kv.k_dtype),
                 bytes.input_read, bytes.cache_write, bytes.total,
-                kv_append_ncu_kernel_regex(kv.dtype), kv_append_control_ncu_kernel_regex(kv.dtype));
+                kv_append_ncu_kernel_regex(kv.k_dtype),
+                kv_append_control_ncu_kernel_regex(kv.k_dtype));
 }
 
 void run_copy_ceiling(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
@@ -1151,7 +1158,7 @@ AppendPromptMetrics run_append_prompt_baseline(KVCache& kv, std::int32_t tokens,
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.dtype);
+    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.k_dtype);
     const Result r     = bench_loop(
         [&](cudaStream_t s) {
             ops::detail::gqa_attention_prompt_launch(tq, tk, tv, tpos, kScale, kv.layer_view(0),
@@ -1159,7 +1166,8 @@ AppendPromptMetrics run_append_prompt_baseline(KVCache& kv, std::int32_t tokens,
         },
         bytes, timing.warmup, timing.repeat, timing.min_time_ms);
 
-    AppendPromptMetrics metrics = append_prompt_metrics_from_result(tokens, context, kv.dtype, r);
+    AppendPromptMetrics metrics =
+        append_prompt_metrics_from_result(tokens, context, kv.k_dtype, r);
     print_append_prompt_result("gqa_attention append-prompt", metrics);
     return metrics;
 }
@@ -1188,7 +1196,7 @@ AppendPromptMetrics run_append_prompt_attention_only(KVCache& kv, std::int32_t t
                                              stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
-    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.dtype);
+    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.k_dtype);
     const Result r     = bench_loop(
         [&](cudaStream_t s) {
             ops::detail::gqa_attention_prompt_attention_launch(tq, tpos, kScale, kv.layer_view(0),
@@ -1196,7 +1204,8 @@ AppendPromptMetrics run_append_prompt_attention_only(KVCache& kv, std::int32_t t
         },
         bytes, timing.warmup, timing.repeat, timing.min_time_ms);
 
-    AppendPromptMetrics metrics = append_prompt_metrics_from_result(tokens, context, kv.dtype, r);
+    AppendPromptMetrics metrics =
+        append_prompt_metrics_from_result(tokens, context, kv.k_dtype, r);
     print_append_prompt_result("gqa_attention append-attn-only", metrics);
     return metrics;
 }
@@ -1300,10 +1309,10 @@ PrefillMetrics run_prefill(KVCache& kv, std::int32_t tokens, const PrefillTiming
             ops::gqa_attention(tq, tk, tv, tpos, kScale, kv.layer_view(0),
                                exact_envelope(static_cast<std::uint32_t>(tokens)), ws, tout, s);
         },
-        prefill_model_floor_bytes(tokens, kv.dtype), timing.warmup, timing.repeat,
+        prefill_model_floor_bytes(tokens, kv.k_dtype), timing.warmup, timing.repeat,
         timing.min_time_ms);
 
-    PrefillMetrics metrics = prefill_metrics_from_result(tokens, kv.dtype, r);
+    PrefillMetrics metrics = prefill_metrics_from_result(tokens, kv.k_dtype, r);
     print_prefill_result(metrics);
     return metrics;
 }
@@ -1334,9 +1343,9 @@ void run_prefill_profile_once(KVCache& kv, std::int32_t tokens) {
     std::printf("PROFILE_ONCE gqa_attention prefill T=%d kv_dtype=%s useful_flops=%.0f "
                 "model_floor_bytes=%.0f tc_peak_tflops=%.1f dram_peak_gbps=%.0f "
                 "ncu_kernel_regex='%s'\n",
-                tokens, kv_dtype_name(kv.dtype), prefill_useful_flops(tokens),
-                prefill_model_floor_bytes(tokens, kv.dtype), kDenseTcPeakTflops, kDramPeakGBs,
-                prefill_ncu_kernel_regex(kv.dtype));
+                tokens, kv_dtype_name(kv.k_dtype), prefill_useful_flops(tokens),
+                prefill_model_floor_bytes(tokens, kv.k_dtype), kDenseTcPeakTflops, kDramPeakGBs,
+                prefill_ncu_kernel_regex(kv.k_dtype));
 }
 
 std::string json_number(double value) {
@@ -1940,11 +1949,13 @@ int main(int argc, char** argv) {
     LayoutBuilder cache_layout_builder;
     auto cache_layout = ninfer::plan_kv_cache(
         cache_layout_builder, cache_layers, static_cast<std::uint32_t>(max_context), kKVHeads,
-        kHeadDim, opt.kv_dtype, opt.kv_dtype == DType::I8 ? kBenchKvQuantGroup : 0);
+        kHeadDim, opt.kv_dtype, opt.kv_dtype,
+        opt.kv_dtype == DType::I8 ? kBenchKvQuantGroup : 0,
+        opt.kv_dtype == DType::I8 ? kBenchKvQuantGroup : 0);
     const DeviceSpan cache_backing = cache_arena.alloc_bytes(cache_layout_builder.finish(256));
     KVCache kv(cache_backing, cache_layout);
     for (std::uint32_t layer = 0; layer < kv.layer_count(); ++layer) {
-        if (kv.dtype == DType::I8) {
+        if (kv.k_dtype == DType::I8) {
             CUDA_CHECK(cudaMemset(kv.k[layer].data, 0, kv.k[layer].bytes()));
             CUDA_CHECK(cudaMemset(kv.v[layer].data, 0, kv.v[layer].bytes()));
             CUDA_CHECK(cudaMemset(kv.k_scale[layer].data, 0, kv.k_scale[layer].bytes()));

--- a/bench/ops/gqa_attention_bench.cu
+++ b/bench/ops/gqa_attention_bench.cu
@@ -14,7 +14,7 @@
 //       --context 0,128,512,2048,8192,32768,131072,261120
 //   ./ninfer_gqa_attention_bench --kv-append --geometry 35b --tokens 1,2,3,4,5,6,1024 \
 //       --context 0,128,512,2048,8192,32768,131072,261120
-// Add --kv-dtype int8 to measure the INT8-G64 KV route.
+// Add --kv-dtype int8, bf16:int8, or int8:bf16 to select the KV-cache route.
 //   ./ninfer_gqa_attention_bench --decode --geometry 35b
 //   ./ninfer_gqa_attention_bench --decode --geometry 35b --decode-pos 2882 --profile-once \
 //       --cold-cache
@@ -88,18 +88,29 @@ std::size_t ceil_div_size(std::size_t value, std::size_t divisor) {
 
 std::size_t align_overhead(std::size_t allocations) { return allocations * 255u; }
 
-std::int32_t small_t_active_splits(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+struct KvDTypes {
+    DType k = DType::BF16;
+    DType v = DType::BF16;
+};
+
+bool symmetric_i8(KvDTypes dtype) { return dtype.k == DType::I8 && dtype.v == DType::I8; }
+
+bool mixed_kv(KvDTypes dtype) { return dtype.k != dtype.v; }
+
+KvDTypes kv_dtypes(const KVCache& cache) { return {cache.k_dtype, cache.v_dtype}; }
+
+std::int32_t small_t_active_splits(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype) {
     const std::int32_t window      = context + tokens;
     const std::int32_t split_scale = 4 / kKVHeads;
     // Keep the byte/scratch model identical to the dtype-aware production
     // schedule so reported bandwidth does not undercount specialized splits.
-    if (kv_dtype == DType::I8 && tokens == 5 && window > 128 && window <= 512) {
+    if (symmetric_i8(kv_dtype) && tokens == 5 && window > 128 && window <= 512) {
         return ceil_div_i32(window, 32 / split_scale);
     }
-    if (kv_dtype == DType::I8 && tokens == 6 && window > 128 && window <= 160) {
+    if (symmetric_i8(kv_dtype) && tokens == 6 && window > 128 && window <= 160) {
         return ceil_div_i32(window, 24 / split_scale);
     }
-    if (kv_dtype == DType::I8 && tokens == 6 && window > 5000 && window <= 8198) {
+    if (symmetric_i8(kv_dtype) && tokens == 6 && window > 5000 && window <= 8198) {
         return std::min(42 * split_scale,
                         std::max(4 * split_scale, ceil_div_i32(window, 192 / split_scale)));
     }
@@ -119,34 +130,30 @@ std::int32_t small_t_active_splits(std::int32_t tokens, std::int32_t context, DT
     return std::min(kGqaDecodeSplits, splits);
 }
 
-std::int32_t decode_active_splits(std::int32_t pos_value, DType kv_dtype) {
+std::int32_t decode_active_splits(std::int32_t pos_value, KvDTypes kv_dtype) {
     return small_t_active_splits(1, pos_value, kv_dtype);
 }
 
-std::int32_t decode_kps(std::int32_t pos_value, DType kv_dtype) {
+std::int32_t decode_kps(std::int32_t pos_value, KvDTypes kv_dtype) {
     const std::int32_t window = pos_value + 1;
     return ceil_div_i32(window, decode_active_splits(pos_value, kv_dtype));
 }
 
-const char* kv_dtype_name(DType dtype) {
-    switch (dtype) {
-    case DType::BF16:
-        return "bf16";
-    case DType::I8:
-        return "int8";
-    default:
-        return "unknown";
-    }
+const char* kv_dtype_name(KvDTypes dtype) {
+    if (dtype.k == DType::BF16) { return dtype.v == DType::BF16 ? "bf16" : "bf16:int8"; }
+    return dtype.v == DType::BF16 ? "int8:bf16" : "int8";
 }
 
-const char* small_t_ncu_kernel_regex(DType dtype) {
-    return dtype == DType::I8 ? "gqa_attention_decode_i8_tiled_kernel"
-                              : "gqa_attention_small_t_tc_partial_bf16_kernel";
+const char* small_t_ncu_kernel_regex(KvDTypes dtype) {
+    if (symmetric_i8(dtype)) { return "gqa_attention_decode_i8_tiled_kernel"; }
+    return mixed_kv(dtype) ? "gqa_attention_small_t_tc_partial_mixed_kernel"
+                           : "gqa_attention_small_t_tc_partial_bf16_kernel";
 }
 
-const char* prefill_ncu_kernel_regex(DType dtype) {
-    return dtype == DType::I8 ? "gqa_attention_prefill_i8_kernel"
-                              : "gqa_attention_prefill_bf16_kernel";
+const char* prefill_ncu_kernel_regex(KvDTypes dtype) {
+    if (symmetric_i8(dtype)) { return "gqa_attention_prefill_i8_kernel"; }
+    return mixed_kv(dtype) ? "gqa_attention_prefill_mixed_kernel"
+                           : "gqa_attention_prefill_bf16_kernel";
 }
 
 double kv_cache_vector_bytes(DType dtype) {
@@ -158,7 +165,9 @@ double kv_cache_vector_bytes(DType dtype) {
     return static_cast<double>(kHeadDim) * static_cast<double>(dtype_size(DType::BF16));
 }
 
-double kv_cache_pair_bytes_per_head(DType dtype) { return 2.0 * kv_cache_vector_bytes(dtype); }
+double kv_cache_pair_bytes_per_head(KvDTypes dtype) {
+    return kv_cache_vector_bytes(dtype.k) + kv_cache_vector_bytes(dtype.v);
+}
 
 double kv_input_pair_bytes_per_head() {
     return 2.0 * static_cast<double>(kHeadDim) * static_cast<double>(dtype_size(DType::BF16));
@@ -170,16 +179,19 @@ struct DecodeBytes {
     std::size_t total     = 0;
 };
 
-double append_prompt_logical_kv_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype);
-double append_prompt_global_floor_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype);
+double append_prompt_logical_kv_bytes(std::int32_t tokens, std::int32_t context,
+                                      KvDTypes kv_dtype);
+double append_prompt_global_floor_bytes(std::int32_t tokens, std::int32_t context,
+                                        KvDTypes kv_dtype);
 
-DecodeBytes decode_bytes(std::int32_t pos_value, DType kv_dtype) {
+DecodeBytes decode_bytes(std::int32_t pos_value, KvDTypes kv_dtype) {
     const auto window      = static_cast<std::size_t>(pos_value) + 1u;
     const auto split_count = static_cast<std::size_t>(decode_active_splits(pos_value, kv_dtype));
 
     const std::size_t k_cache_reads = static_cast<std::size_t>(
-        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype));
-    const std::size_t v_cache_reads = k_cache_reads;
+        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype.k));
+    const std::size_t v_cache_reads = static_cast<std::size_t>(
+        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype.v));
     const std::size_t new_kv_writes = static_cast<std::size_t>(
         static_cast<double>(kKVHeads) * kv_cache_pair_bytes_per_head(kv_dtype));
     const std::size_t q_reads       = kQHeads * kHeadDim * sizeof(std::uint16_t);
@@ -198,7 +210,7 @@ DecodeBytes decode_bytes(std::int32_t pos_value, DType kv_dtype) {
     return bytes;
 }
 
-DecodeBytes small_t_stage_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype,
+DecodeBytes small_t_stage_bytes(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype,
                                 bool append) {
     const auto window      = static_cast<std::size_t>(context + tokens);
     const auto token_count = static_cast<std::size_t>(tokens);
@@ -206,8 +218,9 @@ DecodeBytes small_t_stage_bytes(std::int32_t tokens, std::int32_t context, DType
         static_cast<std::size_t>(small_t_active_splits(tokens, context, kv_dtype));
 
     const std::size_t k_cache_reads = static_cast<std::size_t>(
-        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype));
-    const std::size_t v_cache_reads = k_cache_reads;
+        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype.k));
+    const std::size_t v_cache_reads = static_cast<std::size_t>(
+        static_cast<double>(window * kKVHeads) * kv_cache_vector_bytes(kv_dtype.v));
     const std::size_t new_kv_writes = static_cast<std::size_t>(
         static_cast<double>(token_count * kKVHeads) * kv_cache_pair_bytes_per_head(kv_dtype));
     const std::size_t q_reads       = token_count * kQHeads * kHeadDim * sizeof(std::uint16_t);
@@ -234,7 +247,7 @@ VerifyRoute verify_route(std::int32_t tokens, std::int32_t context) {
     return ops::detail::gqa_attention_resolve_route(kQHeads, tokens, {visible, visible});
 }
 
-const char* verify_route_ncu_kernel_regex(VerifyRoute route, DType dtype) {
+const char* verify_route_ncu_kernel_regex(VerifyRoute route, KvDTypes dtype) {
     return route == VerifyRoute::Prompt ? prefill_ncu_kernel_regex(dtype)
                                         : small_t_ncu_kernel_regex(dtype);
 }
@@ -243,7 +256,7 @@ std::int32_t verify_route_chunks(std::int32_t tokens, VerifyRoute route) {
     return route == VerifyRoute::ChunkedSmallT ? ceil_div_i32(tokens, 6) : 1;
 }
 
-DecodeBytes verify_route_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype,
+DecodeBytes verify_route_bytes(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype,
                                bool append) {
     const VerifyRoute route = verify_route(tokens, context);
     if (route == VerifyRoute::SmallT) {
@@ -275,11 +288,11 @@ DecodeBytes verify_route_bytes(std::int32_t tokens, std::int32_t context, DType 
     return bytes;
 }
 
-DecodeBytes append_small_t_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+DecodeBytes append_small_t_bytes(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype) {
     return verify_route_bytes(tokens, context, kv_dtype, true);
 }
 
-DecodeBytes cached_small_t_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+DecodeBytes cached_small_t_bytes(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype) {
     return verify_route_bytes(tokens, context, kv_dtype, false);
 }
 
@@ -289,7 +302,12 @@ struct KvAppendBytes {
     std::size_t total       = 0;
 };
 
-KvAppendBytes kv_append_bytes(std::int32_t tokens, DType kv_dtype) {
+std::size_t kv_cache_plane_write_bytes(std::int32_t tokens, DType dtype) {
+    return static_cast<std::size_t>(static_cast<double>(tokens * kKVHeads) *
+                                    kv_cache_vector_bytes(dtype));
+}
+
+KvAppendBytes kv_append_bytes(std::int32_t tokens, KvDTypes kv_dtype) {
     const auto token_count = static_cast<std::size_t>(tokens);
     KvAppendBytes bytes;
     bytes.input_read  = static_cast<std::size_t>(static_cast<double>(token_count * kKVHeads) *
@@ -300,8 +318,8 @@ KvAppendBytes kv_append_bytes(std::int32_t tokens, DType kv_dtype) {
     return bytes;
 }
 
-std::int32_t kv_append_ctas(std::int32_t tokens, DType kv_dtype) {
-    if (kv_dtype == DType::I8) {
+std::int32_t kv_append_ctas(std::int32_t tokens, KvDTypes kv_dtype) {
+    if (kv_dtype.k == DType::I8 || kv_dtype.v == DType::I8) {
         constexpr std::int32_t kWarpsPerCta = 8;
         return ceil_div_i32(tokens * kKVHeads * (kHeadDim / kBenchKvQuantGroup), kWarpsPerCta);
     }
@@ -310,14 +328,16 @@ std::int32_t kv_append_ctas(std::int32_t tokens, DType kv_dtype) {
     return ceil_div_i32(tokens * kKVHeads * (kHeadDim / kVecElems), kThreadsPerCta);
 }
 
-const char* kv_append_ncu_kernel_regex(DType dtype) {
-    return dtype == DType::I8 ? "gqa_attention_prefill_fill_i8_kernel"
-                              : "gqa_attention_prefill_fill_bf16_kernel";
+const char* kv_append_ncu_kernel_regex(KvDTypes dtype) {
+    if (symmetric_i8(dtype)) { return "gqa_attention_prefill_fill_i8_kernel"; }
+    return mixed_kv(dtype) ? "gqa_attention_prefill_fill_mixed_kernel"
+                           : "gqa_attention_prefill_fill_bf16_kernel";
 }
 
-const char* kv_append_control_ncu_kernel_regex(DType dtype) {
-    return dtype == DType::I8 ? "bench_kv_append_i8_payload_control_kernel"
-                              : "bench_kv_append_bf16_control_kernel";
+const char* kv_append_control_ncu_kernel_regex(KvDTypes dtype) {
+    if (symmetric_i8(dtype)) { return "bench_kv_append_i8_payload_control_kernel"; }
+    return mixed_kv(dtype) ? "bench_kv_append_mixed_payload_control_kernel"
+                           : "bench_kv_append_bf16_control_kernel";
 }
 
 std::int32_t append_prompt_q_blocks(std::int32_t tokens) {
@@ -355,17 +375,20 @@ double append_prompt_useful_flops(std::int32_t tokens, std::int32_t context) {
            append_prompt_key_sum(tokens, context);
 }
 
-double append_prompt_logical_kv_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+double append_prompt_logical_kv_bytes(std::int32_t tokens, std::int32_t context,
+                                      KvDTypes kv_dtype) {
     return append_prompt_key_sum(tokens, context) * static_cast<double>(kKVHeads) *
            kv_cache_pair_bytes_per_head(kv_dtype);
 }
 
-double append_prompt_tile_kv_read_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+double append_prompt_tile_kv_read_bytes(std::int32_t tokens, std::int32_t context,
+                                        KvDTypes kv_dtype) {
     return append_prompt_qblock_key_rows(tokens, context) * static_cast<double>(kQHeads) *
            kv_cache_pair_bytes_per_head(kv_dtype);
 }
 
-double append_prompt_global_floor_bytes(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+double append_prompt_global_floor_bytes(std::int32_t tokens, std::int32_t context,
+                                        KvDTypes kv_dtype) {
     const double token_count = static_cast<double>(tokens);
     const double q_bytes     = token_count * static_cast<double>(kQHeads) *
                            static_cast<double>(kHeadDim) *
@@ -402,22 +425,26 @@ std::size_t decode_workspace_bytes(const std::vector<std::int32_t>& positions) {
     return bytes;
 }
 
-std::size_t cache_arena_bytes(std::uint32_t layers, std::int32_t max_context, DType kv_dtype) {
+std::size_t cache_arena_bytes(std::uint32_t layers, std::int32_t max_context,
+                              KvDTypes kv_dtype) {
     const auto padded_context = static_cast<std::size_t>(align_up_128(max_context));
     const std::size_t layer_elements =
         static_cast<std::size_t>(kKVHeads) * static_cast<std::size_t>(kHeadDim) * padded_context;
-    if (kv_dtype == DType::I8) {
-        const std::size_t code_bytes     = layer_elements * dtype_size(DType::I8);
-        const std::size_t scale_elements = static_cast<std::size_t>(kKVHeads) *
-                                           static_cast<std::size_t>(kHeadDim / kBenchKvQuantGroup) *
-                                           padded_context;
-        const std::size_t scale_bytes = scale_elements * dtype_size(DType::FP16);
-        return static_cast<std::size_t>(layers) *
-                   (2u * (code_bytes + 255u) + 2u * (scale_bytes + 255u)) +
-               4096u;
-    }
-    const std::size_t layer_bytes = layer_elements * dtype_size(DType::BF16);
-    return static_cast<std::size_t>(layers) * 2u * (layer_bytes + 255u) + 4096u;
+    const auto plane_bytes = [&](DType dtype) {
+        const std::size_t code_bytes = layer_elements * dtype_size(dtype);
+        std::size_t bytes            = code_bytes + 255u;
+        if (dtype == DType::I8) {
+            const std::size_t scale_elements =
+                static_cast<std::size_t>(kKVHeads) *
+                static_cast<std::size_t>(kHeadDim / kBenchKvQuantGroup) * padded_context;
+            const std::size_t scale_bytes = scale_elements * dtype_size(DType::FP16);
+            bytes += scale_bytes + 255u;
+        }
+        return bytes;
+    };
+    return static_cast<std::size_t>(layers) *
+               (plane_bytes(kv_dtype.k) + plane_bytes(kv_dtype.v)) +
+           4096u;
 }
 
 DeviceBuffer make_i32(std::int32_t value) {
@@ -470,6 +497,29 @@ __global__ void bench_kv_append_i8_payload_control_kernel(
         scale_k[group] = 0x3c00u;
         scale_v[group] = 0x3c00u;
     }
+}
+
+template <bool KInt8>
+__global__ void bench_kv_append_mixed_payload_control_kernel(
+    const std::uint32_t* k, const std::uint32_t* v, void* cache_k, void* cache_v,
+    std::uint16_t* scale, std::size_t groups) {
+    const std::size_t group = blockIdx.x * 8u + threadIdx.x / 32u;
+    const std::size_t lane  = threadIdx.x % 32u;
+    if (group >= groups) { return; }
+
+    const std::size_t pair = group * 32u + lane;
+    if constexpr (KInt8) {
+        const std::uint32_t packed = k[pair];
+        static_cast<std::uint16_t*>(cache_k)[pair] =
+            static_cast<std::uint16_t>((packed & 0xffu) | ((packed >> 8u) & 0xff00u));
+        static_cast<std::uint32_t*>(cache_v)[pair] = v[pair];
+    } else {
+        const std::uint32_t packed = v[pair];
+        static_cast<std::uint32_t*>(cache_k)[pair] = k[pair];
+        static_cast<std::uint16_t*>(cache_v)[pair] =
+            static_cast<std::uint16_t>((packed & 0xffu) | ((packed >> 8u) & 0xff00u));
+    }
+    if (lane == 0u) { scale[group] = 0x3c00u; }
 }
 
 void touch_cold_cache(DeviceBuffer& buf, cudaStream_t stream) {
@@ -547,7 +597,8 @@ void print_copy_ceiling_result(const char* tag, const Result& r, std::size_t pay
 }
 
 void print_decode_result(const char* tag, const Result& r, const DecodeBytes& bytes,
-                         std::int32_t pos_value, DType kv_dtype, std::uint32_t round_robin_layers,
+                         std::int32_t pos_value, KvDTypes kv_dtype,
+                         std::uint32_t round_robin_layers,
                          const char* suffix) {
     const double sec       = r.median_us * 1.0e-6;
     const double total_gbs = (sec > 0.0) ? static_cast<double>(bytes.total) / sec / 1.0e9 : 0.0;
@@ -565,7 +616,7 @@ void print_decode_result(const char* tag, const Result& r, const DecodeBytes& by
 }
 
 void print_append_small_t_result(const char* tag, const Result& r, const DecodeBytes& bytes,
-                                 std::int32_t tokens, std::int32_t context, DType kv_dtype,
+                                 std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype,
                                  const char* suffix) {
     const double sec       = r.median_us * 1.0e-6;
     const double total_gbs = (sec > 0.0) ? static_cast<double>(bytes.total) / sec / 1.0e9 : 0.0;
@@ -599,7 +650,7 @@ struct AppendPromptMetrics {
     std::int32_t tokens          = 0;
     std::int32_t context         = 0;
     std::int32_t end_context     = 0;
-    DType kv_dtype               = DType::BF16;
+    KvDTypes kv_dtype;
     std::int32_t q_blocks        = 0;
     std::int64_t attention_ctas  = 0;
     std::int64_t key_tiles       = 0;
@@ -644,7 +695,7 @@ struct PrefillTimingOptions {
 struct KvAppendMetrics {
     std::int32_t tokens               = 0;
     std::int32_t context              = 0;
-    DType kv_dtype                    = DType::BF16;
+    KvDTypes kv_dtype;
     std::int32_t ctas                 = 0;
     int runs                          = 0;
     int inner_iters                   = 1;
@@ -662,7 +713,7 @@ struct KvAppendMetrics {
 };
 
 KvAppendMetrics kv_append_metrics_from_result(std::int32_t tokens, std::int32_t context,
-                                              DType kv_dtype, const Result& r) {
+                                              KvDTypes kv_dtype, const Result& r) {
     const KvAppendBytes bytes = kv_append_bytes(tokens, kv_dtype);
     KvAppendMetrics m;
     m.tokens            = tokens;
@@ -698,7 +749,7 @@ void print_kv_append_result(const KvAppendMetrics& m, const char* suffix = "") {
 }
 
 AppendPromptMetrics append_prompt_metrics_from_result(std::int32_t tokens, std::int32_t context,
-                                                      DType kv_dtype, const Result& r) {
+                                                      KvDTypes kv_dtype, const Result& r) {
     AppendPromptMetrics m;
     m.tokens         = tokens;
     m.context        = context;
@@ -707,11 +758,11 @@ AppendPromptMetrics append_prompt_metrics_from_result(std::int32_t tokens, std::
     m.q_blocks       = append_prompt_q_blocks(tokens);
     m.attention_ctas = static_cast<std::int64_t>(m.q_blocks) * kQHeads;
     m.key_tiles      = append_prompt_key_tiles_per_head(tokens, context) * kQHeads;
-    m.qk_mma_count   = m.key_tiles * (kv_dtype == DType::I8 ? 256 : 512);
+    m.qk_mma_count   = m.key_tiles * (symmetric_i8(kv_dtype) ? 256 : 512);
     m.pv_mma_count   = m.key_tiles * 512;
     m.runs           = r.n_runs;
     m.inner_iters    = r.inner_iters;
-    if (kv_dtype == DType::I8) {
+    if (symmetric_i8(kv_dtype)) {
         m.math_mode    = "s8_qk_f16_pv";
         m.qk_mma_dtype = "s8";
         m.pv_mma_dtype = "f16";
@@ -769,7 +820,8 @@ void run_decode(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Tensor& 
     DeviceBuffer pos_buf = make_i32(pos_value);
     Tensor pos(pos_buf.p, DType::I32, {1});
 
-    const DecodeBytes bytes  = decode_bytes(pos_value, kv.k_dtype);
+    const KvDTypes kv_dtype  = kv_dtypes(kv);
+    const DecodeBytes bytes  = decode_bytes(pos_value, kv_dtype);
     std::uint32_t next_layer = 0;
 
     const Result r = bench_loop(
@@ -784,8 +836,8 @@ void run_decode(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Tensor& 
 
     char tag[96];
     std::snprintf(tag, sizeof(tag), "gqa_attention decode combined pos=%d kv=%s", pos_value,
-                  kv_dtype_name(kv.k_dtype));
-    print_decode_result(tag, r, bytes, pos_value, kv.k_dtype, round_robin_layers,
+                  kv_dtype_name(kv_dtype));
+    print_decode_result(tag, r, bytes, pos_value, kv_dtype, round_robin_layers,
                         (round_robin_layers == 1u) ? " hot_cache_info" : "");
 }
 
@@ -794,7 +846,8 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
                       DeviceBuffer* cold_cache) {
     DeviceBuffer pos_buf = make_i32(pos_value);
     Tensor pos(pos_buf.p, DType::I32, {1});
-    const DecodeBytes bytes = decode_bytes(pos_value, kv.k_dtype);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const DecodeBytes bytes = decode_bytes(pos_value, kv_dtype);
 
     cudaStream_t stream = nullptr;
     if (cold_cache != nullptr) {
@@ -808,13 +861,12 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
 
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention decode pos=%d", pos_value);
-        print_decode_result(tag, r, bytes, pos_value, kv.k_dtype, 1u, " cold_cache");
+        print_decode_result(tag, r, bytes, pos_value, kv_dtype, 1u, " cold_cache");
         std::printf("PROFILE_COLD_METADATA pos=%d kv_dtype=%s splits=%d kps=%d "
                     "cold_cache_bytes=%zu "
                     "useful_kv_bytes=%zu scratch_bytes=%zu total_modeled_bytes=%zu repeats=%d\n",
-                    pos_value, kv_dtype_name(kv.k_dtype),
-                    decode_active_splits(pos_value, kv.k_dtype),
-                    decode_kps(pos_value, kv.k_dtype), cold_cache->bytes, bytes.useful_kv,
+                    pos_value, kv_dtype_name(kv_dtype), decode_active_splits(pos_value, kv_dtype),
+                    decode_kps(pos_value, kv_dtype), cold_cache->bytes, bytes.useful_kv,
                     bytes.scratch, bytes.total, r.n_runs);
         return;
     }
@@ -825,8 +877,8 @@ void run_profile_once(KVCache& kv, WorkspaceArena& ws, const Tensor& q, const Te
 
     std::printf("PROFILE_ONCE gqa_attention decode combined pos=%d kv_dtype=%s splits=%d kps=%d "
                 "useful_kv_bytes=%zu scratch_bytes=%zu total_modeled_bytes=%zu\n",
-                pos_value, kv_dtype_name(kv.k_dtype),
-                decode_active_splits(pos_value, kv.k_dtype), decode_kps(pos_value, kv.k_dtype),
+                pos_value, kv_dtype_name(kv_dtype), decode_active_splits(pos_value, kv_dtype),
+                decode_kps(pos_value, kv_dtype),
                 bytes.useful_kv, bytes.scratch, bytes.total);
 }
 
@@ -848,7 +900,8 @@ void run_append_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.k_dtype);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv_dtype);
     const Result r          = bench_loop(
         [&](cudaStream_t s) {
             ops::gqa_attention(tq, tk, tv, tpos, kScale, kv.layer_view(0),
@@ -859,8 +912,8 @@ void run_append_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
 
     char tag[96];
     std::snprintf(tag, sizeof(tag), "gqa_attention append-small-T kv=%s",
-                  kv_dtype_name(kv.k_dtype));
-    print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, "");
+                  kv_dtype_name(kv_dtype));
+    print_append_small_t_result(tag, r, bytes, tokens, context, kv_dtype, "");
 }
 
 void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t context,
@@ -882,7 +935,8 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv.k_dtype);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv_dtype);
     cudaStream_t stream     = nullptr;
     if (cold_cache != nullptr) {
         const Result r = bench_cold_cache_loop(
@@ -894,22 +948,22 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
             *cold_cache, static_cast<double>(bytes.total));
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention append-small-T kv=%s",
-                      kv_dtype_name(kv.k_dtype));
-        print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, " cold_cache");
+                      kv_dtype_name(kv_dtype));
+        print_append_small_t_result(tag, r, bytes, tokens, context, kv_dtype, " cold_cache");
         const VerifyRoute route = verify_route(tokens, context);
         std::printf("PROFILE_COLD_METADATA mode=append-small-t T=%d context=%d kv_dtype=%s "
                     "route=%s chunks=%d "
                     "cold_cache_bytes=%zu useful_kv_bytes=%zu scratch_bytes=%zu "
                     "total_modeled_bytes=%zu redundancy=%.6f repeats=%d "
                     "ncu_kernel_regex='%s'\n",
-                    tokens, context, kv_dtype_name(kv.k_dtype),
+                    tokens, context, kv_dtype_name(kv_dtype),
                     ops::detail::gqa_attention_route_name(route),
                     verify_route_chunks(tokens, route), cold_cache->bytes, bytes.useful_kv,
                     bytes.scratch, bytes.total,
                     bytes.useful_kv > 0
                         ? static_cast<double>(bytes.total) / static_cast<double>(bytes.useful_kv)
                         : 0.0,
-                    r.n_runs, verify_route_ncu_kernel_regex(route, kv.k_dtype));
+                    r.n_runs, verify_route_ncu_kernel_regex(route, kv_dtype));
         return;
     }
 
@@ -922,13 +976,13 @@ void run_append_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
                 "chunks=%d "
                 "useful_kv_bytes=%zu scratch_bytes=%zu total_model_bytes=%zu redundancy=%.6f "
                 "ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.k_dtype),
+                tokens, context, kv_dtype_name(kv_dtype),
                 ops::detail::gqa_attention_route_name(route), verify_route_chunks(tokens, route),
                 bytes.useful_kv, bytes.scratch, bytes.total,
                 bytes.useful_kv > 0
                     ? static_cast<double>(bytes.total) / static_cast<double>(bytes.useful_kv)
                     : 0.0,
-                verify_route_ncu_kernel_regex(route, kv.k_dtype));
+                verify_route_ncu_kernel_regex(route, kv_dtype));
 }
 
 void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) {
@@ -943,7 +997,8 @@ void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.k_dtype);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv_dtype);
     const Result r          = bench_loop(
         [&](cudaStream_t s) {
             ops::gqa_attention_cached(tq, tpos, kScale, kv.layer_view(0),
@@ -954,8 +1009,8 @@ void run_cached_small_t(KVCache& kv, std::int32_t tokens, std::int32_t context) 
 
     char tag[96];
     std::snprintf(tag, sizeof(tag), "gqa_attention cached-small-T kv=%s",
-                  kv_dtype_name(kv.k_dtype));
-    print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, "");
+                  kv_dtype_name(kv_dtype));
+    print_append_small_t_result(tag, r, bytes, tokens, context, kv_dtype, "");
 }
 
 void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t context,
@@ -970,7 +1025,8 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     Tensor tq(q.p, DType::BF16, {kHeadDim, kQHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
-    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv.k_dtype);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const DecodeBytes bytes = cached_small_t_bytes(tokens, context, kv_dtype);
 
     const auto launch = [&](cudaStream_t s) {
         ops::gqa_attention_cached(tq, tpos, kScale, kv.layer_view(0),
@@ -982,17 +1038,17 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
             bench_cold_cache_loop(launch, *cold_cache, static_cast<double>(bytes.total));
         char tag[96];
         std::snprintf(tag, sizeof(tag), "PROFILE_COLD gqa_attention cached-small-T kv=%s",
-                      kv_dtype_name(kv.k_dtype));
-        print_append_small_t_result(tag, r, bytes, tokens, context, kv.k_dtype, " cold_cache");
+                      kv_dtype_name(kv_dtype));
+        print_append_small_t_result(tag, r, bytes, tokens, context, kv_dtype, " cold_cache");
         const VerifyRoute route = verify_route(tokens, context);
         std::printf(
             "PROFILE_COLD_METADATA mode=cached-small-t T=%d context=%d kv_dtype=%s "
             "route=%s chunks=%d cold_cache_bytes=%zu useful_kv_bytes=%zu scratch_bytes=%zu "
             "total_modeled_bytes=%zu repeats=%d ncu_kernel_regex='%s'\n",
-            tokens, context, kv_dtype_name(kv.k_dtype),
+            tokens, context, kv_dtype_name(kv_dtype),
             ops::detail::gqa_attention_route_name(route),
             verify_route_chunks(tokens, route), cold_cache->bytes, bytes.useful_kv, bytes.scratch,
-            bytes.total, r.n_runs, verify_route_ncu_kernel_regex(route, kv.k_dtype));
+            bytes.total, r.n_runs, verify_route_ncu_kernel_regex(route, kv_dtype));
         return;
     }
 
@@ -1002,18 +1058,18 @@ void run_cached_small_t_profile_once(KVCache& kv, std::int32_t tokens, std::int3
     std::printf("PROFILE_ONCE gqa_attention cached-small-T T=%d context=%d kv_dtype=%s "
                 "route=%s chunks=%d useful_kv_bytes=%zu scratch_bytes=%zu total_model_bytes=%zu "
                 "ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.k_dtype),
+                tokens, context, kv_dtype_name(kv_dtype),
                 ops::detail::gqa_attention_route_name(route), verify_route_chunks(tokens, route),
                 bytes.useful_kv, bytes.scratch, bytes.total,
-                verify_route_ncu_kernel_regex(route, kv.k_dtype));
+                verify_route_ncu_kernel_regex(route, kv_dtype));
 }
 
-void launch_kv_append_control(DType kv_dtype, const DeviceBuffer& k, const DeviceBuffer& v,
+void launch_kv_append_control(KvDTypes kv_dtype, const DeviceBuffer& k, const DeviceBuffer& v,
                               DeviceBuffer& control_k, DeviceBuffer& control_v, std::int32_t tokens,
                               cudaStream_t stream) {
     constexpr int kBlock = 256;
     const int grid       = kv_append_ctas(tokens, kv_dtype);
-    if (kv_dtype == DType::I8) {
+    if (symmetric_i8(kv_dtype)) {
         const std::size_t groups =
             static_cast<std::size_t>(tokens) * kKVHeads * (kHeadDim / kBenchKvQuantGroup);
         const std::size_t code_pairs = static_cast<std::size_t>(tokens) * kKVHeads * kHeadDim / 2u;
@@ -1023,6 +1079,21 @@ void launch_kv_append_control(DType kv_dtype, const DeviceBuffer& k, const Devic
             static_cast<const std::uint32_t*>(k.p), static_cast<const std::uint32_t*>(v.p),
             control_k_data, control_v_data, control_k_data + code_pairs,
             control_v_data + code_pairs, groups);
+    } else if (mixed_kv(kv_dtype)) {
+        const std::size_t groups =
+            static_cast<std::size_t>(tokens) * kKVHeads * (kHeadDim / kBenchKvQuantGroup);
+        const std::size_t code_pairs = static_cast<std::size_t>(tokens) * kKVHeads * kHeadDim / 2u;
+        if (kv_dtype.k == DType::I8) {
+            bench_kv_append_mixed_payload_control_kernel<true><<<grid, kBlock, 0, stream>>>(
+                static_cast<const std::uint32_t*>(k.p), static_cast<const std::uint32_t*>(v.p),
+                control_k.p, control_v.p, static_cast<std::uint16_t*>(control_k.p) + code_pairs,
+                groups);
+        } else {
+            bench_kv_append_mixed_payload_control_kernel<false><<<grid, kBlock, 0, stream>>>(
+                static_cast<const std::uint32_t*>(k.p), static_cast<const std::uint32_t*>(v.p),
+                control_k.p, control_v.p, static_cast<std::uint16_t*>(control_v.p) + code_pairs,
+                groups);
+        }
     } else {
         const std::size_t vectors = k.bytes / sizeof(uint4);
         bench_kv_append_bf16_control_kernel<<<grid, kBlock, 0, stream>>>(
@@ -1039,24 +1110,23 @@ KvAppendMetrics run_kv_append(KVCache& kv, std::int32_t tokens, std::int32_t con
     DeviceBuffer k   = make_bf16(kvn);
     DeviceBuffer v   = make_bf16(kvn);
     DeviceBuffer pos = make_i32_sequence(context, tokens);
-    const std::size_t control_bytes =
-        kv.k_dtype == DType::I8 ? kv_append_bytes(tokens, kv.k_dtype).cache_write / 2u : k.bytes;
-    DeviceBuffer control_k = make_zeros(control_bytes);
-    DeviceBuffer control_v = make_zeros(control_bytes);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    DeviceBuffer control_k  = make_zeros(kv_cache_plane_write_bytes(tokens, kv_dtype.k));
+    DeviceBuffer control_v  = make_zeros(kv_cache_plane_write_bytes(tokens, kv_dtype.v));
     Tensor tk(k.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tv(v.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
 
-    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.k_dtype);
+    const KvAppendBytes bytes = kv_append_bytes(tokens, kv_dtype);
     const Result r            = bench_loop(
         [&](cudaStream_t s) { ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), s); },
         static_cast<double>(bytes.total), timing.warmup, timing.repeat, timing.min_time_ms);
     const Result control = bench_loop(
         [&](cudaStream_t s) {
-            launch_kv_append_control(kv.k_dtype, k, v, control_k, control_v, tokens, s);
+            launch_kv_append_control(kv_dtype, k, v, control_k, control_v, tokens, s);
         },
         static_cast<double>(bytes.total), timing.warmup, timing.repeat, timing.min_time_ms);
-    KvAppendMetrics metrics = kv_append_metrics_from_result(tokens, context, kv.k_dtype, r);
+    KvAppendMetrics metrics = kv_append_metrics_from_result(tokens, context, kv_dtype, r);
     metrics.control_median_us = control.median_us;
     metrics.control_interval_ratio_pct =
         r.median_us > 0.0 ? control.median_us / r.median_us * 100.0 : 0.0;
@@ -1071,14 +1141,13 @@ void run_kv_append_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t c
     DeviceBuffer k   = make_bf16(kvn);
     DeviceBuffer v   = make_bf16(kvn);
     DeviceBuffer pos = make_i32_sequence(context, tokens);
-    const std::size_t control_bytes =
-        kv.k_dtype == DType::I8 ? kv_append_bytes(tokens, kv.k_dtype).cache_write / 2u : k.bytes;
-    DeviceBuffer control_k = make_zeros(control_bytes);
-    DeviceBuffer control_v = make_zeros(control_bytes);
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    DeviceBuffer control_k  = make_zeros(kv_cache_plane_write_bytes(tokens, kv_dtype.k));
+    DeviceBuffer control_v  = make_zeros(kv_cache_plane_write_bytes(tokens, kv_dtype.v));
     Tensor tk(k.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tv(v.p, DType::BF16, {kHeadDim, kKVHeads, tokens});
     Tensor tpos(pos.p, DType::I32, {tokens});
-    const KvAppendBytes bytes = kv_append_bytes(tokens, kv.k_dtype);
+    const KvAppendBytes bytes = kv_append_bytes(tokens, kv_dtype);
 
     cudaStream_t stream = nullptr;
     if (cold_cache != nullptr) {
@@ -1086,30 +1155,29 @@ void run_kv_append_profile_once(KVCache& kv, std::int32_t tokens, std::int32_t c
             [&](cudaStream_t s) { ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), s); },
             *cold_cache, static_cast<double>(bytes.total));
         const KvAppendMetrics metrics =
-            kv_append_metrics_from_result(tokens, context, kv.k_dtype, r);
+            kv_append_metrics_from_result(tokens, context, kv_dtype, r);
         print_kv_append_result(metrics, " cold_cache");
         std::printf("PROFILE_COLD_METADATA mode=kv-append T=%d context=%d kv_dtype=%s CTAs=%d "
                     "cold_cache_bytes=%zu input_read_bytes=%zu cache_write_bytes=%zu "
                     "total_modeled_bytes=%zu repeats=%d ncu_kernel_regex='%s'\n",
-                    tokens, context, kv_dtype_name(kv.k_dtype), metrics.ctas, cold_cache->bytes,
+                    tokens, context, kv_dtype_name(kv_dtype), metrics.ctas, cold_cache->bytes,
                     bytes.input_read, bytes.cache_write, bytes.total, r.n_runs,
-                    kv_append_ncu_kernel_regex(kv.k_dtype));
+                    kv_append_ncu_kernel_regex(kv_dtype));
         return;
     }
 
     ops::gqa_kv_append(tk, tv, tpos, kv.layer_view(0), stream);
-    launch_kv_append_control(kv.k_dtype, k, v, control_k, control_v, tokens, stream);
+    launch_kv_append_control(kv_dtype, k, v, control_k, control_v, tokens, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     std::printf("PROFILE_ONCE mode=kv-append T=%d context=%d kv_dtype=%s CTAs=%d "
                 "input_read_bytes=%zu cache_write_bytes=%zu total_model_bytes=%zu "
                 "ncu_kernel_regex='%s' control_ncu_kernel_regex='%s'\n",
-                tokens, context, kv_dtype_name(kv.k_dtype), kv_append_ctas(tokens, kv.k_dtype),
+                tokens, context, kv_dtype_name(kv_dtype), kv_append_ctas(tokens, kv_dtype),
                 bytes.input_read, bytes.cache_write, bytes.total,
-                kv_append_ncu_kernel_regex(kv.k_dtype),
-                kv_append_control_ncu_kernel_regex(kv.k_dtype));
+                kv_append_ncu_kernel_regex(kv_dtype), kv_append_control_ncu_kernel_regex(kv_dtype));
 }
 
-void run_copy_ceiling(std::int32_t tokens, std::int32_t context, DType kv_dtype) {
+void run_copy_ceiling(std::int32_t tokens, std::int32_t context, KvDTypes kv_dtype) {
     const DecodeBytes bytes = append_small_t_bytes(tokens, context, kv_dtype);
     DeviceBuffer src        = make_zeros(bytes.useful_kv);
     DeviceBuffer dst        = make_zeros(bytes.useful_kv);
@@ -1158,8 +1226,9 @@ AppendPromptMetrics run_append_prompt_baseline(KVCache& kv, std::int32_t tokens,
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
-    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.k_dtype);
-    const Result r     = bench_loop(
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const double bytes      = append_prompt_global_floor_bytes(tokens, context, kv_dtype);
+    const Result r = bench_loop(
         [&](cudaStream_t s) {
             ops::detail::gqa_attention_prompt_launch(tq, tk, tv, tpos, kScale, kv.layer_view(0),
                                                          tout, s);
@@ -1167,7 +1236,7 @@ AppendPromptMetrics run_append_prompt_baseline(KVCache& kv, std::int32_t tokens,
         bytes, timing.warmup, timing.repeat, timing.min_time_ms);
 
     AppendPromptMetrics metrics =
-        append_prompt_metrics_from_result(tokens, context, kv.k_dtype, r);
+        append_prompt_metrics_from_result(tokens, context, kv_dtype, r);
     print_append_prompt_result("gqa_attention append-prompt", metrics);
     return metrics;
 }
@@ -1196,8 +1265,9 @@ AppendPromptMetrics run_append_prompt_attention_only(KVCache& kv, std::int32_t t
                                              stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
-    const double bytes = append_prompt_global_floor_bytes(tokens, context, kv.k_dtype);
-    const Result r     = bench_loop(
+    const KvDTypes kv_dtype = kv_dtypes(kv);
+    const double bytes      = append_prompt_global_floor_bytes(tokens, context, kv_dtype);
+    const Result r = bench_loop(
         [&](cudaStream_t s) {
             ops::detail::gqa_attention_prompt_attention_launch(tq, tpos, kScale, kv.layer_view(0),
                                                                    tout, s);
@@ -1205,7 +1275,7 @@ AppendPromptMetrics run_append_prompt_attention_only(KVCache& kv, std::int32_t t
         bytes, timing.warmup, timing.repeat, timing.min_time_ms);
 
     AppendPromptMetrics metrics =
-        append_prompt_metrics_from_result(tokens, context, kv.k_dtype, r);
+        append_prompt_metrics_from_result(tokens, context, kv_dtype, r);
     print_append_prompt_result("gqa_attention append-attn-only", metrics);
     return metrics;
 }
@@ -1215,7 +1285,7 @@ double prefill_useful_flops(std::int32_t tokens) {
            static_cast<double>(tokens) * static_cast<double>(tokens + 1);
 }
 
-double prefill_model_floor_bytes(std::int32_t tokens, DType kv_dtype) {
+double prefill_model_floor_bytes(std::int32_t tokens, KvDTypes kv_dtype) {
     const double q_bytes = static_cast<double>(tokens) * static_cast<double>(kQHeads) *
                            static_cast<double>(kHeadDim) *
                            static_cast<double>(sizeof(std::uint16_t));
@@ -1230,7 +1300,7 @@ double prefill_model_floor_bytes(std::int32_t tokens, DType kv_dtype) {
 
 struct PrefillMetrics {
     std::int32_t tokens      = 0;
-    DType kv_dtype           = DType::BF16;
+    KvDTypes kv_dtype;
     int runs                 = 0;
     int inner_iters          = 1;
     double median_ms         = 0.0;
@@ -1248,7 +1318,7 @@ struct PrefillMetrics {
     const char* bound        = "tc";
 };
 
-PrefillMetrics prefill_metrics_from_result(std::int32_t tokens, DType kv_dtype, const Result& r) {
+PrefillMetrics prefill_metrics_from_result(std::int32_t tokens, KvDTypes kv_dtype, const Result& r) {
     PrefillMetrics m;
     m.tokens            = tokens;
     m.kv_dtype          = kv_dtype;
@@ -1304,15 +1374,16 @@ PrefillMetrics run_prefill(KVCache& kv, std::int32_t tokens, const PrefillTiming
     Tensor tpos(pos.p, DType::I32, {tokens});
     Tensor tout(out.p, DType::BF16, {kHeadDim, kQHeads, tokens});
 
+    const KvDTypes kv_dtype = kv_dtypes(kv);
     const Result r = bench_loop(
         [&](cudaStream_t s) {
             ops::gqa_attention(tq, tk, tv, tpos, kScale, kv.layer_view(0),
                                exact_envelope(static_cast<std::uint32_t>(tokens)), ws, tout, s);
         },
-        prefill_model_floor_bytes(tokens, kv.k_dtype), timing.warmup, timing.repeat,
+        prefill_model_floor_bytes(tokens, kv_dtype), timing.warmup, timing.repeat,
         timing.min_time_ms);
 
-    PrefillMetrics metrics = prefill_metrics_from_result(tokens, kv.k_dtype, r);
+    PrefillMetrics metrics = prefill_metrics_from_result(tokens, kv_dtype, r);
     print_prefill_result(metrics);
     return metrics;
 }
@@ -1340,12 +1411,13 @@ void run_prefill_profile_once(KVCache& kv, std::int32_t tokens) {
                        exact_envelope(static_cast<std::uint32_t>(tokens)), ws, tout, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
+    const KvDTypes kv_dtype = kv_dtypes(kv);
     std::printf("PROFILE_ONCE gqa_attention prefill T=%d kv_dtype=%s useful_flops=%.0f "
                 "model_floor_bytes=%.0f tc_peak_tflops=%.1f dram_peak_gbps=%.0f "
                 "ncu_kernel_regex='%s'\n",
-                tokens, kv_dtype_name(kv.k_dtype), prefill_useful_flops(tokens),
-                prefill_model_floor_bytes(tokens, kv.k_dtype), kDenseTcPeakTflops, kDramPeakGBs,
-                prefill_ncu_kernel_regex(kv.k_dtype));
+                 tokens, kv_dtype_name(kv_dtype), prefill_useful_flops(tokens),
+                 prefill_model_floor_bytes(tokens, kv_dtype), kDenseTcPeakTflops, kDramPeakGBs,
+                 prefill_ncu_kernel_regex(kv_dtype));
 }
 
 std::string json_number(double value) {
@@ -1595,7 +1667,7 @@ struct Options {
     std::int32_t decode_pos          = 0;
     std::int32_t context             = 0;
     std::uint32_t round_robin_layers = 1;
-    DType kv_dtype                   = DType::BF16;
+    KvDTypes kv_dtype;
     bool geometry_35b                = false;
     std::vector<std::int32_t> tokens;
     std::vector<std::int32_t> contexts;
@@ -1610,28 +1682,28 @@ void fail_usage(const char* message) {
         stderr,
         "error: %s\n"
         "usage: ninfer_gqa_attention_bench [--prefill] [--tokens T[,T...]] "
-        "[--geometry 27b|35b] [--kv-dtype bf16|int8] "
+        "[--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16] "
         "[--expect-tflops-pct-min PCT] [--csv-out path] [--json-out path]\n"
         "       ninfer_gqa_attention_bench --prefill --tokens 4096 --profile-once\n"
         "       ninfer_gqa_attention_bench --append-small-t --tokens T[,T...] "
-        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8] "
+        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16] "
         "[--profile-once] [--cold-cache]\n"
         "       ninfer_gqa_attention_bench --cached-small-t --tokens T[,T...] "
-        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8] "
+        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16] "
         "[--profile-once] [--cold-cache]\n"
         "       ninfer_gqa_attention_bench --kv-append --tokens T[,T...] "
-        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8] "
+        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16] "
         "[--profile-once] [--cold-cache] [--csv-out path] [--json-out path]\n"
         "       ninfer_gqa_attention_bench --append-prompt-baseline --tokens T[,T...] "
-        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8] "
+        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16] "
         "[--csv-out path] [--json-out path]\n"
         "       ninfer_gqa_attention_bench --append-prompt-attention-only --tokens T[,T...] "
-        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8]\n"
+        "--context N[,N...] [--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16]\n"
         "       ninfer_gqa_attention_bench --copy-ceiling --tokens T --context N "
-        "[--geometry 27b|35b] [--kv-dtype bf16|int8]\n"
+        "[--geometry 27b|35b] [--kv-dtype bf16|int8|bf16:int8|int8:bf16]\n"
         "       ninfer_gqa_attention_bench --decode [--decode-pos N] [--profile-once] "
         "[--cold-cache] [--round-robin-layers 16] [--geometry 27b|35b] "
-        "[--kv-dtype bf16|int8]\n",
+        "[--kv-dtype bf16|int8|bf16:int8|int8:bf16]\n",
         message);
     std::exit(2);
 }
@@ -1661,13 +1733,38 @@ double parse_double_arg(const char* text, const char* flag) {
     return value;
 }
 
-DType parse_kv_dtype_arg(const char* text, const char* flag) {
-    if (!std::strcmp(text, "bf16")) { return DType::BF16; }
-    if (!std::strcmp(text, "int8")) { return DType::I8; }
-    char msg[128];
-    std::snprintf(msg, sizeof(msg), "%s expects bf16 or int8", flag);
+KvDTypes parse_kv_dtype_arg(const char* text, const char* flag) {
+    const std::string_view value(text);
+    const auto parse_plane = [](std::string_view plane, DType& dtype) {
+        if (plane == "bf16") {
+            dtype = DType::BF16;
+            return true;
+        }
+        if (plane == "int8") {
+            dtype = DType::I8;
+            return true;
+        }
+        return false;
+    };
+
+    KvDTypes dtype;
+    const std::size_t separator = value.find(':');
+    if (separator == std::string_view::npos) {
+        if (parse_plane(value, dtype.k)) {
+            dtype.v = dtype.k;
+            return dtype;
+        }
+    } else if (value.find(':', separator + 1) == std::string_view::npos &&
+               parse_plane(value.substr(0, separator), dtype.k) &&
+               parse_plane(value.substr(separator + 1), dtype.v)) {
+        return dtype;
+    }
+
+    char msg[256];
+    std::snprintf(msg, sizeof(msg),
+                  "%s expects bf16, int8, bf16:int8, or int8:bf16; got '%s'", flag, text);
     fail_usage(msg);
-    return DType::BF16;
+    return {};
 }
 
 std::vector<std::int32_t> parse_i32_list_arg(const char* text, const char* flag, bool allow_zero) {
@@ -1949,19 +2046,22 @@ int main(int argc, char** argv) {
     LayoutBuilder cache_layout_builder;
     auto cache_layout = ninfer::plan_kv_cache(
         cache_layout_builder, cache_layers, static_cast<std::uint32_t>(max_context), kKVHeads,
-        kHeadDim, opt.kv_dtype, opt.kv_dtype,
-        opt.kv_dtype == DType::I8 ? kBenchKvQuantGroup : 0,
-        opt.kv_dtype == DType::I8 ? kBenchKvQuantGroup : 0);
+        kHeadDim, opt.kv_dtype.k, opt.kv_dtype.v,
+        opt.kv_dtype.k == DType::I8 ? kBenchKvQuantGroup : 0,
+        opt.kv_dtype.v == DType::I8 ? kBenchKvQuantGroup : 0);
     const DeviceSpan cache_backing = cache_arena.alloc_bytes(cache_layout_builder.finish(256));
     KVCache kv(cache_backing, cache_layout);
     for (std::uint32_t layer = 0; layer < kv.layer_count(); ++layer) {
         if (kv.k_dtype == DType::I8) {
             CUDA_CHECK(cudaMemset(kv.k[layer].data, 0, kv.k[layer].bytes()));
-            CUDA_CHECK(cudaMemset(kv.v[layer].data, 0, kv.v[layer].bytes()));
             CUDA_CHECK(cudaMemset(kv.k_scale[layer].data, 0, kv.k_scale[layer].bytes()));
-            CUDA_CHECK(cudaMemset(kv.v_scale[layer].data, 0, kv.v_scale[layer].bytes()));
         } else {
             CUDA_CHECK(cudaMemset(kv.k[layer].data, 0x3e, kv.k[layer].bytes()));
+        }
+        if (kv.v_dtype == DType::I8) {
+            CUDA_CHECK(cudaMemset(kv.v[layer].data, 0, kv.v[layer].bytes()));
+            CUDA_CHECK(cudaMemset(kv.v_scale[layer].data, 0, kv.v_scale[layer].bytes()));
+        } else {
             CUDA_CHECK(cudaMemset(kv.v[layer].data, 0x3d, kv.v[layer].bytes()));
         }
     }

--- a/bench/ops/kv_cache_append_prefix_bench.cu
+++ b/bench/ops/kv_cache_append_prefix_bench.cu
@@ -245,8 +245,10 @@ struct Case {
             .padded_context = kCapacity,
             .num_kv_heads   = kKVHeads,
             .head_dim       = kD,
-            .dtype          = DType::BF16,
-            .quant_group    = 0,
+            .k_dtype        = DType::BF16,
+            .v_dtype        = DType::BF16,
+            .k_quant_group  = 0,
+            .v_quant_group  = 0,
         };
     }
 

--- a/bench/targets/qwen3_6_27b/ninfer_bench.cpp
+++ b/bench/targets/qwen3_6_27b/ninfer_bench.cpp
@@ -179,7 +179,7 @@ int main(int argc, char** argv) {
 
         std::cerr << "[ninfer_bench] loading " << options.artifact_path
                   << " (max_context=" << max_context
-                  << ", kv_cache=" << ninfer::bench::kv_cache_name(options.kv_cache) << ")\n";
+                  << ", kv_cache=" << ninfer::kv_cache_storage_name(options.kv_cache) << ")\n";
         ninfer::Engine engine(std::move(engine_options));
         fill_cuda_environment(env, options.device);
         env.load   = engine.load_summary();

--- a/bench/targets/qwen3_6_27b/ninfer_bench_support.cpp
+++ b/bench/targets/qwen3_6_27b/ninfer_bench_support.cpp
@@ -48,10 +48,20 @@ std::uint32_t parse_u32(std::string_view text, const char* label, bool allow_zer
     return static_cast<std::uint32_t>(value);
 }
 
+KvCacheFormat parse_kv_format(std::string_view text) {
+    if (text == "bf16") { return KvCacheFormat::BFloat16; }
+    if (text == "int8") { return KvCacheFormat::Int8Group64; }
+    throw std::invalid_argument("--kv-dtype must be bf16, int8, or <k>:<v> of those");
+}
+
+// K/V formats are selected independently as "<k>:<v>"; a bare value selects both.
 KvCacheStorage parse_kv_cache(std::string_view text) {
-    if (text == "bf16") { return KvCacheStorage::BFloat16; }
-    if (text == "int8") { return KvCacheStorage::Int8Group64; }
-    throw std::invalid_argument("--kv-dtype must be bf16 or int8");
+    const std::size_t separator = text.find(':');
+    if (separator == std::string_view::npos) {
+        return kv_cache_uniform(parse_kv_format(text));
+    }
+    return KvCacheStorage{parse_kv_format(text.substr(0, separator)),
+                          parse_kv_format(text.substr(separator + 1))};
 }
 
 std::vector<int> parse_int_list(std::string_view value, const char* label) {
@@ -270,7 +280,8 @@ std::string usage_text(std::string_view program) {
         << "  --max-ctx <tokens>          override auto-sized context capacity\n"
         << "  --prefill-chunk <tokens>    multiple of " << kPrefillChunkAlignment
         << " (default: " << kDefaultPrefillChunk << ")\n"
-        << "  --kv-dtype <bf16|int8>      KV cache storage (default: bf16)\n"
+        << "  --kv-dtype <bf16|int8|bf16:int8|int8:bf16>\n"
+        << "                                K:V KV cache storage (default: bf16)\n"
         << "  --mtp-draft-tokens <0..5>   speculative draft window (default: 0)\n"
         << "  --lm-head-draft             use the optimized proposal head; requires MTP\n"
         << "  --device <id>               CUDA device ordinal (default: 0)\n"
@@ -562,7 +573,8 @@ std::string format_table(const BenchEnvironment& env, const std::vector<TestResu
         << format_bytes(env.memory.kv_payload_bytes) << '\n'
         << "  corpus:     " << env.corpus_path << " (" << env.corpus_tokens << " tokens)\n"
         << "  config:     max_context=" << env.max_context << " prefill_chunk=" << env.prefill_chunk
-        << " kv_cache=" << kv_cache_name(env.kv_cache) << " mtp_k=" << env.mtp_draft_tokens
+        << " kv_cache=" << kv_cache_storage_name(env.kv_cache) << " mtp_k="
+        << env.mtp_draft_tokens
         << " proposal_head=" << proposal_head_name(env.proposal_head)
         << " decode_path=" << decode_path_name(env.use_cuda_graph, env.mtp_draft_tokens)
         << " graph_prime="
@@ -637,7 +649,7 @@ std::string format_json(const BenchEnvironment& env, const std::string& command,
         << "  \"memory\": {\n"
         << "    \"device\": " << env.memory.device << ",\n"
         << "    \"max_context\": " << env.memory.max_context << ",\n"
-        << "    \"kv_cache\": \"" << kv_cache_name(env.memory.kv_cache) << "\",\n";
+        << "    \"kv_cache\": \"" << kv_cache_storage_name(env.memory.kv_cache) << "\",\n";
     append_arena_json(out, "weights", env.memory.weights, "    ", true);
     append_arena_json(out, "sequence", env.memory.sequence, "    ", true);
     append_arena_json(out, "workspace", env.memory.workspace, "    ", true);
@@ -646,7 +658,7 @@ std::string format_json(const BenchEnvironment& env, const std::string& command,
         << "  \"config\": {\n"
         << "    \"max_context\": " << env.max_context << ",\n"
         << "    \"prefill_chunk\": " << env.prefill_chunk << ",\n"
-        << "    \"kv_cache\": \"" << kv_cache_name(env.kv_cache) << "\",\n"
+        << "    \"kv_cache\": \"" << kv_cache_storage_name(env.kv_cache) << "\",\n"
         << "    \"mtp_draft_tokens\": " << env.mtp_draft_tokens << ",\n"
         << "    \"proposal_head\": \"" << proposal_head_name(env.proposal_head) << "\",\n"
         << "    \"use_cuda_graph\": " << (env.use_cuda_graph ? "true" : "false") << ",\n"
@@ -734,7 +746,7 @@ std::string format_csv(const BenchEnvironment& env, const std::vector<TestResult
             << env.max_context << ',' << env.prefill_chunk << ',' << env.mtp_draft_tokens << ','
             << proposal_head_name(env.proposal_head) << ','
             << decode_path_name(env.use_cuda_graph, env.mtp_draft_tokens) << ','
-            << kv_cache_name(env.kv_cache) << ',' << env.memory.kv_payload_bytes << ','
+            << kv_cache_storage_name(env.kv_cache) << ',' << env.memory.kv_payload_bytes << ','
             << env.load.host_to_device_bytes << ',' << env.memory.weights.capacity_bytes << ','
             << env.memory.sequence.capacity_bytes << ',' << env.memory.workspace.capacity_bytes
             << ',' << result.workspace_peak_bytes << ',' << spec.rounds << ','
@@ -781,16 +793,6 @@ std::string json_escape(std::string_view value) {
         }
     }
     return out;
-}
-
-std::string kv_cache_name(KvCacheStorage storage) {
-    switch (storage) {
-    case KvCacheStorage::BFloat16:
-        return "bf16";
-    case KvCacheStorage::Int8Group64:
-        return "int8-group64";
-    }
-    return "unknown";
 }
 
 std::string proposal_head_name(ProposalHead head) {

--- a/bench/targets/qwen3_6_27b/ninfer_bench_support.h
+++ b/bench/targets/qwen3_6_27b/ninfer_bench_support.h
@@ -62,7 +62,7 @@ struct BenchOptions {
     int warmup      = kDefaultWarmup;
     std::optional<std::uint32_t> max_context;
     std::uint32_t prefill_chunk    = kDefaultPrefillChunk;
-    KvCacheStorage kv_cache        = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     std::uint32_t mtp_draft_tokens = 0;
     ProposalHead proposal_head     = ProposalHead::Full;
     int device                     = 0;
@@ -104,7 +104,7 @@ struct BenchEnvironment {
 
     std::uint32_t max_context                      = 0;
     std::uint32_t prefill_chunk                    = kDefaultPrefillChunk;
-    KvCacheStorage kv_cache                        = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     std::uint32_t mtp_draft_tokens                 = 0;
     ProposalHead proposal_head                     = ProposalHead::Full;
     bool use_cuda_graph                            = true;
@@ -146,7 +146,6 @@ std::string format_json(const BenchEnvironment& env, const std::string& command,
 std::string format_csv(const BenchEnvironment& env, const std::vector<TestResult>& results);
 
 std::string json_escape(std::string_view value);
-std::string kv_cache_name(KvCacheStorage storage);
 std::string proposal_head_name(ProposalHead head);
 std::uint64_t file_size_or_zero(const std::string& path);
 

--- a/bench/targets/qwen3_6_27b/target_mtp_round_bench.cpp
+++ b/bench/targets/qwen3_6_27b/target_mtp_round_bench.cpp
@@ -123,7 +123,7 @@ int run(const Options& options) {
                                                                       (options.draft_tokens + 1ULL) +
                                                                   2ULL * options.draft_tokens);
     engine.prefill_chunk             = 128;
-    engine.kv_cache                  = ninfer::KvCacheStorage::BFloat16;
+    engine.kv_cache                  = ninfer::KvCacheStorage{};
     engine.speculative.backend       = ninfer::SpeculativeBackend::Mtp;
     engine.speculative.draft_tokens  = options.draft_tokens;
     engine.speculative.proposal_head = options.proposal;

--- a/bench/targets/qwen3_6_35b_a3b/dflash_round_bench.cpp
+++ b/bench/targets/qwen3_6_35b_a3b/dflash_round_bench.cpp
@@ -161,7 +161,7 @@ int run(const Options& options) {
     engine.device                    = options.device;
     engine.max_context               = static_cast<std::uint32_t>(capacity);
     engine.prefill_chunk             = 128;
-    engine.kv_cache                  = ninfer::KvCacheStorage::BFloat16;
+    engine.kv_cache                  = ninfer::KvCacheStorage{};
     engine.speculative.backend       = ninfer::SpeculativeBackend::DFlash;
     engine.speculative.draft_tokens  = options.draft_tokens;
     engine.speculative.proposal_head = options.proposal;

--- a/bench/targets/qwen3_6_35b_a3b/target_speculative_round_bench.cpp
+++ b/bench/targets/qwen3_6_35b_a3b/target_speculative_round_bench.cpp
@@ -199,9 +199,11 @@ StateLayout plan_state(const Options& options, std::uint32_t maximum_k) {
             .capacity              = capacity,
             .kv_heads              = detail::TextConfig::kv_heads,
             .attention_head_dim    = detail::TextConfig::head_dim,
-            .kv_dtype              = options.kv_dtype,
-            .kv_quant_group = options.kv_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
-            .enable_mtp     = false,
+            .kv_k_dtype            = options.kv_dtype,
+            .kv_v_dtype            = options.kv_dtype,
+            .kv_k_quant_group = options.kv_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
+            .kv_v_quant_group = options.kv_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
+            .enable_mtp       = false,
             .gdn =
                 {
                     .layers         = detail::TextConfig::gdn_layers(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,7 +131,7 @@ measured recommendation rather than a semantic limit.
 | `--prefill-chunk N` | positive text-prefill chunk, in multiples of 128 | `1024` |
 | `--max-new N` | requested output-token limit | `128` |
 | `--device N` | CUDA device index | `0` |
-| `--kv-dtype bf16\|int8` | KV-cache storage | `bf16` |
+| `--kv-dtype bf16\|int8\|bf16:int8\|int8:bf16` | K:V KV-cache storage; bare value selects both | `bf16` |
 | `--spec mtp\|dflash` | speculative backend | off |
 | `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
@@ -157,7 +157,9 @@ Run `./build/apps/ninfer --help` for the exact option contract.
 
 Both registered models have a native context limit of 262,144 tokens. The practical allocation on
 one RTX 5090 depends on the selected artifact, media workload, output budget, and KV-cache type.
-Use `--kv-dtype int8` for large context allocations. The prepared prompt must fit
-`--max-context`; generation stops at the remaining context capacity when necessary.
+Use `--kv-dtype int8` for the smallest large-context allocation. Use `bf16:int8` to keep K in
+BF16 while halving V code storage, or `int8:bf16` for the inverse. In mixed syntax the first value
+is K and the second is V. The prepared prompt must fit `--max-context`; generation stops at the
+remaining context capacity when necessary.
 
 All weight, sequence, workspace, and graph allocations are released when the Engine is destroyed.

--- a/docs/maintainer/op-development.md
+++ b/docs/maintainer/op-development.md
@@ -476,11 +476,13 @@ conformance matrix, and target-representative activations is not a universal err
 arbitrary unbounded or adversarial tensors. Each semantically complete entry point is checked
 directly against the oracle; pairwise implementation parity is supplementary evidence.
 
-GQA applies this rule concretely. BF16-cache and INT8-G64-cache A1/A3 share an FP64 ideal attention
-oracle over BF16 Q and logical cache values (BF16 or FP32-decoded INT8-G64). The target's INT8
-Q8-G64 query compute profile remains an intentional optimized implementation; the GQA suite gives
-the BF16-cache and INT8-cache compute profiles separate named criteria without folding either into
-a second reference. Exact INT8 cache code and scale validation remains a separate codec check.
+GQA applies this rule concretely. K and V independently select BF16 or INT8-G64 storage, while all
+A1/A3 combinations share an FP64 ideal attention oracle over BF16 Q and per-side logical cache
+values (BF16 or FP32-decoded INT8-G64). The symmetric INT8 Q8-G64 query profile remains an
+intentional optimized implementation; mixed profiles keep BF16 Q/K math and dequantize their INT8
+side. The GQA suite gives BF16, INT8, and mixed compute profiles separate named criteria without
+folding any into a second reference. Exact per-side INT8 code and scale validation remains a
+separate codec check.
 
 ### 8.1 Op qualification standard
 

--- a/docs/maintainer/qwen3.6-27b-model.md
+++ b/docs/maintainer/qwen3.6-27b-model.md
@@ -146,10 +146,10 @@ x = x + o_projection(a)
 ```
 
 Prefill appends all K/V columns and evaluates causal attention for the chunk. Decode appends one
-column and attends over the resident prefix. KV storage may be BF16 or INT8-G64. The exact runtime
-cache codec and the common ideal attention oracle are defined by the repository-internal
-[`gqa_attention.h`](../../include/ninfer/ops/gqa_attention.h) contract. Both cache formats and their
-optimized compute profiles are judged by that one oracle construction rather than by
+column and attends over the resident prefix. K and V independently select BF16 or INT8-G64 storage.
+The exact runtime cache codec and the common ideal attention oracle are defined by the
+repository-internal [`gqa_attention.h`](../../include/ninfer/ops/gqa_attention.h) contract. The
+BF16, INT8, and mixed compute profiles are judged by that one oracle construction rather than by
 implementation-mirroring references.
 
 Text-only positions use the same scalar position for temporal, height, and width MRoPE sections.
@@ -364,11 +364,11 @@ remain consistent.
 - the ideal GQA oracle evaluates dot products, stable softmax, and value reduction in FP64 from
   BF16 Q and logical cache values; the BF16 Op output is promoted to FP64 for comparison;
 - low-bit weight storage changes representation, not the intended dequantized matrix;
-- INT8-G64 KV stores FP16 scales and signed codes, and its ideal logical K/V values are their FP32
-  decode;
-- the target's INT8 attention path intentionally quantizes Q to Q8-G64 for production computation;
-  this native compute profile does not replace BF16 Q in the common ideal oracle, and its delta is
-  accepted through the separate named INT8-cache compute-profile criterion;
+- each INT8-G64 K or V plane stores its own FP16 scales and signed codes, and its ideal logical
+  values are their FP32 decode;
+- the symmetric INT8 attention path intentionally quantizes Q to Q8-G64 for production computation;
+  mixed paths keep BF16 Q/K Tensor Core math and dequantize only the INT8 plane; neither profile
+  replaces BF16 Q in the common ideal oracle, and each delta has a separately named criterion;
 - the full target `lm_head` is used for prefill, verification, and ordinary decode regardless of
   draft-head mode.
 
@@ -379,8 +379,8 @@ route and accepted against the Op's criterion for that implementation profile.
 
 GQA numerical qualification covers both registered geometries, supported prompt and small-T
 regimes, the maintained conformance matrix, and target-representative activation ranges. Its
-BF16-cache and INT8-cache compute-profile criteria are explicitly named in the GQA conformance
-suite; they are not claimed as pointwise bounds for every arbitrary or adversarial BF16 tensor. A1
+BF16-cache, INT8-cache, and mixed-cache compute-profile criteria are explicitly named in the GQA
+conformance suite; they are not claimed as pointwise bounds for every arbitrary or adversarial BF16 tensor. A1
 append-and-attend and A3 cached-only attention are each checked directly against the common ideal
 oracle. Equality between those different numerical paths is not a contract or acceptance test.
 

--- a/docs/maintainer/qwen3.6-35b-a3b-model.md
+++ b/docs/maintainer/qwen3.6-35b-a3b-model.md
@@ -734,8 +734,8 @@ encoder or audio projection tower. Token presence is not evidence of an audio in
   matrix. Proposal selection may use the existing full `lm_head` or the artifact's existing
   optimized proposal head; neither is a private companion parameter.
 - Public activation, cache, and recurrent-state dtypes are stated by their owning Op/state contract.
-  In particular, GDN recurrent matrices and decay controls are FP32, while registered BF16/INT8 KV
-  formats remain real persistent representation boundaries.
+  In particular, GDN recurrent matrices and decay controls are FP32, while K and V independently
+  select registered BF16/INT8 persistent representation boundaries.
 - Every floating-point Op uses one independent naive FP32/FP64 mathematical oracle over its logical
   inputs. Packed weights are decoded from their stored codes and exact stored scales. Exact
   transforms and codecs use exact oracles.

--- a/docs/maintainer/tensor-formats.md
+++ b/docs/maintainer/tensor-formats.md
@@ -150,8 +150,9 @@ components. There is no generic fallback obligation for another combination.
 
 KV-cache quantization, activation quantization, temporary kernel compression, recurrent state, and
 communication formats are runtime-state codecs. They are outside this persistent-tensor registry
-even if they also use signed integers and grouped scales. In particular, an INT8 KV-cache format
-must not be labeled `W8G32_F16S` merely because some of its fields look similar.
+even if they also use signed integers and grouped scales. K and V may independently use BF16 or
+INT8-G64 runtime storage; an INT8 KV-cache plane must not be labeled `W8G32_F16S` merely because
+some of its fields look similar.
 
 ## 3. Canonical identities and direct-format semantics
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -158,7 +158,7 @@ curl http://127.0.0.1:8080/v1/models \
 | `--device N` | CUDA device index | `0` |
 | `--max-request-mib N` | body-size limit before JSON parsing | `384` |
 | `--request-log-jsonl FILE` | append full-precision server/request records | disabled |
-| `--kv-dtype bf16\|int8` | KV-cache storage | `bf16` |
+| `--kv-dtype bf16\|int8\|bf16:int8\|int8:bf16` | K:V KV-cache storage; bare value selects both | `bf16` |
 | `--spec mtp\|dflash` | speculative backend | off |
 | `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -103,7 +103,7 @@ $CLI "$MODEL" --messages examples/cli/messages/long_8k.json \
   --no-thinking --greedy --max-new 64
 
 $CLI "$MODEL" --messages examples/cli/messages/long_64k.json \
-  --max-context 65536 --kv-dtype int8 --prefill-chunk 1024 \
+  --max-context 65536 --kv-dtype bf16:int8 --prefill-chunk 1024 \
   --no-thinking --greedy --max-new 64
 
 $CLI "$MODEL" --messages examples/cli/messages/long_128k.json \

--- a/include/ninfer/ops/bidirectional_gqa_attention.h
+++ b/include/ninfer/ops/bidirectional_gqa_attention.h
@@ -34,7 +34,8 @@ struct GqaContextExecutionEnvelope {
  *
  * q/out are contiguous BF16 [128,32,T]. query_k/query_v are contiguous BF16 [128,8,T].
  * context_length is a contiguous device I32 scalar L. context is a read-only linear BF16 cache
- * with logical shape [128,capacity,8], of which [0,L) is populated. scale is 1/sqrt(128).
+ * with logical shape [128,capacity,8], of which [0,L) is populated. This DFlash companion cache
+ * has no scale planes and is independent of the target Text/MTP KV format. scale is 1/sqrt(128).
  *
  * There is no causal triangle: every query row attends every other query K/V row. Context and
  * query K/V remain separate physical segments and every input/cache byte is unchanged. The oracle

--- a/include/ninfer/ops/gqa_attention.h
+++ b/include/ninfer/ops/gqa_attention.h
@@ -19,8 +19,9 @@ struct GqaExecutionEnvelope {
  * Shared numerical contract for A1/A2/A3.
  *
  * Public q/k/v inputs and BF16 cache values are interpreted after their BF16 storage boundary.
- * INT8-G64 cache rows use one FP16 scale for each contiguous 64-element group. For BF16 source
- * values x, their exact observable encoding is:
+ * The K and V planes select their storage independently: each side is BF16 or INT8-G64, and the
+ * two sides may differ (e.g. K BF16 with V INT8-G64). INT8-G64 cache rows use one FP16 scale for
+ * each contiguous 64-element group. For BF16 source values x, their exact observable encoding is:
  *
  *   a          = max_i abs(FP32(x[i]))
  *   scale_bits = FP16_RNE(a / 127)
@@ -30,18 +31,19 @@ struct GqaExecutionEnvelope {
  *   decode[i]  = FP32(code[i]) * s
  *
  * A1 and A2 produce identical code and scale bits. The common ideal attention oracle uses BF16 Q
- * and logical cache values (BF16 values for a BF16 cache, FP32 decode above for INT8-G64), then
- * evaluates score dot products, stable softmax, and value reduction in FP64. The BF16 Op output is
- * promoted to FP64 for comparison with that result.
+ * and logical cache values (per side: BF16 values for a BF16 plane, FP32 decode above for an
+ * INT8-G64 plane), then evaluates score dot products, stable softmax, and value reduction in FP64.
+ * The BF16 Op output is promoted to FP64 for comparison with that result.
  *
  * The registered INT8 implementation defines Q8-G64, paired with INT8-G64 K, as its native query
- * compute profile. Its profile-defined query quantization and any narrower staging do not replace
- * BF16 Q in the ideal oracle. BF16-cache and INT8-cache compute profiles therefore have separate
- * named numerical criteria owned by the GQA conformance test. Those envelopes apply to the
- * registered geometries, tested token extents, conformance matrix, and target-representative
- * activation range; they are not a universal error bound for arbitrary adversarial BF16 tensors.
- * A1 and A3 are each qualified directly against the ideal oracle. A1-versus-A3 parity is only an
- * additional consistency check.
+ * compute profile; it applies only when both planes are INT8-G64. Its profile-defined query
+ * quantization and any narrower staging do not replace BF16 Q in the ideal oracle. A mixed-format
+ * cache keeps BF16 Q/K tensor-core math and dequantizes only the INT8-G64 side. BF16-cache,
+ * INT8-cache, and mixed-cache compute profiles therefore have separate named numerical criteria
+ * owned by the GQA conformance test. Those envelopes apply to the registered geometries, tested
+ * token extents, conformance matrix, and target-representative activation range; they are not a
+ * universal error bound for arbitrary adversarial BF16 tensors. A1 and A3 are each qualified
+ * directly against the ideal oracle. A1-versus-A3 parity is only an additional consistency check.
  */
 
 /**
@@ -60,7 +62,7 @@ struct GqaExecutionEnvelope {
  * The registered geometries are `[256,24|4,T]` group 6 and `[256,16|2,T]` group 8. q/k/v/out
  * are contiguous BF16, positions is contiguous sequential I32 [T], and scale is 1/sqrt(256).
  * T may be any positive value that fits the declared cache and execution envelope.
- * Cache storage is BF16 or INT8-G64 under the shared numerical contract above. The caller
+ * Cache storage is BF16 or INT8-G64 per side under the shared numerical contract above. The caller
  * guarantees that every row in the causal domain is populated and that `positions[T-1]+1` lies in
  * the declared execution envelope. The envelope is a host launch-resource promise; it does not
  * alter the causal mask.

--- a/include/ninfer/ops/kv_cache_append_prefix.h
+++ b/include/ninfer/ops/kv_cache_append_prefix.h
@@ -42,7 +42,8 @@ void kv_cache_append_prefix(const Tensor& k, const Tensor& v, const Tensor& posi
  * Absolute position p maps to physical slot p mod 4096. The caller guarantees that the live
  * interval ends immediately before positions[0] and that advancing it by commit_count makes every
  * overwritten old slot dead. One invocation may commit at most the ring capacity, so no two live
- * writes race for one physical slot.
+ * writes race for one physical slot. The cyclic cache is BF16 with no scale planes; it belongs to
+ * DFlash and is independent of the target Text/MTP KV format.
  */
 void kv_cache_append_prefix(const Tensor& k, const Tensor& v, const Tensor& positions,
                             const Tensor& commit_count,

--- a/include/ninfer/ops/swa.h
+++ b/include/ninfer/ops/swa.h
@@ -29,11 +29,11 @@ struct SwaContextExecutionEnvelope {
  * q/out are contiguous BF16 [128,32,T], query_k/query_v are contiguous BF16 [128,8,T], and
  * positions is contiguous device I32 [T] with positions[i] = L+i.
  *
- * The read-only cyclic context contains committed absolute positions [max(0,L-4096),L), with
- * absolute position p stored at physical slot p mod 4096. Query K/V is a separate temporary
- * segment at positions [L,L+T). For every query position p_i, the admitted populated keys satisfy
- * abs(p_j-p_i)<4096. Thus distance 4095 is included, distance 4096 is excluded, and every query
- * row sees every temporary query row. scale is 1/sqrt(128).
+ * The read-only cyclic context is BF16 with no scale planes and contains committed absolute
+ * positions [max(0,L-4096),L), with absolute position p stored at physical slot p mod 4096. Query
+ * K/V is a separate temporary segment at positions [L,L+T). For every query position p_i, the
+ * admitted populated keys satisfy abs(p_j-p_i)<4096. Thus distance 4095 is included, distance 4096
+ * is excluded, and every query row sees every temporary query row. scale is 1/sqrt(128).
  *
  * Context and query K/V are unchanged. out is the only observable mutation and is completely
  * overwritten. The current optimized implementation domain is T=1..16 on sm_120a.

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -15,10 +15,33 @@ namespace ninfer {
 
 using TokenId = std::int32_t;
 
-enum class KvCacheStorage : std::uint8_t {
+enum class KvCacheFormat : std::uint8_t {
     BFloat16,
     Int8Group64,
 };
+
+/**
+ * KV cache storage selected independently for the K and V planes. INT8-G64 stores one FP16
+ * scale per contiguous 64-element group; a mixed selection (for example K BF16 with V
+ * INT8-G64) quantizes only the selected side.
+ */
+struct KvCacheStorage {
+    KvCacheFormat k = KvCacheFormat::BFloat16;
+    KvCacheFormat v = KvCacheFormat::BFloat16;
+
+    constexpr bool operator==(const KvCacheStorage&) const = default;
+};
+
+[[nodiscard]] constexpr KvCacheStorage kv_cache_uniform(KvCacheFormat format) noexcept {
+    return KvCacheStorage{format, format};
+}
+
+[[nodiscard]] constexpr std::string_view kv_cache_storage_name(KvCacheStorage storage) noexcept {
+    if (storage.k == KvCacheFormat::BFloat16) {
+        return storage.v == KvCacheFormat::BFloat16 ? "bf16" : "bf16:int8-group64";
+    }
+    return storage.v == KvCacheFormat::BFloat16 ? "int8-group64:bf16" : "int8-group64";
+}
 
 enum class ProposalHead : std::uint8_t {
     Full,
@@ -47,7 +70,7 @@ struct EngineOptions {
     int device                  = 0;
     std::uint32_t max_context   = 2048;
     std::uint32_t prefill_chunk = 1024;
-    KvCacheStorage kv_cache     = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     SpeculativeOptions speculative;
     bool enable_vision  = false;
     bool use_cuda_graph = true;
@@ -240,7 +263,7 @@ struct ArenaMemorySummary {
 struct MemorySummary {
     int device                = 0;
     std::uint32_t max_context = 0;
-    KvCacheStorage kv_cache   = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     ArenaMemorySummary weights;
     ArenaMemorySummary sequence;
     ArenaMemorySummary workspace;

--- a/src/core/kv_cache.cpp
+++ b/src/core/kv_cache.cpp
@@ -54,7 +54,8 @@ Tensor bind_tensor(DeviceSpan backing, const LayoutRegion& region, DType dtype,
 
 KVCacheLayout plan_kv_cache(LayoutBuilder& builder, std::uint32_t full_layers,
                             std::uint32_t max_context_in, std::int32_t num_kv_heads_in,
-                            std::int32_t head_dim_in, DType dtype_in, std::int32_t quant_group_in) {
+                            std::int32_t head_dim_in, DType k_dtype_in, DType v_dtype_in,
+                            std::int32_t k_quant_group_in, std::int32_t v_quant_group_in) {
     if (full_layers == 0) { throw std::invalid_argument("KVCache layers must be nonzero"); }
     if (max_context_in == 0 ||
         max_context_in > static_cast<std::uint32_t>(std::numeric_limits<std::int32_t>::max())) {
@@ -69,30 +70,38 @@ KVCacheLayout plan_kv_cache(LayoutBuilder& builder, std::uint32_t full_layers,
     layout.padded_context = align_up_u32(max_context_in, 128);
     layout.num_kv_heads   = num_kv_heads_in;
     layout.head_dim       = head_dim_in;
-    layout.dtype          = dtype_in;
-    layout.quant_group    = normalize_quant_group(dtype_in, quant_group_in, head_dim_in);
+    layout.k_dtype        = k_dtype_in;
+    layout.v_dtype        = v_dtype_in;
+    layout.k_quant_group  = normalize_quant_group(k_dtype_in, k_quant_group_in, head_dim_in);
+    layout.v_quant_group  = normalize_quant_group(v_dtype_in, v_quant_group_in, head_dim_in);
 
     const auto padded_context_i32 = static_cast<std::int32_t>(layout.padded_context);
-    const Tensor code_shape(nullptr, dtype_in, {head_dim_in, padded_context_i32, num_kv_heads_in});
-    const bool quantized      = dtype_in == DType::I8;
-    const std::int32_t groups = quantized ? head_dim_in / layout.quant_group : 0;
-    const std::size_t scale_bytes =
-        quantized
-            ? Tensor(nullptr, DType::FP16, {groups, padded_context_i32, num_kv_heads_in}).bytes()
-            : 0;
+    const Tensor k_code_shape(nullptr, k_dtype_in,
+                              {head_dim_in, padded_context_i32, num_kv_heads_in});
+    const Tensor v_code_shape(nullptr, v_dtype_in,
+                              {head_dim_in, padded_context_i32, num_kv_heads_in});
+    const bool k_quantized = k_dtype_in == DType::I8;
+    const bool v_quantized = v_dtype_in == DType::I8;
+    const auto scale_bytes = [&](bool quantized, std::int32_t quant_group) -> std::size_t {
+        if (!quantized) { return 0; }
+        const std::int32_t groups = head_dim_in / quant_group;
+        return Tensor(nullptr, DType::FP16, {groups, padded_context_i32, num_kv_heads_in}).bytes();
+    };
+    const std::size_t k_scale_bytes = scale_bytes(k_quantized, layout.k_quant_group);
+    const std::size_t v_scale_bytes = scale_bytes(v_quantized, layout.v_quant_group);
     layout.k.reserve(full_layers);
     layout.v.reserve(full_layers);
-    if (quantized) {
-        layout.k_scale.reserve(full_layers);
-        layout.v_scale.reserve(full_layers);
-    }
+    if (k_quantized) { layout.k_scale.reserve(full_layers); }
+    if (v_quantized) { layout.v_scale.reserve(full_layers); }
     for (std::uint32_t layer = 0; layer < full_layers; ++layer) {
         const std::string prefix = "KV layer " + std::to_string(layer);
-        layout.k.push_back(builder.add(code_shape.bytes(), kArenaAlign, prefix + " K"));
-        layout.v.push_back(builder.add(code_shape.bytes(), kArenaAlign, prefix + " V"));
-        if (quantized) {
-            layout.k_scale.push_back(builder.add(scale_bytes, kArenaAlign, prefix + " K scale"));
-            layout.v_scale.push_back(builder.add(scale_bytes, kArenaAlign, prefix + " V scale"));
+        layout.k.push_back(builder.add(k_code_shape.bytes(), kArenaAlign, prefix + " K"));
+        layout.v.push_back(builder.add(v_code_shape.bytes(), kArenaAlign, prefix + " V"));
+        if (k_quantized) {
+            layout.k_scale.push_back(builder.add(k_scale_bytes, kArenaAlign, prefix + " K scale"));
+        }
+        if (v_quantized) {
+            layout.v_scale.push_back(builder.add(v_scale_bytes, kArenaAlign, prefix + " V scale"));
         }
     }
     return layout;
@@ -112,29 +121,36 @@ std::size_t KVCacheLayout::payload_bytes() const noexcept {
 
 KVCache::KVCache(DeviceSpan backing, const KVCacheLayout& layout)
     : max_context(layout.max_context), padded_context(layout.padded_context),
-      num_kv_heads(layout.num_kv_heads), head_dim(layout.head_dim), dtype(layout.dtype),
-      quant_group(layout.quant_group) {
+      num_kv_heads(layout.num_kv_heads), head_dim(layout.head_dim), k_dtype(layout.k_dtype),
+      v_dtype(layout.v_dtype), k_quant_group(layout.k_quant_group),
+      v_quant_group(layout.v_quant_group) {
     const auto layers = layout.k.size();
     if (layers == 0 || layout.v.size() != layers ||
-        (dtype == DType::I8 &&
-         (layout.k_scale.size() != layers || layout.v_scale.size() != layers)) ||
-        (dtype != DType::I8 && (!layout.k_scale.empty() || !layout.v_scale.empty()))) {
+        (k_dtype == DType::I8 && layout.k_scale.size() != layers) ||
+        (k_dtype != DType::I8 && !layout.k_scale.empty()) ||
+        (v_dtype == DType::I8 && layout.v_scale.size() != layers) ||
+        (v_dtype != DType::I8 && !layout.v_scale.empty())) {
         throw std::invalid_argument("KVCache layout plane counts are inconsistent");
     }
-    const auto padded = static_cast<std::int32_t>(padded_context);
-    const auto groups = dtype == DType::I8 ? head_dim / quant_group : 0;
+    const auto padded   = static_cast<std::int32_t>(padded_context);
+    const auto k_groups = k_dtype == DType::I8 ? head_dim / k_quant_group : 0;
+    const auto v_groups = v_dtype == DType::I8 ? head_dim / v_quant_group : 0;
     k.reserve(layers);
     v.reserve(layers);
     k_scale.reserve(layout.k_scale.size());
     v_scale.reserve(layout.v_scale.size());
     for (std::size_t layer = 0; layer < layers; ++layer) {
-        k.push_back(bind_tensor(backing, layout.k[layer], dtype, {head_dim, padded, num_kv_heads}));
-        v.push_back(bind_tensor(backing, layout.v[layer], dtype, {head_dim, padded, num_kv_heads}));
-        if (dtype == DType::I8) {
+        k.push_back(
+            bind_tensor(backing, layout.k[layer], k_dtype, {head_dim, padded, num_kv_heads}));
+        v.push_back(
+            bind_tensor(backing, layout.v[layer], v_dtype, {head_dim, padded, num_kv_heads}));
+        if (k_dtype == DType::I8) {
             k_scale.push_back(bind_tensor(backing, layout.k_scale[layer], DType::FP16,
-                                          {groups, padded, num_kv_heads}));
+                                          {k_groups, padded, num_kv_heads}));
+        }
+        if (v_dtype == DType::I8) {
             v_scale.push_back(bind_tensor(backing, layout.v_scale[layer], DType::FP16,
-                                          {groups, padded, num_kv_heads}));
+                                          {v_groups, padded, num_kv_heads}));
         }
     }
 }
@@ -150,13 +166,13 @@ KVCacheLayerView KVCache::layer_view(std::uint32_t layer) const {
         .padded_context = padded_context,
         .num_kv_heads   = num_kv_heads,
         .head_dim       = head_dim,
-        .dtype          = dtype,
-        .quant_group    = quant_group,
+        .k_dtype        = k_dtype,
+        .v_dtype        = v_dtype,
+        .k_quant_group  = k_quant_group,
+        .v_quant_group  = v_quant_group,
     };
-    if (dtype == DType::I8) {
-        view.k_scale = k_scale[layer];
-        view.v_scale = v_scale[layer];
-    }
+    if (k_dtype == DType::I8) { view.k_scale = k_scale[layer]; }
+    if (v_dtype == DType::I8) { view.v_scale = v_scale[layer]; }
     return view;
 }
 

--- a/src/core/kv_cache.h
+++ b/src/core/kv_cache.h
@@ -19,8 +19,10 @@ struct KVCacheLayerView {
     std::uint32_t padded_context = 0;
     std::int32_t num_kv_heads    = 0;
     std::int32_t head_dim        = 0;
-    DType dtype                  = DType::BF16;
-    std::int32_t quant_group     = 0;
+    DType k_dtype                = DType::BF16;
+    DType v_dtype                = DType::BF16;
+    std::int32_t k_quant_group   = 0;
+    std::int32_t v_quant_group   = 0;
 };
 
 /**
@@ -47,8 +49,10 @@ struct KVCacheLayout {
     std::uint32_t padded_context = 0;
     std::int32_t num_kv_heads    = 0;
     std::int32_t head_dim        = 0;
-    DType dtype                  = DType::BF16;
-    std::int32_t quant_group     = 0;
+    DType k_dtype                = DType::BF16;
+    DType v_dtype                = DType::BF16;
+    std::int32_t k_quant_group   = 0;
+    std::int32_t v_quant_group   = 0;
     std::vector<LayoutRegion> k;
     std::vector<LayoutRegion> v;
     std::vector<LayoutRegion> k_scale;
@@ -59,8 +63,10 @@ struct KVCacheLayout {
 
 [[nodiscard]] KVCacheLayout plan_kv_cache(LayoutBuilder& builder, std::uint32_t full_layers,
                                           std::uint32_t max_context, std::int32_t num_kv_heads,
-                                          std::int32_t head_dim, DType dtype = DType::BF16,
-                                          std::int32_t quant_group = 0);
+                                          std::int32_t head_dim, DType k_dtype = DType::BF16,
+                                          DType v_dtype = DType::BF16,
+                                          std::int32_t k_quant_group = 0,
+                                          std::int32_t v_quant_group = 0);
 
 struct KVCache {
     std::vector<Tensor> k;
@@ -71,8 +77,10 @@ struct KVCache {
     std::uint32_t padded_context = 0;
     std::int32_t num_kv_heads    = 0;
     std::int32_t head_dim        = 0;
-    DType dtype                  = DType::BF16;
-    std::int32_t quant_group     = 0;
+    DType k_dtype                = DType::BF16;
+    DType v_dtype                = DType::BF16;
+    std::int32_t k_quant_group   = 0;
+    std::int32_t v_quant_group   = 0;
 
     KVCache() = default;
     KVCache(DeviceSpan backing, const KVCacheLayout& layout);

--- a/src/ops/kernel/gqa_attention_decode_mixed.cuh
+++ b/src/ops/kernel/gqa_attention_decode_mixed.cuh
@@ -1,0 +1,499 @@
+#pragma once
+
+// ninfer::ops - split-KV GQA small-T attention, mixed-format KV-cache partial kernel.
+// One K/V plane is BF16 and the other is INT8-G64. Built on the BF16 kernel
+// skeleton (gqa_attention_decode_bf16.cuh): Q and both MMAs stay BF16; the
+// INT8-G64 side is staged as codes+scales and dequantized once into the same
+// swizzled BF16 tile the BF16 side fills directly. The fused append stores the
+// BF16 side verbatim and quantizes the INT8-G64 side, after which all of its
+// keys (history and current tokens) are read back from the cache codes.
+//
+// Standalone from both symmetric kernels; shared scaffolding lives in
+// gqa_attention_decode.cuh, the codec helpers in gqa_attention_kv_quant.cuh.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <math_constants.h>
+
+#include "ops/kernel/gqa_attention_decode.cuh"
+#include "ops/kernel/gqa_attention_kv_quant.cuh"
+
+#include <cstdint>
+
+namespace ninfer::ops {
+
+template <typename Geometry, int TokenTile, int WarpsPerCta, bool KInt8, bool VInt8,
+          typename CacheInput>
+__launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_mixed_kernel(
+    const __nv_bfloat16* q, CacheInput input, const std::int32_t* pos, void* cache_k,
+    void* cache_v, __half* cache_k_scale, __half* cache_v_scale, std::int32_t tokens,
+    std::int32_t padded_context, std::int32_t max_context, float scale,
+    __nv_bfloat16* partial_acc, float* partial_m, float* partial_l) {
+    static_assert(TokenTile >= 1 && TokenTile <= 6);
+    static_assert(WarpsPerCta >= 1 && WarpsPerCta <= 4);
+    static_assert(KInt8 != VInt8, "mixed kernel serves exactly one INT8-G64 side");
+
+    constexpr int Wc            = WarpsPerCta;
+    constexpr int Br            = Wc * 16;
+    constexpr int Bc            = 32;
+    constexpr int D             = kGqaHeadDim;
+    constexpr int Threads       = Wc * 32;
+    constexpr int Groups        = kGqaKvQuantGroups;
+    constexpr int QKNt          = Bc / 8;
+    constexpr int QKKs          = D / 16;
+    constexpr int PVNt          = D / 8;
+    constexpr int PVKs          = Bc / 16;
+    constexpr float Log2E       = 1.4426950408889634074f;
+    constexpr unsigned FullMask = 0xffffffffu;
+    constexpr int QkvRows       = 2 * Bc;
+
+    static_assert(QkvRows >= Br);
+
+    __shared__ __align__(16) __nv_bfloat16 qkv_s[QkvRows * D];
+    __shared__ __align__(16) __nv_bfloat16 p_s[Wc * 16 * Bc];
+    __shared__ __align__(16) std::int8_t i8_codes_s[Bc * D];
+    __shared__ __align__(16) __half i8_scale_s[Bc * Groups];
+    __nv_bfloat16* k_s = qkv_s;
+    __nv_bfloat16* v_s = qkv_s + Bc * D;
+
+    __nv_bfloat16* cache_k_bf16 = static_cast<__nv_bfloat16*>(cache_k);
+    __nv_bfloat16* cache_v_bf16 = static_cast<__nv_bfloat16*>(cache_v);
+    std::int8_t* cache_k_i8     = static_cast<std::int8_t*>(cache_k);
+    std::int8_t* cache_v_i8     = static_cast<std::int8_t*>(cache_v);
+
+    const int kv_head     = static_cast<int>(blockIdx.x);
+    const int split       = static_cast<int>(blockIdx.y);
+    const int split_count = static_cast<int>(gridDim.y);
+    const int tid         = static_cast<int>(threadIdx.x);
+    const int warp        = tid >> 5;
+    const int lane        = tid & 31;
+    const int row_count   = tokens * Geometry::GroupSize;
+
+    auto write_neutral = [&]() {
+        for (int row = tid; row < row_count; row += Threads) {
+            int q_head = 0;
+            int token  = 0;
+            gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+            if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
+                partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] =
+                    -CUDART_INF_F;
+                partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = 0.0f;
+            }
+        }
+        for (int idx = tid; idx < row_count * D; idx += Threads) {
+            const int row = idx / D;
+            const int d   = idx - row * D;
+            int q_head    = 0;
+            int token     = 0;
+            gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+            if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
+                partial_acc[gqa_partial_acc_index<Geometry>(q_head, d, token, split, tokens)] =
+                    __float2bfloat16(0.0f);
+            }
+        }
+    };
+
+    if (kv_head < 0 || kv_head >= Geometry::KVHeads || tokens < 1 || tokens > TokenTile ||
+        row_count > Br || split_count <= 0) {
+        return;
+    }
+
+    const std::int32_t first_pos = pos[0];
+    const std::int32_t last_pos  = pos[tokens - 1];
+    if (first_pos < 0 || last_pos < 0 || last_pos >= max_context) {
+        write_neutral();
+        return;
+    }
+
+    const int window = last_pos + 1;
+    const int active_split_count =
+        gqa_small_t_active_splits<Geometry, false>(window, split_count, TokenTile);
+    if (split >= active_split_count) { return; }
+
+    const int kps         = div_up(window, active_split_count);
+    const int split_start = split * kps;
+    const int split_limit = split_start + kps;
+    const int split_end   = (split_limit < window) ? split_limit : window;
+    if (split_start >= split_end) {
+        write_neutral();
+        return;
+    }
+
+    if constexpr (CacheInput::writes_cache) {
+        // The owning split stores each new row. The BF16 side copies verbatim and is
+        // re-read from input below, so no split depends on another split's write.
+        if constexpr (!KInt8 || !VInt8) {
+            for (int chunk = tid; chunk < tokens * (D / 8); chunk += Threads) {
+                const int token = chunk / (D / 8);
+                const int d     = (chunk - token * (D / 8)) * 8;
+                const int p_tok = pos[token];
+                if (p_tok >= split_start && p_tok < split_end && p_tok >= 0 &&
+                    p_tok < max_context) {
+                    const std::int64_t new_off   = gqa_kv_new_index<Geometry>(kv_head, d, token);
+                    const std::int64_t cache_off =
+                        gqa_cache_index(kv_head, d, p_tok, padded_context);
+                    if constexpr (!KInt8) {
+                        store_vec(&cache_k_bf16[cache_off], load_vec<int4>(&input.k[new_off]));
+                    }
+                    if constexpr (!VInt8) {
+                        store_vec(&cache_v_bf16[cache_off], load_vec<int4>(&input.v[new_off]));
+                    }
+                }
+            }
+        }
+        // The INT8-G64 side quantizes its rows; its attention reads the codes back.
+        for (int pair = warp; pair < tokens * Groups; pair += Wc) {
+            const int token    = pair / Groups;
+            const int grp      = pair - token * Groups;
+            const int position = pos[token];
+            if (position < split_start || position >= split_end) { continue; }
+            const int d0 = grp * kGqaKvQuantGroup + lane;
+            const int d1 = d0 + 32;
+            if constexpr (KInt8) {
+                const std::int64_t src0 = gqa_kv_new_index<Geometry>(kv_head, d0, token);
+                const std::int64_t src1 = gqa_kv_new_index<Geometry>(kv_head, d1, token);
+                const float x0          = __bfloat162float(input.k[src0]);
+                const float x1          = __bfloat162float(input.k[src1]);
+                float amax              = fmaxf(fabsf(x0), fabsf(x1));
+                amax                    = warp_max(amax, FullMask);
+                const __half sh  = __float2half_rn(amax > 0.0f ? amax / 127.0f : 0.0f);
+                const float s    = __half2float(sh);
+                const float inv  = s > 0.0f ? 1.0f / s : 0.0f;
+                cache_k_i8[gqa_kv_quant_code_index(kv_head, d0, position, padded_context)] =
+                    gqa_kv_quant_code(x0, inv);
+                cache_k_i8[gqa_kv_quant_code_index(kv_head, d1, position, padded_context)] =
+                    gqa_kv_quant_code(x1, inv);
+                if (lane == 0) {
+                    cache_k_scale[gqa_kv_quant_scale_index(kv_head, grp, position,
+                                                           padded_context)] = sh;
+                }
+            }
+            if constexpr (VInt8) {
+                const std::int64_t src0 = gqa_kv_new_index<Geometry>(kv_head, d0, token);
+                const std::int64_t src1 = gqa_kv_new_index<Geometry>(kv_head, d1, token);
+                const float x0          = __bfloat162float(input.v[src0]);
+                const float x1          = __bfloat162float(input.v[src1]);
+                float amax              = fmaxf(fabsf(x0), fabsf(x1));
+                amax                    = warp_max(amax, FullMask);
+                const __half sh  = __float2half_rn(amax > 0.0f ? amax / 127.0f : 0.0f);
+                const float s    = __half2float(sh);
+                const float inv  = s > 0.0f ? 1.0f / s : 0.0f;
+                cache_v_i8[gqa_kv_quant_code_index(kv_head, d0, position, padded_context)] =
+                    gqa_kv_quant_code(x0, inv);
+                cache_v_i8[gqa_kv_quant_code_index(kv_head, d1, position, padded_context)] =
+                    gqa_kv_quant_code(x1, inv);
+                if (lane == 0) {
+                    cache_v_scale[gqa_kv_quant_scale_index(kv_head, grp, position,
+                                                           padded_context)] = sh;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    for (int idx = tid; idx < Br * D; idx += Threads) {
+        const int row = idx / D;
+        const int d   = idx - row * D;
+        int q_head    = 0;
+        int token     = 0;
+        gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+        __nv_bfloat16 value = __float2bfloat16(0.0f);
+        if (row < row_count && gqa_valid_q_head<Geometry>(kv_head, q_head)) {
+            value = q[gqa_q_index<Geometry>(q_head, d, token)];
+        }
+        qkv_s[row * D + gqa_small_t_tc_swz(row, d)] = value;
+    }
+    __syncthreads();
+
+    const int gid = lane >> 2;
+    const int lid = lane & 3;
+
+    const int a_mat    = lane >> 3;
+    const int a_rin    = lane & 7;
+    const int a_rowoff = a_rin + ((a_mat & 1) << 3);
+    const int a_coloff = (a_mat >> 1) << 3;
+    const int b_rin    = lane & 7;
+    const int b_koff   = ((lane >> 3) & 1) << 3;
+
+    const int warp_row0 = warp * 16;
+    __nv_bfloat16* p_sw = &p_s[warp * 16 * Bc];
+
+    unsigned af_q[QKKs][4];
+#pragma unroll
+    for (int k = 0; k < QKKs; ++k) {
+        const int arow = warp_row0 + a_rowoff;
+        const int acol = k * 16 + a_coloff;
+        ldmatrix_x4(af_q[k][0], af_q[k][1], af_q[k][2], af_q[k][3],
+                    smem_addr(&qkv_s[arow * D + gqa_small_t_tc_swz(arow, acol)]));
+    }
+    __syncthreads();
+
+    // Stage one BF16 key tile with the same from_new policy as the BF16 kernel.
+    auto stage_bf16_tile = [&]<bool IsK>(__nv_bfloat16* tile_s, const __nv_bfloat16* cache_side,
+                                         int k0) {
+#pragma unroll 1
+        for (int chunk = tid; chunk < Bc * (D / 8); chunk += Threads) {
+            const int key_l    = chunk / (D / 8);
+            const int d        = (chunk - key_l * (D / 8)) * 8;
+            const int key      = k0 + key_l;
+            __nv_bfloat16* dst = &tile_s[key_l * D + gqa_small_t_tc_swz(key_l, d)];
+            if (key < split_end) {
+                if constexpr (CacheInput::writes_cache) {
+                    const __nv_bfloat16* input_side = IsK ? input.k : input.v;
+                    const int new_token             = key - first_pos;
+                    const bool from_new = new_token >= 0 && new_token < tokens && key >= first_pos;
+                    if (from_new) {
+                        const std::int64_t off =
+                            gqa_kv_new_index<Geometry>(kv_head, d, new_token);
+                        ninfer::ops::cp_async<16>(dst, &input_side[off]);
+                    } else {
+                        const std::int64_t off = gqa_cache_index(kv_head, d, key, padded_context);
+                        ninfer::ops::cp_async<16>(dst, &cache_side[off]);
+                    }
+                } else {
+                    const std::int64_t off = gqa_cache_index(kv_head, d, key, padded_context);
+                    ninfer::ops::cp_async<16>(dst, &cache_side[off]);
+                }
+            } else {
+                store_vec(dst, make_int4(0, 0, 0, 0));
+            }
+        }
+    };
+
+    // Stage one INT8-G64 key tile as raw codes + scales (every key, including the
+    // current tokens, comes from the cache; see the append note above).
+    auto stage_i8_tile = [&](const std::int8_t* cache_side, const __half* scale_side, int k0) {
+        for (int key_l = tid; key_l < Bc; key_l += Threads) {
+            const int key  = k0 + key_l;
+            __half* dst    = &i8_scale_s[key_l * Groups];
+            if (key < split_end) {
+                const std::int64_t off =
+                    gqa_kv_quant_scale_index(kv_head, 0, key, padded_context);
+                ninfer::ops::cp_async<8>(dst, &scale_side[off]);
+            } else {
+                store_vec(dst, make_int2(0, 0));
+            }
+        }
+#pragma unroll 1
+        for (int chunk = tid; chunk < Bc * (D / 16); chunk += Threads) {
+            const int key_l    = chunk / (D / 16);
+            const int d        = (chunk - key_l * (D / 16)) * 16;
+            const int key      = k0 + key_l;
+            std::int8_t* dst   = &i8_codes_s[key_l * D + d];
+            if (key < split_end) {
+                const std::int64_t off = gqa_kv_quant_code_index(kv_head, d, key, padded_context);
+                ninfer::ops::cp_async<16>(dst, &cache_side[off]);
+            } else {
+                store_vec(dst, make_int4(0, 0, 0, 0));
+            }
+        }
+    };
+
+    // Dequantize the staged INT8-G64 tile into the swizzled BF16 tile the MMAs read.
+    auto dequant_i8_tile = [&](__nv_bfloat16* tile_s) {
+#pragma unroll 1
+        for (int chunk = tid; chunk < Bc * (D / 8); chunk += Threads) {
+            const int key_l = chunk / (D / 8);
+            const int d     = (chunk - key_l * (D / 8)) * 8;
+            const int grp   = d >> 6;
+            const float s   = __half2float(i8_scale_s[key_l * Groups + grp]);
+            store_vec(&tile_s[key_l * D + gqa_small_t_tc_swz(key_l, d)],
+                      gqa_kv_dequant_i8x8_from(&i8_codes_s[key_l * D + d], s));
+        }
+    };
+
+    float acc[PVNt][4];
+#pragma unroll
+    for (int n = 0; n < PVNt; ++n) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) { acc[n][i] = 0.0f; }
+    }
+    float m0 = -CUDART_INF_F, m1 = -CUDART_INF_F, l0 = 0.0f, l1 = 0.0f;
+
+    const int key_blocks = div_up(split_end - split_start, Bc);
+    for (int kb = 0; kb < key_blocks; ++kb) {
+        const int k0 = split_start + kb * Bc;
+        if constexpr (KInt8) {
+            stage_i8_tile(cache_k_i8, cache_k_scale, k0);
+        } else {
+            stage_bf16_tile.template operator()<true>(k_s, cache_k_bf16, k0);
+        }
+        if constexpr (VInt8) {
+            stage_i8_tile(cache_v_i8, cache_v_scale, k0);
+        } else {
+            stage_bf16_tile.template operator()<false>(v_s, cache_v_bf16, k0);
+        }
+        ninfer::ops::cp_commit();
+        ninfer::ops::cp_wait<0>();
+        __syncthreads();
+        if constexpr (KInt8) { dequant_i8_tile(k_s); }
+        if constexpr (VInt8) { dequant_i8_tile(v_s); }
+        __syncthreads();
+
+        float score[QKNt][4];
+#pragma unroll
+        for (int nt = 0; nt < QKNt; ++nt) {
+            score[nt][0] = score[nt][1] = score[nt][2] = score[nt][3] = 0.0f;
+#pragma unroll
+            for (int k = 0; k < QKKs; ++k) {
+                unsigned bf[2];
+                const int brow = nt * 8 + b_rin;
+                const int bcol = k * 16 + b_koff;
+                ldmatrix_x2(bf[0], bf[1],
+                            smem_addr(&k_s[brow * D + gqa_small_t_tc_swz(brow, bcol)]));
+                mma_bf16(score[nt][0], score[nt][1], score[nt][2], score[nt][3], af_q[k][0],
+                         af_q[k][1], af_q[k][2], af_q[k][3], bf[0], bf[1]);
+            }
+        }
+
+        const int row0 = warp_row0 + gid;
+        const int row1 = row0 + 8;
+        int q_head0 = 0, token0 = 0, q_head1 = 0, token1 = 0;
+        gqa_small_t_tc_row_to_qt<Geometry>(row0, tokens, kv_head, q_head0, token0);
+        gqa_small_t_tc_row_to_qt<Geometry>(row1, tokens, kv_head, q_head1, token1);
+        const int qabs0 = (row0 < row_count) ? pos[token0] : -1;
+        const int qabs1 = (row1 < row_count) ? pos[token1] : -1;
+
+        float bm0 = -CUDART_INF_F, bm1 = -CUDART_INF_F;
+#pragma unroll
+        for (int nt = 0; nt < QKNt; ++nt) {
+            const int col0 = nt * 8 + 2 * lid;
+            const int col1 = col0 + 1;
+            const int key0 = k0 + col0;
+            const int key1 = col1 + k0;
+            score[nt][0]   = (row0 < row_count && key0 < split_end && key0 <= qabs0)
+                                 ? score[nt][0] * scale
+                                 : -CUDART_INF_F;
+            score[nt][1]   = (row0 < row_count && key1 < split_end && key1 <= qabs0)
+                                 ? score[nt][1] * scale
+                                 : -CUDART_INF_F;
+            score[nt][2]   = (row1 < row_count && key0 < split_end && key0 <= qabs1)
+                                 ? score[nt][2] * scale
+                                 : -CUDART_INF_F;
+            score[nt][3]   = (row1 < row_count && key1 < split_end && key1 <= qabs1)
+                                 ? score[nt][3] * scale
+                                 : -CUDART_INF_F;
+            bm0            = fmaxf(bm0, fmaxf(score[nt][0], score[nt][1]));
+            bm1            = fmaxf(bm1, fmaxf(score[nt][2], score[nt][3]));
+        }
+        bm0 = warp_max<4>(bm0, FullMask);
+        bm1 = warp_max<4>(bm1, FullMask);
+
+        const float nm0    = fmaxf(m0, bm0);
+        const float nm1    = fmaxf(m1, bm1);
+        const float alpha0 = (m0 == -CUDART_INF_F) ? 0.0f : exp2_approx((m0 - nm0) * Log2E);
+        const float alpha1 = (m1 == -CUDART_INF_F) ? 0.0f : exp2_approx((m1 - nm1) * Log2E);
+
+        float bl0 = 0.0f, bl1 = 0.0f;
+#pragma unroll
+        for (int nt = 0; nt < QKNt; ++nt) {
+            const int col0  = nt * 8 + 2 * lid;
+            const int col1  = col0 + 1;
+            const float p00 = (nm0 > -CUDART_INF_F && score[nt][0] > -CUDART_INF_F)
+                                  ? exp2_approx((score[nt][0] - nm0) * Log2E)
+                                  : 0.0f;
+            const float p01 = (nm0 > -CUDART_INF_F && score[nt][1] > -CUDART_INF_F)
+                                  ? exp2_approx((score[nt][1] - nm0) * Log2E)
+                                  : 0.0f;
+            const float p10 = (nm1 > -CUDART_INF_F && score[nt][2] > -CUDART_INF_F)
+                                  ? exp2_approx((score[nt][2] - nm1) * Log2E)
+                                  : 0.0f;
+            const float p11 = (nm1 > -CUDART_INF_F && score[nt][3] > -CUDART_INF_F)
+                                  ? exp2_approx((score[nt][3] - nm1) * Log2E)
+                                  : 0.0f;
+            bl0 += p00 + p01;
+            bl1 += p10 + p11;
+            p_sw[gid * Bc + gqa_small_t_tc_swz32(gid, col0)]           = __float2bfloat16(p00);
+            p_sw[gid * Bc + gqa_small_t_tc_swz32(gid, col1)]           = __float2bfloat16(p01);
+            p_sw[(gid + 8) * Bc + gqa_small_t_tc_swz32(gid + 8, col0)] = __float2bfloat16(p10);
+            p_sw[(gid + 8) * Bc + gqa_small_t_tc_swz32(gid + 8, col1)] = __float2bfloat16(p11);
+        }
+        bl0 = warp_sum<4>(bl0, FullMask);
+        bl1 = warp_sum<4>(bl1, FullMask);
+
+        l0 = l0 * alpha0 + bl0;
+        l1 = l1 * alpha1 + bl1;
+        m0 = nm0;
+        m1 = nm1;
+#pragma unroll
+        for (int n = 0; n < PVNt; ++n) {
+            acc[n][0] *= alpha0;
+            acc[n][1] *= alpha0;
+            acc[n][2] *= alpha1;
+            acc[n][3] *= alpha1;
+        }
+        __syncwarp();
+
+#pragma unroll
+        for (int n = 0; n < PVNt; ++n) {
+#pragma unroll
+            for (int k = 0; k < PVKs; ++k) {
+                unsigned pf[4];
+                const int pcol = k * 16 + a_coloff;
+                ldmatrix_x4(pf[0], pf[1], pf[2], pf[3],
+                            smem_addr(&p_sw[a_rowoff * Bc + gqa_small_t_tc_swz32(a_rowoff, pcol)]));
+                unsigned vf[2];
+                const int vrow = k * 16 + b_koff + b_rin;
+                const int vcol = n * 8;
+                ldmatrix_x2_t(vf[0], vf[1],
+                              smem_addr(&v_s[vrow * D + gqa_small_t_tc_swz(vrow, vcol)]));
+                mma_bf16(acc[n][0], acc[n][1], acc[n][2], acc[n][3], pf[0], pf[1], pf[2], pf[3],
+                         vf[0], vf[1]);
+            }
+        }
+        __syncthreads();
+    }
+
+    if (lid == 0) {
+        const int row0 = warp_row0 + gid;
+        const int row1 = row0 + 8;
+        if (row0 < row_count) {
+            int q_head = 0;
+            int token  = 0;
+            gqa_small_t_tc_row_to_qt<Geometry>(row0, tokens, kv_head, q_head, token);
+            partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = m0;
+            partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = l0;
+        }
+        if (row1 < row_count) {
+            int q_head = 0;
+            int token  = 0;
+            gqa_small_t_tc_row_to_qt<Geometry>(row1, tokens, kv_head, q_head, token);
+            partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = m1;
+            partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = l1;
+        }
+    }
+
+    // MMA fragments hold each row in four-lane groups. Stage the final split-local
+    // accumulator through shared memory so partial_acc is written as contiguous d-vector stores.
+#pragma unroll
+    for (int n = 0; n < PVNt; ++n) {
+        const int d0   = n * 8 + 2 * lid;
+        const int d1   = d0 + 1;
+        const int row0 = warp_row0 + gid;
+        const int row1 = row0 + 8;
+        if (row0 < row_count) {
+            qkv_s[row0 * D + d0] = __float2bfloat16(acc[n][0]);
+            qkv_s[row0 * D + d1] = __float2bfloat16(acc[n][1]);
+        }
+        if (row1 < row_count) {
+            qkv_s[row1 * D + d0] = __float2bfloat16(acc[n][2]);
+            qkv_s[row1 * D + d1] = __float2bfloat16(acc[n][3]);
+        }
+    }
+    __syncthreads();
+
+    for (int chunk = tid; chunk < row_count * (D / 8); chunk += Threads) {
+        const int row = chunk / (D / 8);
+        const int d   = (chunk - row * (D / 8)) * 8;
+        int q_head    = 0;
+        int token     = 0;
+        gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+        if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
+            const std::int64_t dst =
+                gqa_partial_acc_index<Geometry>(q_head, d, token, split, tokens);
+            store_vec(&partial_acc[dst], load_vec<int4>(&qkv_s[row * D + d]));
+        }
+    }
+}
+
+} // namespace ninfer::ops

--- a/src/ops/kernel/gqa_attention_prefill_mixed.cuh
+++ b/src/ops/kernel/gqa_attention_prefill_mixed.cuh
@@ -1,0 +1,516 @@
+#pragma once
+
+// Mixed-format GQA prompt kernels: one K/V plane is BF16, the other INT8-G64.
+// Built on the BF16 prompt kernel skeleton (gqa_attention_prefill_bf16.cuh): Q, QK,
+// and PV stay on BF16 tensor cores; the INT8-G64 side is staged as codes+scales and
+// dequantized once into the same swizzled BF16 tile the BF16 side fills directly.
+// The fill kernel stores the BF16 side verbatim and quantizes the INT8-G64 side per
+// (token, kv_head, 64-group) warp unit, one warp per side format as registered.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <math_constants.h>
+
+#include "ops/kernel/gqa_attention_kv_quant.cuh"
+#include "ops/kernel/gqa_attention_prefill_common.cuh"
+
+#include <cstdint>
+
+namespace ninfer::ops {
+
+inline constexpr int kGqaPrefillMixedSmemBytes = kGqaPrefillSmemBytes;
+
+// One warp per (token, kv_head, 64-d group): the INT8-G64 side quantizes its group
+// (two dimensions per lane, matching the symmetric INT8 fill exactly); the BF16 side
+// copies its group verbatim (eight 16-byte vectors, one per lane 0..7).
+template <typename Geometry, bool KInt8, bool VInt8>
+__launch_bounds__(256) __global__ void gqa_attention_prefill_fill_mixed_kernel(
+    const __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const std::int32_t* __restrict__ positions, void* __restrict__ cache_k,
+    void* __restrict__ cache_v, __half* __restrict__ scale_k, __half* __restrict__ scale_v,
+    std::int32_t tokens, std::int32_t padded_context) {
+    static_assert(KInt8 != VInt8, "mixed fill serves exactly one INT8-G64 side");
+
+    constexpr int Warps         = 8;
+    constexpr unsigned FullMask = 0xffffffffu;
+    const int warp              = static_cast<int>(threadIdx.x) >> 5;
+    const int lane              = static_cast<int>(threadIdx.x) & 31;
+    const int unit              = static_cast<int>(blockIdx.x) * Warps + warp;
+    const int units             = tokens * Geometry::KVHeads * kGqaKvQuantGroups;
+    if (unit >= units) { return; }
+
+    const int group    = unit % kGqaKvQuantGroups;
+    const int tmp      = unit / kGqaKvQuantGroups;
+    const int kv_head  = tmp % Geometry::KVHeads;
+    const int token    = tmp / Geometry::KVHeads;
+    const int position = positions[0] + token;
+    const int d0       = group * kGqaKvQuantGroup;
+
+    auto quantize_side = [&](const __nv_bfloat16* src, std::int8_t* dst, __half* scale_dst) {
+        const int dd0           = d0 + lane;
+        const int dd1           = dd0 + 32;
+        const std::int64_t src0 = gqa_kv_quant_src_index<Geometry>(kv_head, dd0, token);
+        const std::int64_t src1 = gqa_kv_quant_src_index<Geometry>(kv_head, dd1, token);
+        const float x0          = __bfloat162float(src[src0]);
+        const float x1          = __bfloat162float(src[src1]);
+        float absmax            = fmaxf(fabsf(x0), fabsf(x1));
+        absmax                  = warp_max(absmax, FullMask);
+        const __half sh  = __float2half_rn(absmax > 0.0f ? absmax / 127.0f : 0.0f);
+        const float s    = __half2float(sh);
+        const float inv  = s > 0.0f ? 1.0f / s : 0.0f;
+        dst[gqa_kv_quant_code_index(kv_head, dd0, position, padded_context)] =
+            gqa_kv_quant_code(x0, inv);
+        dst[gqa_kv_quant_code_index(kv_head, dd1, position, padded_context)] =
+            gqa_kv_quant_code(x1, inv);
+        if (lane == 0) {
+            scale_dst[gqa_kv_quant_scale_index(kv_head, group, position, padded_context)] = sh;
+        }
+    };
+
+    auto copy_side = [&](const __nv_bfloat16* src, __nv_bfloat16* dst) {
+        if (lane < kGqaKvQuantGroup / 8) {
+            const int d = d0 + lane * 8;
+            const std::int64_t src_off = gqa_kv_quant_src_index<Geometry>(kv_head, d, token);
+            const std::int64_t dst_off =
+                gqa_kv_quant_code_index(kv_head, d, position, padded_context);
+            store_vec(&dst[dst_off], load_vec<int4>(&src[src_off]));
+        }
+    };
+
+    if constexpr (KInt8) {
+        quantize_side(k, static_cast<std::int8_t*>(cache_k), scale_k);
+    } else {
+        copy_side(k, static_cast<__nv_bfloat16*>(cache_k));
+    }
+    if constexpr (VInt8) {
+        quantize_side(v, static_cast<std::int8_t*>(cache_v), scale_v);
+    } else {
+        copy_side(v, static_cast<__nv_bfloat16*>(cache_v));
+    }
+}
+
+// Load/dequantize one INT8-G64 cache tile directly into the swizzled BF16 MMA tile.
+// Eight lanes in each warp share one scale load; codes remain one coalesced 64-bit
+// load per eight dimensions. This avoids a second shared-memory staging arena.
+__device__ __forceinline__ void gqa_prefill_dequant_i8_cache_tile(
+    __nv_bfloat16* tile_s, const std::int8_t* cache, const __half* cache_scale, int kv_head,
+    int k0, int max_query_abs, int padded_context, int tid) {
+    constexpr int D       = kGqaPrefillHeadDim;
+    constexpr int Bc      = kGqaPrefillBc;
+    constexpr int Threads = kGqaPrefillThreads;
+    constexpr unsigned FullMask = 0xffffffffu;
+    const int lane = tid & 31;
+#pragma unroll 1
+    for (int chunk = tid; chunk < Bc * (D / 8); chunk += Threads) {
+        const int key_l = chunk / (D / 8);
+        const int d     = (chunk - key_l * (D / 8)) * 8;
+        const int key   = k0 + key_l;
+        const int grp   = d >> 6;
+        __nv_bfloat16* dst = &tile_s[key_l * D + gqa_prefill_swz(key_l, d)];
+        if (key <= max_query_abs) {
+            float s = 0.0f;
+            if ((lane & 7) == 0) {
+                const std::int64_t scale_off =
+                    gqa_kv_quant_scale_index(kv_head, grp, key, padded_context);
+                s = __half2float(cache_scale[scale_off]);
+            }
+            s = __shfl_sync(FullMask, s, grp * 8);
+            const std::int64_t code_off =
+                gqa_kv_quant_code_index(kv_head, d, key, padded_context);
+            store_vec(dst, gqa_kv_dequant_i8x8_from(&cache[code_off], s));
+        } else {
+            store_vec(dst, make_int4(0, 0, 0, 0));
+        }
+    }
+}
+
+// FlashAttention-2 forward over a mixed-format cache; identical tiling and MMA
+// schedule to the BF16 prompt kernel, with the INT8-G64 side dequantized in place
+// of a direct BF16 stage.
+template <typename Geometry, bool KInt8, bool VInt8>
+__launch_bounds__(kGqaPrefillThreads, 1) __global__
+    void gqa_attention_prefill_mixed_kernel(const __nv_bfloat16* __restrict__ q,
+                                            void* __restrict__ cache_k, void* __restrict__ cache_v,
+                                            const __half* __restrict__ cache_k_scale,
+                                            const __half* __restrict__ cache_v_scale,
+                                            const std::int32_t* __restrict__ positions, float scale,
+                                            __nv_bfloat16* __restrict__ out, std::int32_t tokens,
+                                            std::int32_t padded_context) {
+    static_assert(KInt8 != VInt8, "mixed kernel serves exactly one INT8-G64 side");
+
+    constexpr int D             = kGqaPrefillHeadDim; // 256
+    constexpr int Br            = kGqaPrefillBr;      // 64 query rows
+    constexpr int Bc            = kGqaPrefillBc;      // 64 key cols
+    constexpr int Threads       = kGqaPrefillThreads; // 128
+    constexpr int QKNt          = Bc / 8;             // 8  QK score n-tiles
+    constexpr int QKKs          = D / 16;             // 16 QK contraction steps over head_dim
+    constexpr int PVNt          = D / 8;              // 32 PV output n-tiles
+    constexpr int PVKs          = Bc / 16;            // 4  PV contraction steps over keys
+    constexpr float Log2E       = 1.4426950408889634074f;
+    constexpr unsigned FullMask = 0xffffffffu;
+
+    static_assert(Threads == 128);
+
+    extern __shared__ __align__(16) __nv_bfloat16 gqa_smem[];
+    __nv_bfloat16* q_s       = gqa_smem;     // [Br, D] swizzled
+    __nv_bfloat16* k_s       = q_s + Br * D; // [Bc, D] swizzled
+    __nv_bfloat16* v_s       = k_s + Bc * D; // [Bc, D] swizzled
+
+    const __nv_bfloat16* cache_k_bf16 = static_cast<const __nv_bfloat16*>(cache_k);
+    const __nv_bfloat16* cache_v_bf16 = static_cast<const __nv_bfloat16*>(cache_v);
+    const std::int8_t* cache_k_i8     = static_cast<const std::int8_t*>(cache_k);
+    const std::int8_t* cache_v_i8     = static_cast<const std::int8_t*>(cache_v);
+
+    const int q_block  = static_cast<int>(blockIdx.x);
+    const int q_head   = static_cast<int>(blockIdx.y);
+    const int tid      = static_cast<int>(threadIdx.x);
+    const int warp     = tid >> 5;
+    const int lane     = tid & 31;
+    const int q0       = q_block * Br;
+    const int kv_head  = q_head / Geometry::GroupSize;
+    const int base_pos = positions[0];
+
+    if (q_head >= Geometry::QHeads || q0 >= tokens) { return; }
+
+    const int gid = lane >> 2;
+    const int lid = lane & 3;
+
+    const int a_mat    = lane >> 3;
+    const int a_rin    = lane & 7;
+    const int a_rowoff = a_rin + ((a_mat & 1) << 3);
+    const int b_rin    = lane & 7;
+    const int b_koff   = ((lane >> 3) & 1) << 3;
+    const int warp_row0 = warp * 16; // this warp owns rows [warp_row0, warp_row0+16)
+
+    // Per-lane precomputed swizzled ldmatrix base addresses (see gqa_prefill_swz_addr).
+    const unsigned q_sbase = smem_addr(q_s);
+    const unsigned k_sbase = smem_addr(k_s);
+    const unsigned v_sbase = smem_addr(v_s);
+    // Q A-fragment: row = warp_row0 + a_rowoff, col = k*16 + a_coloff.
+    const unsigned q_lane_base = q_sbase + static_cast<unsigned>((warp_row0 + a_rowoff) * 512);
+    const unsigned q_as        = static_cast<unsigned>((a_mat >> 1) << 4);
+    const unsigned q_r         = static_cast<unsigned>(a_rin << 4);
+    // K B-fragment via ldmatrix.x4 (2 n-tiles/instr): lanes 16-31 fetch the +8-key
+    // half (extra 4096 bytes), lanes with bit3 set fetch the +8 d-contract half.
+    const unsigned k_lane_base =
+        k_sbase + static_cast<unsigned>(b_rin * 512) + (static_cast<unsigned>(lane >> 4) << 12);
+    const unsigned k_as = static_cast<unsigned>((b_koff >> 3) << 4);
+    const unsigned k_r  = static_cast<unsigned>(b_rin << 4);
+    // V B-fragment via ldmatrix.x4.trans (2 n-tiles/instr): row = k*16 + (bit3)*8 + b_rin,
+    // col = n*8 + (lane>>4)*8.
+    const unsigned v_lane_base = v_sbase + static_cast<unsigned>(((lane >> 3) & 1) * 4096) +
+                                 static_cast<unsigned>(b_rin * 512);
+    const unsigned v_as = static_cast<unsigned>((lane >> 4) << 4);
+    const unsigned v_r  = static_cast<unsigned>(b_rin << 4);
+
+    // Stage Q into smem once via cp.async (overlaps with the K(0) prologue load
+    // below); it stays resident for the whole key loop.
+    {
+        constexpr int VecPerRow      = D / 8;
+        constexpr int QRowStride     = D * Geometry::QHeads; // global stride between tokens
+        const __nv_bfloat16* q_block = q + gqa_prefill_q_index<Geometry>(q_head, 0, q0);
+        if (q0 + Br <= tokens) {
+#pragma unroll
+            for (int chunk = tid; chunk < Br * VecPerRow; chunk += Threads) {
+                const int row    = chunk >> 5;
+                const int d      = (chunk & 31) << 3;
+                __nv_bfloat16* p = &q_s[row * D + gqa_prefill_swz(row, d)];
+                cp_async<16, Cache::cg>(p, &q_block[row * QRowStride + d]);
+            }
+        } else {
+#pragma unroll
+            for (int chunk = tid; chunk < Br * VecPerRow; chunk += Threads) {
+                const int row    = chunk >> 5;
+                const int d      = (chunk & 31) << 3;
+                __nv_bfloat16* p = &q_s[row * D + gqa_prefill_swz(row, d)];
+                if (q0 + row < tokens) {
+                    cp_async<16, Cache::cg>(p, &q_block[row * QRowStride + d]);
+                } else {
+                    store_vec(p, make_int4(0, 0, 0, 0));
+                }
+            }
+        }
+    }
+
+    float acc[PVNt][4];
+#pragma unroll
+    for (int n = 0; n < PVNt; ++n) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) { acc[n][i] = 0.0f; }
+    }
+    float m0 = -CUDART_INF_F, m1 = -CUDART_INF_F, l0 = 0.0f, l1 = 0.0f;
+
+    const int tile_rows     = min(Br, tokens - q0);
+    const int max_query_abs = base_pos + q0 + tile_rows - 1;
+    const int n_block_max   = (max_query_abs / Bc) + 1; // n_block_min == 0
+
+    // Fold softmax_scale into the exp2 (FA-style): scores stay raw, so the
+    // per-element "* scale" multiply drops out of the QK epilogue entirely.
+    const float scale_l2 = scale * Log2E;
+
+    auto issue_k_tile = [&](int k0) {
+        if constexpr (!KInt8) {
+            gqa_prefill_stage_kv(k_s, cache_k_bf16, kv_head, k0, max_query_abs, padded_context,
+                                 tid);
+        }
+    };
+    auto issue_v_tile = [&](int k0) {
+        if constexpr (!VInt8) {
+            gqa_prefill_stage_kv(v_s, cache_v_bf16, kv_head, k0, max_query_abs, padded_context,
+                                 tid);
+        }
+    };
+
+    // Prologue: commit Q, then kick off K(0). The loop's wait<0> below drains both.
+    ninfer::ops::cp_commit();
+    if constexpr (!KInt8) {
+        issue_k_tile(0);
+        ninfer::ops::cp_commit();
+    }
+
+    for (int kb = 0; kb < n_block_max; ++kb) {
+        const int k0 = kb * Bc;
+
+        ninfer::ops::cp_wait<0>(); // K(kb) landed (also publishes q_s / prev PV done)
+        __syncthreads();
+
+        // Overlap the V(kb) load against the K dequant + QK MMA below.
+        if constexpr (!VInt8) {
+            issue_v_tile(k0);
+            ninfer::ops::cp_commit();
+        }
+
+        if constexpr (KInt8) {
+            gqa_prefill_dequant_i8_cache_tile(k_s, cache_k_i8, cache_k_scale, kv_head, k0,
+                                              max_query_abs, padded_context, tid);
+            __syncthreads();
+        }
+
+        // S = Q Kᵀ for this warp's 16 rows over all Bc keys, in registers.
+        // Software-pipelined like cute's gemm: issue the ldmatrix for contraction
+        // step k+1 while the m16n8k16 MMAs for step k run, so the LSU (ldmatrix)
+        // and tensor pipes overlap instead of stalling on each other.
+        float score[QKNt][4];
+#pragma unroll
+        for (int nt = 0; nt < QKNt; ++nt) {
+            score[nt][0] = score[nt][1] = score[nt][2] = score[nt][3] = 0.0f;
+        }
+        // Swizzled ldmatrix addresses via precomputed per-lane bases + immediates.
+        unsigned af[2][4];
+        unsigned bf[2][QKNt][2];
+        {
+            ldmatrix_x4(af[0][0], af[0][1], af[0][2], af[0][3],
+                        gqa_prefill_swz_addr(q_lane_base, 0u, q_as, q_r));
+#pragma unroll
+            for (int nt2 = 0; nt2 < QKNt; nt2 += 2) {
+                ldmatrix_x4(bf[0][nt2][0], bf[0][nt2][1], bf[0][nt2 + 1][0], bf[0][nt2 + 1][1],
+                            gqa_prefill_swz_addr(k_lane_base + static_cast<unsigned>(nt2 * 4096),
+                                                 0u, k_as, k_r));
+            }
+        }
+#pragma unroll
+        for (int k = 0; k < QKKs; ++k) {
+            const int cur = k & 1;
+            const int nxt = cur ^ 1;
+            if (k + 1 < QKKs) {
+                const unsigned ck = static_cast<unsigned>((k + 1) << 5);
+                ldmatrix_x4(af[nxt][0], af[nxt][1], af[nxt][2], af[nxt][3],
+                            gqa_prefill_swz_addr(q_lane_base, ck, q_as, q_r));
+#pragma unroll
+                for (int nt2 = 0; nt2 < QKNt; nt2 += 2) {
+                    ldmatrix_x4(
+                        bf[nxt][nt2][0], bf[nxt][nt2][1], bf[nxt][nt2 + 1][0], bf[nxt][nt2 + 1][1],
+                        gqa_prefill_swz_addr(k_lane_base + static_cast<unsigned>(nt2 * 4096), ck,
+                                             k_as, k_r));
+                }
+            }
+#pragma unroll
+            for (int nt = 0; nt < QKNt; ++nt) {
+                mma_bf16(score[nt][0], score[nt][1], score[nt][2], score[nt][3], af[cur][0],
+                         af[cur][1], af[cur][2], af[cur][3], bf[cur][nt][0], bf[cur][nt][1]);
+            }
+        }
+
+        const int row0             = warp_row0 + gid;
+        const int row1             = warp_row0 + gid + 8;
+        const int qrow0            = q0 + row0;
+        const int qrow1            = q0 + row1;
+        const int qabs0            = (qrow0 < tokens) ? base_pos + qrow0 : -1;
+        const int qabs1            = (qrow1 < tokens) ? base_pos + qrow1 : -1;
+        const bool full_score_tile = (q0 + Br <= tokens) && ((k0 + Bc - 1) <= (base_pos + q0));
+
+        // block row-max on raw (unscaled) scores; scale is folded into exp2 below
+        float bm0 = -CUDART_INF_F, bm1 = -CUDART_INF_F;
+        if (full_score_tile) {
+#pragma unroll
+            for (int nt = 0; nt < QKNt; ++nt) {
+                bm0 = fmaxf(bm0, fmaxf(score[nt][0], score[nt][1]));
+                bm1 = fmaxf(bm1, fmaxf(score[nt][2], score[nt][3]));
+            }
+        } else {
+#pragma unroll
+            for (int nt = 0; nt < QKNt; ++nt) {
+                const int key0 = k0 + nt * 8 + 2 * lid;
+                const int key1 = key0 + 1;
+                score[nt][0]   = (qrow0 < tokens && key0 <= qabs0) ? score[nt][0] : -CUDART_INF_F;
+                score[nt][1]   = (qrow0 < tokens && key1 <= qabs0) ? score[nt][1] : -CUDART_INF_F;
+                score[nt][2]   = (qrow1 < tokens && key0 <= qabs1) ? score[nt][2] : -CUDART_INF_F;
+                score[nt][3]   = (qrow1 < tokens && key1 <= qabs1) ? score[nt][3] : -CUDART_INF_F;
+                bm0            = fmaxf(bm0, fmaxf(score[nt][0], score[nt][1]));
+                bm1            = fmaxf(bm1, fmaxf(score[nt][2], score[nt][3]));
+            }
+        }
+        bm0 = warp_max<4>(bm0, FullMask);
+        bm1 = warp_max<4>(bm1, FullMask);
+
+        const float nm0        = fmaxf(m0, bm0);
+        const float nm1        = fmaxf(m1, bm1);
+        const float nm0_scaled = nm0 * scale_l2;
+        const float nm1_scaled = nm1 * scale_l2;
+        const float alpha0     = exp2_approx(__fmaf_rn(m0, scale_l2, -nm0_scaled));
+        const float alpha1     = exp2_approx(__fmaf_rn(m1, scale_l2, -nm1_scaled));
+
+        // P = exp2(S - m), repacked into the PV A-fragment layout, plus local block row-sum.
+        // The row-sum allreduce is deferred to the epilogue; only row max must be reduced per tile.
+        float bl0 = 0.0f, bl1 = 0.0f;
+        unsigned p_frag[PVKs][4];
+        if (full_score_tile) {
+#pragma unroll
+            for (int nt = 0; nt < QKNt; ++nt) {
+                const float p00 = exp2_approx(__fmaf_rn(score[nt][0], scale_l2, -nm0_scaled));
+                const float p01 = exp2_approx(__fmaf_rn(score[nt][1], scale_l2, -nm0_scaled));
+                const float p10 = exp2_approx(__fmaf_rn(score[nt][2], scale_l2, -nm1_scaled));
+                const float p11 = exp2_approx(__fmaf_rn(score[nt][3], scale_l2, -nm1_scaled));
+                bl0 += p00 + p01;
+                bl1 += p10 + p11;
+                const int pk = nt >> 1;
+                if ((nt & 1) == 0) {
+                    p_frag[pk][0] = pack_bf16x2(p00, p01);
+                    p_frag[pk][1] = pack_bf16x2(p10, p11);
+                } else {
+                    p_frag[pk][2] = pack_bf16x2(p00, p01);
+                    p_frag[pk][3] = pack_bf16x2(p10, p11);
+                }
+            }
+        } else {
+#pragma unroll
+            for (int nt = 0; nt < QKNt; ++nt) {
+                const float p00 = (score[nt][0] > -CUDART_INF_F)
+                                      ? exp2_approx(__fmaf_rn(score[nt][0], scale_l2, -nm0_scaled))
+                                      : 0.0f;
+                const float p01 = (score[nt][1] > -CUDART_INF_F)
+                                      ? exp2_approx(__fmaf_rn(score[nt][1], scale_l2, -nm0_scaled))
+                                      : 0.0f;
+                const float p10 = (score[nt][2] > -CUDART_INF_F)
+                                      ? exp2_approx(__fmaf_rn(score[nt][2], scale_l2, -nm1_scaled))
+                                      : 0.0f;
+                const float p11 = (score[nt][3] > -CUDART_INF_F)
+                                      ? exp2_approx(__fmaf_rn(score[nt][3], scale_l2, -nm1_scaled))
+                                      : 0.0f;
+                bl0 += p00 + p01;
+                bl1 += p10 + p11;
+                const int pk = nt >> 1;
+                if ((nt & 1) == 0) {
+                    p_frag[pk][0] = pack_bf16x2(p00, p01);
+                    p_frag[pk][1] = pack_bf16x2(p10, p11);
+                } else {
+                    p_frag[pk][2] = pack_bf16x2(p00, p01);
+                    p_frag[pk][3] = pack_bf16x2(p10, p11);
+                }
+            }
+        }
+
+        l0 = __fmaf_rn(l0, alpha0, bl0);
+        l1 = __fmaf_rn(l1, alpha1, bl1);
+        m0 = nm0;
+        m1 = nm1;
+#pragma unroll
+        for (int n = 0; n < PVNt; ++n) {
+            acc[n][0] *= alpha0;
+            acc[n][1] *= alpha0;
+            acc[n][2] *= alpha1;
+            acc[n][3] *= alpha1;
+        }
+
+        if constexpr (!VInt8) {
+            ninfer::ops::cp_wait<0>(); // V(kb) landed; QK done reading k_s
+            __syncthreads();
+        } else {
+            // No V cp.async wait supplies the BF16 path's CTA rendezvous. All warps
+            // must finish QK before K(kb+1) is allowed to overwrite k_s.
+            __syncthreads();
+        }
+
+        if constexpr (VInt8) {
+            gqa_prefill_dequant_i8_cache_tile(v_s, cache_v_i8, cache_v_scale, kv_head, k0,
+                                              max_query_abs, padded_context, tid);
+        }
+
+        // Prefetch BF16 K(kb+1), overlapping the PV MMA. An INT8-G64 K side is
+        // loaded directly into the BF16 tile at the start of its next iteration.
+        if constexpr (!KInt8) {
+            if (kb + 1 < n_block_max) {
+                issue_k_tile((kb + 1) * Bc);
+                ninfer::ops::cp_commit();
+            }
+        }
+
+        if constexpr (VInt8) { __syncthreads(); } // publish the dequantized V tile
+
+        // O += P V, contracting over the Bc keys. The (k, n) iteration space is
+        // flattened and software-pipelined: the transposed ldmatrix for the next
+        // V fragment is issued while the current MMA runs.
+        // Each x4.trans load covers 2 output n-tiles (16 dims); pipeline the next
+        // load against the current pair of MMAs.
+        constexpr int PVHalf  = PVNt / 2;      // 16 n-tile pairs
+        constexpr int PVLoads = PVKs * PVHalf; // 64 x4.trans loads
+        // Swizzled V x4.trans addresses via precomputed per-lane base + immediates.
+        unsigned vf[2][4];
+        {
+            ldmatrix_x4_t(vf[0][0], vf[0][1], vf[0][2], vf[0][3],
+                          gqa_prefill_swz_addr(v_lane_base, 0u, v_as, v_r));
+        }
+#pragma unroll
+        for (int li = 0; li < PVLoads; ++li) {
+            const int k   = li / PVHalf;
+            const int n2  = (li % PVHalf) * 2;
+            const int cur = li & 1;
+            const int nxt = cur ^ 1;
+            if (li + 1 < PVLoads) {
+                const int k2       = (li + 1) / PVHalf;
+                const int n2b      = ((li + 1) % PVHalf) * 2;
+                const unsigned ckv = static_cast<unsigned>(n2b << 4);
+                ldmatrix_x4_t(vf[nxt][0], vf[nxt][1], vf[nxt][2], vf[nxt][3],
+                              gqa_prefill_swz_addr(v_lane_base + static_cast<unsigned>(k2 * 8192),
+                                                   ckv, v_as, v_r));
+            }
+            mma_bf16(acc[n2][0], acc[n2][1], acc[n2][2], acc[n2][3], p_frag[k][0], p_frag[k][1],
+                     p_frag[k][2], p_frag[k][3], vf[cur][0], vf[cur][1]);
+            mma_bf16(acc[n2 + 1][0], acc[n2 + 1][1], acc[n2 + 1][2], acc[n2 + 1][3], p_frag[k][0],
+                     p_frag[k][1], p_frag[k][2], p_frag[k][3], vf[cur][2], vf[cur][3]);
+        }
+    }
+
+    l0 = warp_sum<4>(l0, FullMask);
+    l1 = warp_sum<4>(l1, FullMask);
+
+    // Normalize once per row via reciprocal-multiply instead of 128 IEEE divides.
+    const float inv_l0 = (l0 > 0.0f) ? __frcp_rn(l0) : 0.0f;
+    const float inv_l1 = (l1 > 0.0f) ? __frcp_rn(l1) : 0.0f;
+#pragma unroll
+    for (int n = 0; n < PVNt; ++n) {
+        const int d0    = n * 8 + 2 * lid;
+        const int qrow0 = q0 + warp_row0 + gid;
+        const int qrow1 = q0 + warp_row0 + gid + 8;
+        if (qrow0 < tokens) {
+            *reinterpret_cast<unsigned*>(&out[gqa_prefill_q_index<Geometry>(q_head, d0, qrow0)]) =
+                pack_bf16x2(acc[n][0] * inv_l0, acc[n][1] * inv_l0);
+        }
+        if (qrow1 < tokens) {
+            *reinterpret_cast<unsigned*>(&out[gqa_prefill_q_index<Geometry>(q_head, d0, qrow1)]) =
+                pack_bf16x2(acc[n][2] * inv_l1, acc[n][3] * inv_l1);
+        }
+    }
+}
+
+} // namespace ninfer::ops

--- a/src/ops/launcher/gqa_attention_decode.cu
+++ b/src/ops/launcher/gqa_attention_decode.cu
@@ -5,6 +5,7 @@
 #include "ops/kernel/gqa_attention_decode.cuh"
 #include "ops/kernel/gqa_attention_decode_bf16.cuh"
 #include "ops/kernel/gqa_attention_decode_i8.cuh"
+#include "ops/kernel/gqa_attention_decode_mixed.cuh"
 #include "core/device.h" // CUDA_CHECK
 #include "ninfer/ops/gqa_attention.h"
 
@@ -16,7 +17,9 @@ namespace {
 
 // Supplies an upper bound for the device-side active-split policy over one explicit execution
 // envelope. Eager calls normally pass an exact window; graph calls pass their target-private
-// replay interval. The dtype-aware wrapper below adds the measured INT8 specializations.
+// replay interval. The profile-aware wrapper below adds the measured INT8 specializations.
+// The INT8 policy applies only to the symmetric INT8 kernel; mixed-format caches keep the
+// BF16 policy of the kernel skeleton they share.
 template <typename Geometry>
 std::int32_t gqa_small_t_split_upper_bound(std::int32_t window) {
     if (window <= 0) { return Geometry::DecodeSplits; }
@@ -41,19 +44,19 @@ std::int32_t gqa_small_t_split_upper_bound(std::int32_t window) {
 }
 
 template <typename Geometry>
-std::int32_t gqa_small_t_split_count(std::int32_t window, std::int32_t tokens, DType kv_dtype) {
+std::int32_t gqa_small_t_split_count(std::int32_t window, std::int32_t tokens, bool i8_profile) {
     // A 64-key default split just above a 32-key boundary makes the partial
     // kernel execute a nearly empty second tile. These short ranges instead
     // launch one 32-key tile per split; the larger CTAs keep the small grid busy.
-    if (kv_dtype == DType::I8 && tokens == 5 && window > 128 && window <= 512) {
+    if (i8_profile && tokens == 5 && window > 128 && window <= 512) {
         return div_up(window, 32 / Geometry::DecodeSplitScale);
     }
-    if (kv_dtype == DType::I8 && tokens == 6 && window > 128 && window <= 160) {
+    if (i8_profile && tokens == 6 && window > 128 && window <= 160) {
         return div_up(window, 24 / Geometry::DecodeSplitScale);
     }
     // Bc=64 is one CTA/SM on these model shapes. Keep the 8K grid at or below
     // one 170-SM wave after accounting for the geometry's KV-head count.
-    if (kv_dtype == DType::I8 && tokens == 6 && window > 5000 && window <= 8198) {
+    if (i8_profile && tokens == 6 && window > 5000 && window <= 8198) {
         const std::int32_t splits   = div_up(window, 192 / Geometry::DecodeSplitScale);
         constexpr std::int32_t kMin = 4 * Geometry::DecodeSplitScale;
         constexpr std::int32_t kMax = 42 * Geometry::DecodeSplitScale;
@@ -65,12 +68,12 @@ std::int32_t gqa_small_t_split_count(std::int32_t window, std::int32_t tokens, D
 
 template <typename Geometry>
 std::int32_t gqa_small_t_launch_capacity(GqaExecutionEnvelope envelope, std::int32_t tokens,
-                                         DType dtype) {
+                                         bool i8_profile) {
     std::int32_t capacity = 0;
     const auto include    = [&](std::uint32_t window) {
         if (window < envelope.min_visible_keys || window > envelope.max_visible_keys) { return; }
-        const auto splits =
-            gqa_small_t_split_count<Geometry>(static_cast<std::int32_t>(window), tokens, dtype);
+        const auto splits = gqa_small_t_split_count<Geometry>(
+            static_cast<std::int32_t>(window), tokens, i8_profile);
         capacity = capacity > splits ? capacity : splits;
     };
     include(envelope.min_visible_keys);
@@ -98,6 +101,27 @@ void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos
             static_cast<const __nv_bfloat16*>(q.data), input,
             static_cast<const std::int32_t*>(pos.data), static_cast<__nv_bfloat16*>(cache_k.data),
             static_cast<__nv_bfloat16*>(cache_v.data), tokens, padded_context, max_context, scale,
+            static_cast<__nv_bfloat16*>(partial_acc.data), static_cast<float*>(partial_m.data),
+            static_cast<float*>(partial_l.data));
+    CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename Geometry, int TokenTile, int WarpsPerCta, bool KInt8, typename CacheInput>
+void launch_tc_partial_mixed(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
+                             KVCacheLayerView cache, std::int32_t padded_context,
+                             std::int32_t max_context, std::int32_t splits, Tensor& partial_acc,
+                             Tensor& partial_m, Tensor& partial_l, cudaStream_t stream) {
+    constexpr int kBlock = 32 * WarpsPerCta;
+    const int tokens     = q.ne[2];
+    const dim3 grid(Geometry::KVHeads, splits, 1);
+    // Mixed kernel stages through static smem only, like the BF16 kernel.
+    gqa_attention_small_t_tc_partial_mixed_kernel<Geometry, TokenTile, WarpsPerCta, KInt8, !KInt8,
+                                                  CacheInput>
+        <<<grid, kBlock, 0, stream>>>(
+            static_cast<const __nv_bfloat16*>(q.data), input,
+            static_cast<const std::int32_t*>(pos.data), cache.k.data, cache.v.data,
+            static_cast<__half*>(cache.k_scale.data), static_cast<__half*>(cache.v_scale.data),
+            tokens, padded_context, max_context, scale,
             static_cast<__nv_bfloat16*>(partial_acc.data), static_cast<float*>(partial_m.data),
             static_cast<float*>(partial_l.data));
     CUDA_CHECK(cudaGetLastError());
@@ -206,16 +230,27 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
     const auto padded_context        = static_cast<std::int32_t>(cache.padded_context);
     const auto max_context           = static_cast<std::int32_t>(cache.max_context);
     const auto implementation_window = static_cast<std::int32_t>(envelope.max_visible_keys);
-    const auto splits = gqa_small_t_launch_capacity<Geometry>(envelope, q.ne[2], cache.dtype);
+    const bool k_i8                  = cache.k_dtype == DType::I8;
+    const bool v_i8                  = cache.v_dtype == DType::I8;
+    const bool i8_profile            = k_i8 && v_i8;
+    const auto splits = gqa_small_t_launch_capacity<Geometry>(envelope, q.ne[2], i8_profile);
 
-    // BF16 keeps its row-tile warp count; INT8 selects its producer/consumer
-    // geometry inside launch_tc_partial_i8.
+    // BF16 keeps its row-tile warp count (shared by the mixed kernel); symmetric
+    // INT8 selects its producer/consumer geometry inside launch_tc_partial_i8.
 #define NINFER_GQA_SMALL_T_DISPATCH(TOKENS, WARPS)                                                 \
     do {                                                                                           \
-        if (cache.dtype == DType::I8) {                                                            \
+        if (i8_profile) {                                                                          \
             launch_tc_partial_i8<Geometry, (TOKENS)>(q, input, pos, scale, cache, padded_context,  \
                                                      max_context, implementation_window, splits,   \
                                                      partial_acc, partial_m, partial_l, stream);   \
+        } else if (k_i8) {                                                                         \
+            launch_tc_partial_mixed<Geometry, (TOKENS), (WARPS), true>(                            \
+                q, input, pos, scale, cache, padded_context, max_context, splits, partial_acc,     \
+                partial_m, partial_l, stream);                                                     \
+        } else if (v_i8) {                                                                         \
+            launch_tc_partial_mixed<Geometry, (TOKENS), (WARPS), false>(                           \
+                q, input, pos, scale, cache, padded_context, max_context, splits, partial_acc,     \
+                partial_m, partial_l, stream);                                                     \
         } else {                                                                                   \
             launch_tc_partial_bf16<Geometry, (TOKENS), (WARPS)>(                                   \
                 q, input, pos, scale, cache, padded_context, max_context, splits, partial_acc,     \
@@ -250,7 +285,7 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
     constexpr int kReduceBlock = 256;
     constexpr int kDChunk      = 64;
     const dim3 reduce_grid(Geometry::QHeads, div_up(kGqaHeadDim, kDChunk), q.ne[2]);
-    if (cache.dtype == DType::I8) {
+    if (i8_profile) {
         gqa_attention_small_t_reduce_output_kernel<Geometry, kDChunk, true>
             <<<reduce_grid, kReduceBlock, 0, stream>>>(
                 static_cast<const __nv_bfloat16*>(partial_acc.data),

--- a/src/ops/launcher/gqa_attention_prefill.cu
+++ b/src/ops/launcher/gqa_attention_prefill.cu
@@ -5,6 +5,7 @@
 #include "ops/common/math.h"
 #include "ops/kernel/gqa_attention_prefill_bf16.cuh"
 #include "ops/kernel/gqa_attention_prefill_i8.cuh"
+#include "ops/kernel/gqa_attention_prefill_mixed.cuh"
 #include "core/device.h" // CUDA_CHECK
 
 #include <cstdint>
@@ -12,13 +13,37 @@
 namespace ninfer::ops::detail {
 namespace {
 
+template <typename Geometry, bool KInt8>
+void gqa_attention_prompt_attention_launch_mixed(const Tensor& q, const Tensor& positions,
+                                                 float scale, const KVCacheLayerView& cache,
+                                                 Tensor& out, cudaStream_t stream) {
+    static const cudaError_t attr =
+        cudaFuncSetAttribute(gqa_attention_prefill_mixed_kernel<Geometry, KInt8, !KInt8>,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             kGqaPrefillMixedSmemBytes);
+    CUDA_CHECK(attr);
+
+    const auto tokens         = static_cast<std::int32_t>(q.ne[2]);
+    const auto padded_context = static_cast<std::int32_t>(cache.padded_context);
+    const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
+                              static_cast<unsigned>(Geometry::QHeads), 1u);
+    gqa_attention_prefill_mixed_kernel<Geometry, KInt8, !KInt8>
+        <<<attention_grid, kGqaPrefillThreads, kGqaPrefillMixedSmemBytes, stream>>>(
+            static_cast<const __nv_bfloat16*>(q.data), cache.k.data, cache.v.data,
+            static_cast<const __half*>(cache.k_scale.data),
+            static_cast<const __half*>(cache.v_scale.data),
+            static_cast<const std::int32_t*>(positions.data), scale,
+            static_cast<__nv_bfloat16*>(out.data), tokens, padded_context);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 template <typename Geometry>
 void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& positions,
                                                float scale, const KVCacheLayerView& cache,
                                                Tensor& out, cudaStream_t stream) {
     const Tensor& cache_k = cache.k;
     const Tensor& cache_v = cache.v;
-    // Both dtype-specialized kernels exceed the default 48 KiB dynamic-smem ceiling.
+    // All format-specialized kernels exceed the default 48 KiB dynamic-smem ceiling.
     static const cudaError_t attr_bf16 =
         cudaFuncSetAttribute(gqa_attention_prefill_bf16_kernel<Geometry>,
                              cudaFuncAttributeMaxDynamicSharedMemorySize, kGqaPrefillSmemBytes);
@@ -30,7 +55,9 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
 
     const auto tokens         = static_cast<std::int32_t>(q.ne[2]);
     const auto padded_context = static_cast<std::int32_t>(cache.padded_context);
-    if (cache.dtype == DType::I8) {
+    const bool k_i8           = cache.k_dtype == DType::I8;
+    const bool v_i8           = cache.v_dtype == DType::I8;
+    if (k_i8 && v_i8) {
         const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillI8Br)),
                                   static_cast<unsigned>(Geometry::QHeads), 1u);
         const Tensor& cache_k_scale = cache.k_scale;
@@ -44,6 +71,12 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
                 static_cast<const __half*>(cache_v_scale.data),
                 static_cast<const std::int32_t*>(positions.data), scale,
                 static_cast<__nv_bfloat16*>(out.data), tokens, padded_context);
+    } else if (k_i8) {
+        gqa_attention_prompt_attention_launch_mixed<Geometry, true>(q, positions, scale, cache,
+                                                                    out, stream);
+    } else if (v_i8) {
+        gqa_attention_prompt_attention_launch_mixed<Geometry, false>(q, positions, scale, cache,
+                                                                     out, stream);
     } else {
         const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
                                   static_cast<unsigned>(Geometry::QHeads), 1u);
@@ -58,6 +91,26 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
     CUDA_CHECK(cudaGetLastError());
 }
 
+template <typename Geometry, bool KInt8>
+void gqa_kv_append_launch_mixed(const Tensor& k, const Tensor& v, const Tensor& positions,
+                                KVCacheLayerView cache, cudaStream_t stream) {
+    const auto tokens         = static_cast<std::int32_t>(k.ne[2]);
+    const auto padded_context = static_cast<std::int32_t>(cache.padded_context);
+    constexpr int kFillBlock  = 256;
+    constexpr int kFillWarps  = kFillBlock / 32;
+    const std::int64_t fill_units =
+        static_cast<std::int64_t>(tokens) * Geometry::KVHeads * kGqaKvQuantGroups;
+    const int fill_grid =
+        static_cast<int>(div_up(fill_units, static_cast<std::int64_t>(kFillWarps)));
+    gqa_attention_prefill_fill_mixed_kernel<Geometry, KInt8, !KInt8>
+        <<<fill_grid, kFillBlock, 0, stream>>>(
+            static_cast<const __nv_bfloat16*>(k.data), static_cast<const __nv_bfloat16*>(v.data),
+            static_cast<const std::int32_t*>(positions.data), cache.k.data, cache.v.data,
+            static_cast<__half*>(cache.k_scale.data), static_cast<__half*>(cache.v_scale.data),
+            tokens, padded_context);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 template <typename Geometry>
 void gqa_kv_append_launch_for(const Tensor& k, const Tensor& v, const Tensor& positions,
                               KVCacheLayerView cache, cudaStream_t stream) {
@@ -65,7 +118,9 @@ void gqa_kv_append_launch_for(const Tensor& k, const Tensor& v, const Tensor& po
     const auto padded_context = static_cast<std::int32_t>(cache.padded_context);
     Tensor& cache_k           = cache.k;
     Tensor& cache_v           = cache.v;
-    if (cache.dtype == DType::I8) {
+    const bool k_i8           = cache.k_dtype == DType::I8;
+    const bool v_i8           = cache.v_dtype == DType::I8;
+    if (k_i8 && v_i8) {
         Tensor& cache_k_scale    = cache.k_scale;
         Tensor& cache_v_scale    = cache.v_scale;
         constexpr int kFillBlock = 256;
@@ -81,6 +136,10 @@ void gqa_kv_append_launch_for(const Tensor& k, const Tensor& v, const Tensor& po
             static_cast<__half*>(cache_k_scale.data), static_cast<__half*>(cache_v_scale.data),
             tokens, padded_context);
         CUDA_CHECK(cudaGetLastError());
+    } else if (k_i8) {
+        gqa_kv_append_launch_mixed<Geometry, true>(k, v, positions, cache, stream);
+    } else if (v_i8) {
+        gqa_kv_append_launch_mixed<Geometry, false>(k, v, positions, cache, stream);
     } else {
         constexpr int kBlock           = 256;
         constexpr int kFillVecElems    = 8;

--- a/src/ops/wrapper/bidirectional_gqa_attention.cpp
+++ b/src/ops/wrapper/bidirectional_gqa_attention.cpp
@@ -41,7 +41,8 @@ void require_contiguous_nonnull(const Tensor& tensor, const char* op, const char
 }
 
 void validate_context(const KVCacheLayerView& context, const char* op) {
-    if (context.dtype != DType::BF16 || context.quant_group != 0 ||
+    if (context.k_dtype != DType::BF16 || context.v_dtype != DType::BF16 ||
+        context.k_quant_group != 0 || context.v_quant_group != 0 ||
         context.num_kv_heads != kKVHeads || context.head_dim != kHeadDim) {
         throw std::invalid_argument(std::string(op) + ": invalid context geometry or dtype");
     }

--- a/src/ops/wrapper/gqa_attention.cpp
+++ b/src/ops/wrapper/gqa_attention.cpp
@@ -56,46 +56,51 @@ void require_contiguous_nonnull(const Tensor& tensor, const char* op, const char
     }
 }
 
+void validate_cache_side(DType side_dtype, std::int32_t side_quant_group, const Tensor& codes,
+                         const Tensor& scales, std::int32_t padded, std::int32_t kv_heads,
+                         const char* op, const char* name) {
+    if (side_dtype != DType::BF16 && side_dtype != DType::I8) {
+        throw std::invalid_argument(std::string(op) + ": invalid KV cache side dtype");
+    }
+    if (side_dtype == DType::BF16 && side_quant_group != 0) {
+        throw std::invalid_argument(std::string(op) + ": BF16 KV cache must not have quant_group");
+    }
+    if (side_dtype == DType::I8 && side_quant_group != kKvQuantGroup) {
+        throw std::invalid_argument(std::string(op) + ": I8 KV cache must use quant_group 64");
+    }
+    const std::string codes_name = std::string("cache ") + name;
+    if (codes.dtype != side_dtype) {
+        throw std::invalid_argument(std::string(op) + ": invalid KV cache code dtype");
+    }
+    require_shape(codes, kHeadDim, padded, kv_heads, 1, op, codes_name.c_str());
+    require_contiguous_nonnull(codes, op, codes_name.c_str());
+    if (side_dtype == DType::BF16) {
+        if (scales.data != nullptr) {
+            throw std::invalid_argument(std::string(op) + ": BF16 KV cache must not have scales");
+        }
+        return;
+    }
+    constexpr std::int32_t groups = kHeadDim / kKvQuantGroup;
+    const std::string scales_name = codes_name + " scale";
+    if (scales.dtype != DType::FP16) {
+        throw std::invalid_argument(std::string(op) + ": invalid KV cache scale dtype");
+    }
+    require_shape(scales, groups, padded, kv_heads, 1, op, scales_name.c_str());
+    require_contiguous_nonnull(scales, op, scales_name.c_str());
+}
+
 void validate_cache(const KVCacheLayerView& cache, std::int32_t kv_heads, const char* op) {
-    if ((cache.dtype != DType::BF16 && cache.dtype != DType::I8) ||
-        cache.num_kv_heads != kv_heads || cache.head_dim != kHeadDim) {
+    if (cache.num_kv_heads != kv_heads || cache.head_dim != kHeadDim) {
         throw std::invalid_argument(std::string(op) + ": invalid KV cache geometry or dtype");
     }
     if (cache.max_context == 0 || cache.padded_context < cache.max_context) {
         throw std::invalid_argument(std::string(op) + ": invalid KV cache capacity");
     }
-    if (cache.dtype == DType::BF16 && cache.quant_group != 0) {
-        throw std::invalid_argument(std::string(op) + ": BF16 KV cache must not have quant_group");
-    }
-    if (cache.dtype == DType::I8 && cache.quant_group != kKvQuantGroup) {
-        throw std::invalid_argument(std::string(op) + ": I8 KV cache must use quant_group 64");
-    }
-
     const std::int32_t padded = checked_i32(cache.padded_context, op, "padded_context");
-    const DType code_dtype    = cache.dtype == DType::I8 ? DType::I8 : DType::BF16;
-    if (cache.k.dtype != code_dtype || cache.v.dtype != code_dtype) {
-        throw std::invalid_argument(std::string(op) + ": invalid KV cache code dtype");
-    }
-    require_shape(cache.k, kHeadDim, padded, kv_heads, 1, op, "cache k");
-    require_shape(cache.v, kHeadDim, padded, kv_heads, 1, op, "cache v");
-    require_contiguous_nonnull(cache.k, op, "cache k");
-    require_contiguous_nonnull(cache.v, op, "cache v");
-
-    if (cache.dtype == DType::BF16) {
-        if (cache.k_scale.data != nullptr || cache.v_scale.data != nullptr) {
-            throw std::invalid_argument(std::string(op) + ": BF16 KV cache must not have scales");
-        }
-        return;
-    }
-
-    constexpr std::int32_t groups = kHeadDim / kKvQuantGroup;
-    if (cache.k_scale.dtype != DType::FP16 || cache.v_scale.dtype != DType::FP16) {
-        throw std::invalid_argument(std::string(op) + ": invalid KV cache scale dtype");
-    }
-    require_shape(cache.k_scale, groups, padded, kv_heads, 1, op, "cache k scale");
-    require_shape(cache.v_scale, groups, padded, kv_heads, 1, op, "cache v scale");
-    require_contiguous_nonnull(cache.k_scale, op, "cache k scale");
-    require_contiguous_nonnull(cache.v_scale, op, "cache v scale");
+    validate_cache_side(cache.k_dtype, cache.k_quant_group, cache.k, cache.k_scale, padded,
+                        kv_heads, op, "k");
+    validate_cache_side(cache.v_dtype, cache.v_quant_group, cache.v, cache.v_scale, padded,
+                        kv_heads, op, "v");
 }
 
 void validate_envelope(GqaExecutionEnvelope envelope, const KVCacheLayerView& cache,

--- a/src/ops/wrapper/kv_cache_append_prefix.cpp
+++ b/src/ops/wrapper/kv_cache_append_prefix.cpp
@@ -61,7 +61,8 @@ detail::KVCacheAppendPrefixPlan validate_inputs(const Tensor& k, const Tensor& v
 
 void validate_linear_cache(const KVCacheLayerView& cache,
                            KVCacheAppendPrefixExecutionEnvelope envelope) {
-    if (cache.dtype != DType::BF16 || cache.quant_group != 0 || cache.num_kv_heads != kKVHeads ||
+    if (cache.k_dtype != DType::BF16 || cache.v_dtype != DType::BF16 || cache.k_quant_group != 0 ||
+        cache.v_quant_group != 0 || cache.num_kv_heads != kKVHeads ||
         cache.head_dim != kHeadDim || cache.padded_context < cache.max_context ||
         cache.padded_context >
             static_cast<std::uint32_t>(std::numeric_limits<std::int32_t>::max()) ||

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -90,10 +90,6 @@ std::string tool_choice_name(const ToolChoice& choice) {
     return "unknown";
 }
 
-const char* kv_cache_name(ninfer::KvCacheStorage storage) {
-    return storage == ninfer::KvCacheStorage::BFloat16 ? "bf16" : "int8-group64";
-}
-
 const char* proposal_head_name(ninfer::ProposalHead proposal) {
     return proposal == ninfer::ProposalHead::Optimized ? "optimized" : "full";
 }
@@ -297,7 +293,7 @@ std::string format_server_start_json(const std::string& server_instance_id, std:
           {"device", options.device},
           {"max_context", options.max_context},
           {"prefill_chunk", options.prefill_chunk},
-          {"kv_cache", kv_cache_name(options.kv_cache)},
+          {"kv_cache", ninfer::kv_cache_storage_name(options.kv_cache)},
           {"vision", options.enable_vision},
           {"cuda_graph", options.use_cuda_graph},
           {"prefix_reuse", options.allow_prefix_reuse},

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -44,11 +44,22 @@ std::uint64_t parse_u64(const char* text, const char* label) {
     return static_cast<std::uint64_t>(value);
 }
 
+KvCacheFormat parse_kv_format(const std::string& value) {
+    if (value == "bf16") { return KvCacheFormat::BFloat16; }
+    if (value == "int8") { return KvCacheFormat::Int8Group64; }
+    throw std::invalid_argument("invalid kv-dtype: " + value);
+}
+
+// K/V formats are selected independently as "<k>:<v>"; a bare value selects both.
 KvCacheStorage parse_kv_dtype(const char* text) {
     const std::string value(text);
-    if (value == "bf16") { return KvCacheStorage::BFloat16; }
-    if (value == "int8") { return KvCacheStorage::Int8Group64; }
-    throw std::invalid_argument("invalid kv-dtype: " + value);
+    const std::size_t separator = value.find(':');
+    if (separator == std::string::npos) { return kv_cache_uniform(parse_kv_format(value)); }
+    if (separator == 0 || separator + 1 >= value.size()) {
+        throw std::invalid_argument("invalid kv-dtype: " + value);
+    }
+    return KvCacheStorage{parse_kv_format(value.substr(0, separator)),
+                          parse_kv_format(value.substr(separator + 1))};
 }
 
 } // namespace
@@ -58,7 +69,7 @@ std::string serve_usage_text(const char* argv0) {
            " <model.ninfer> [--host H] [--port N] [--api-key KEY] "
            "[--model-id ID] [--max-context N] [--prefill-chunk N] [--device N] "
            "[--max-request-mib N] [--request-log-jsonl FILE] "
-           "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
+           "[--kv-dtype bf16|int8|bf16:int8|int8:bf16] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
            "[--lm-head-draft] [--no-thinking] [--cors] "

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -27,7 +27,7 @@ struct ServeOptions {
     std::uint32_t prefill_chunk   = 1024;
     std::size_t max_request_bytes = kDefaultMaxRequestBytes;
     int device                    = 0;
-    KvCacheStorage kv_cache       = KvCacheStorage::BFloat16;
+    KvCacheStorage kv_cache;
     SpeculativeOptions speculative;
     bool enable_vision      = false;
     bool use_cuda_graph     = true;

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/decoder_state.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/decoder_state.h
@@ -55,8 +55,10 @@ struct DecoderStateSpec {
     std::uint32_t capacity              = 0;
     std::int32_t kv_heads               = 0;
     std::int32_t attention_head_dim     = 0;
-    DType kv_dtype                      = DType::BF16;
-    std::int32_t kv_quant_group         = 0;
+    DType kv_k_dtype                    = DType::BF16;
+    DType kv_v_dtype                    = DType::BF16;
+    std::int32_t kv_k_quant_group       = 0;
+    std::int32_t kv_v_quant_group       = 0;
     bool enable_mtp                     = false;
     GdnStateSpec gdn;
 };

--- a/src/targets/qwen3_6/impl/runtime/dflash_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/dflash_context_impl.h
@@ -11,8 +11,9 @@ DFlashPersistentState::DFlashPersistentState(DeviceSpan backing,
     : local(backing, layout.local), boundary_local(backing, layout.boundary_local),
       full(backing, layout.full), commit_count(layout.commit_count.bind(backing)) {
     if (local.layer_count() != 5 || boundary_local.layer_count() != 5 || full.layer_count() != 1 ||
-        local.dtype != DType::BF16 || boundary_local.dtype != DType::BF16 ||
-        full.dtype != DType::BF16) {
+        local.k_dtype != DType::BF16 || local.v_dtype != DType::BF16 ||
+        boundary_local.k_dtype != DType::BF16 || boundary_local.v_dtype != DType::BF16 ||
+        full.k_dtype != DType::BF16 || full.v_dtype != DType::BF16) {
         throw std::invalid_argument("DFlash persistent cache layout is invalid");
     }
 }
@@ -26,8 +27,8 @@ CyclicKVCacheLayerView DFlashPersistentState::local_layer(std::uint32_t layer) c
         .padded_capacity = view.padded_context,
         .num_kv_heads    = view.num_kv_heads,
         .head_dim        = view.head_dim,
-        .dtype           = view.dtype,
-        .quant_group     = view.quant_group,
+        .dtype           = view.k_dtype,
+        .quant_group     = view.k_quant_group,
     };
 }
 

--- a/src/targets/qwen3_6/impl/runtime/layouts.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts.h
@@ -58,8 +58,10 @@ struct SequencePlanImpl<NINFER_QWEN36_VARIANT> {
     std::uint32_t prefill_chunk            = 0;
     std::uint32_t draft_window             = 0;
     SpeculativeBackend speculative_backend = SpeculativeBackend::None;
-    DType kv_dtype                         = DType::BF16;
-    std::int32_t kv_quant_group            = 0;
+    DType kv_k_dtype                       = DType::BF16;
+    DType kv_v_dtype                       = DType::BF16;
+    std::int32_t kv_k_quant_group          = 0;
+    std::int32_t kv_v_quant_group          = 0;
     ProposalHead proposal_head             = ProposalHead::Full;
     StartupFeatures features;
     bool use_cuda_graph = true;

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -48,8 +48,10 @@ PersistentLayout persistent_layout(const SequencePlanImpl& plan) {
                      .capacity              = plan.capacity,
                      .kv_heads              = TextConfig::kv_heads,
                      .attention_head_dim    = TextConfig::head_dim,
-                     .kv_dtype              = plan.kv_dtype,
-                     .kv_quant_group        = plan.kv_quant_group,
+                     .kv_k_dtype            = plan.kv_k_dtype,
+                     .kv_v_dtype            = plan.kv_v_dtype,
+                     .kv_k_quant_group      = plan.kv_k_quant_group,
+                     .kv_v_quant_group      = plan.kv_v_quant_group,
                      .enable_mtp            = plan.features.mtp(),
                      .gdn =
                          {
@@ -443,8 +445,10 @@ std::unique_ptr<SequencePlanImpl> plan_sequence_impl(DeviceContext& device,
     impl->features            = qwen3_6::startup_features(options);
     impl->use_cuda_graph      = options.use_cuda_graph;
     impl->device              = options.device;
-    impl->kv_dtype       = options.kv_cache == KvCacheStorage::BFloat16 ? DType::BF16 : DType::I8;
-    impl->kv_quant_group = impl->kv_dtype == DType::I8 ? kKvQuantGroup : 0;
+    impl->kv_k_dtype = options.kv_cache.k == KvCacheFormat::BFloat16 ? DType::BF16 : DType::I8;
+    impl->kv_v_dtype = options.kv_cache.v == KvCacheFormat::BFloat16 ? DType::BF16 : DType::I8;
+    impl->kv_k_quant_group = impl->kv_k_dtype == DType::I8 ? kKvQuantGroup : 0;
+    impl->kv_v_quant_group = impl->kv_v_dtype == DType::I8 ? kKvQuantGroup : 0;
     impl->persistent     = persistent_layout(*impl);
     const auto [dflash_workspace, fixed_workspace_bytes] = dflash_workspace_layout(*impl);
     impl->dflash_workspace                               = dflash_workspace;

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -133,8 +133,10 @@ public:
     const std::uint32_t prefill_chunk;
     const std::uint32_t draft_window;
     const SpeculativeBackend speculative_backend;
-    const DType kv_dtype;
-    const std::int32_t kv_quant_group;
+    const DType kv_k_dtype;
+    const DType kv_v_dtype;
+    const std::int32_t kv_k_quant_group;
+    const std::int32_t kv_v_quant_group;
     const ProposalHead proposal_head;
     const bool vision_enabled;
     const bool use_cuda_graph;

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -113,8 +113,9 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
                                  DeviceContext& device_in)
     : model(model_in), device(device_in), capacity(plan.capacity),
       prefill_chunk(plan.prefill_chunk), draft_window(plan.draft_window),
-      speculative_backend(plan.speculative_backend), kv_dtype(plan.kv_dtype),
-      kv_quant_group(plan.kv_quant_group), proposal_head(plan.proposal_head),
+      speculative_backend(plan.speculative_backend), kv_k_dtype(plan.kv_k_dtype),
+      kv_v_dtype(plan.kv_v_dtype), kv_k_quant_group(plan.kv_k_quant_group),
+      kv_v_quant_group(plan.kv_v_quant_group), proposal_head(plan.proposal_head),
       vision_enabled(plan.features.vision), use_cuda_graph(plan.use_cuda_graph),
       kv_payload_bytes(plan.persistent.kv_payload_bytes),
       graph_allowance_bytes(plan.graph_allowance_bytes),
@@ -1089,7 +1090,10 @@ MemorySummary ProgramImplCore::memory_summary() const noexcept {
     MemorySummary out;
     out.device      = device.device;
     out.max_context = capacity;
-    out.kv_cache = kv_dtype == DType::BF16 ? KvCacheStorage::BFloat16 : KvCacheStorage::Int8Group64;
+    out.kv_cache = KvCacheStorage{
+        kv_k_dtype == DType::BF16 ? KvCacheFormat::BFloat16 : KvCacheFormat::Int8Group64,
+        kv_v_dtype == DType::BF16 ? KvCacheFormat::BFloat16 : KvCacheFormat::Int8Group64,
+    };
     DeviceArena& weights = *model.weights_arena;
     out.weights = ArenaMemorySummary{weights.capacity(), weights.used(), weights.peak_used()};
     out.sequence =

--- a/src/targets/qwen3_6/impl/state/decoder_state.cpp
+++ b/src/targets/qwen3_6/impl/state/decoder_state.cpp
@@ -144,12 +144,13 @@ void GdnStateStore::reset_running(cudaStream_t stream) {
 
 DecoderStateLayout plan_decoder_state(LayoutBuilder& builder, const DecoderStateSpec& spec) {
     DecoderStateLayout layout;
-    layout.text_kv =
-        plan_kv_cache(builder, spec.full_attention_layers, spec.capacity, spec.kv_heads,
-                      spec.attention_head_dim, spec.kv_dtype, spec.kv_quant_group);
+    layout.text_kv = plan_kv_cache(builder, spec.full_attention_layers, spec.capacity,
+                                   spec.kv_heads, spec.attention_head_dim, spec.kv_k_dtype,
+                                   spec.kv_v_dtype, spec.kv_k_quant_group, spec.kv_v_quant_group);
     if (spec.enable_mtp) {
         layout.mtp_kv = plan_kv_cache(builder, spec.mtp_layers, spec.capacity, spec.kv_heads,
-                                      spec.attention_head_dim, spec.kv_dtype, spec.kv_quant_group);
+                                      spec.attention_head_dim, spec.kv_k_dtype, spec.kv_v_dtype,
+                                      spec.kv_k_quant_group, spec.kv_v_quant_group);
     }
     layout.gdn = plan_gdn_state(builder, spec.gdn);
     return layout;

--- a/tests/ops/test_bidirectional_gqa_attention.cpp
+++ b/tests/ops/test_bidirectional_gqa_attention.cpp
@@ -110,6 +110,7 @@ void bidirectional_gqa_oracle(const std::vector<float>& q, const std::vector<flo
     }
 }
 
+// DFlash's full companion cache is fixed BF16; mixed target KV never reaches this Op.
 KVCacheLayerView make_context_view(DeviceBuffer& k, DeviceBuffer& v, int max_context,
                                    int padded_context) {
     return {
@@ -121,8 +122,10 @@ KVCacheLayerView make_context_view(DeviceBuffer& k, DeviceBuffer& v, int max_con
         .padded_context = static_cast<std::uint32_t>(padded_context),
         .num_kv_heads   = kKVHeads,
         .head_dim       = kD,
-        .dtype          = DType::BF16,
-        .quant_group    = 0,
+        .k_dtype        = DType::BF16,
+        .v_dtype        = DType::BF16,
+        .k_quant_group  = 0,
+        .v_quant_group  = 0,
     };
 }
 

--- a/tests/ops/test_gqa_attention.cpp
+++ b/tests/ops/test_gqa_attention.cpp
@@ -25,7 +25,7 @@ constexpr std::int32_t kQuantGroups   = kHeadDim / kQuantGroup;
 constexpr float kAttentionScale       = 0.0625f;
 constexpr std::uint16_t kOutputCanary = 0x7fc1u;
 
-// The Op has two registered compute profiles. A1 and A3 use the same criterion for a given
+// The Op has three registered compute profiles. A1 and A3 use the same criterion for a given
 // profile; token count, geometry, execution envelope, and private launch route do not select it.
 constexpr ReductionCriterion kAttentionBf16Criterion{
     /*relative_l2*/ 2.8e-3,
@@ -37,6 +37,14 @@ constexpr ReductionCriterion kAttentionInt8Criterion{
     /*relative_l2*/ 3.15e-3,
     /*gross_absolute*/ 1.1e-3,
     /*gross_relative_to_max_reference*/ 2.2e-3,
+};
+
+// Mixed-format caches (one BF16 side, one INT8-G64 side) keep BF16 tensor-core math and
+// dequantize only the INT8 side. Their prompt route has its own qualified gross-error profile.
+constexpr ReductionCriterion kAttentionMixedCriterion{
+    /*relative_l2*/ 3.15e-3,
+    /*gross_absolute*/ 1.8e-3,
+    /*gross_relative_to_max_reference*/ 2.7e-3,
 };
 
 struct Geometry {
@@ -190,7 +198,8 @@ std::int32_t round_even_to_i32(float value) {
 
 struct HostCache {
     Geometry geometry;
-    DType dtype;
+    DType k_dtype;
+    DType v_dtype;
     std::int32_t max_context;
     std::int32_t padded_context;
     std::vector<std::uint16_t> k_bf16;
@@ -224,25 +233,27 @@ void encode_group(const std::vector<float>& source, std::size_t source_base,
     }
 }
 
-HostCache make_cache(const Geometry& geometry, DType dtype, std::int32_t max_context,
-                     std::uint32_t seed) {
+HostCache make_cache(const Geometry& geometry, DType k_dtype, DType v_dtype,
+                     std::int32_t max_context, std::uint32_t seed) {
     const std::int32_t padded_context = align_up_128(max_context);
     const std::size_t elements        = cache_elements(geometry, padded_context);
     std::vector<float> logical_k      = make_bf16_values(elements, seed, -0.25f, 0.25f);
     std::vector<float> logical_v      = make_bf16_values(elements, seed + 1u, -1.0f, 1.0f);
 
-    HostCache cache{geometry, dtype, max_context, padded_context};
-    if (dtype == DType::BF16) {
-        cache.k_bf16 = to_bf16_bits(logical_k);
-        cache.v_bf16 = to_bf16_bits(logical_v);
-        return cache;
-    }
-
-    cache.k_i8.assign(elements, 0);
-    cache.v_i8.assign(elements, 0);
+    HostCache cache{geometry, k_dtype, v_dtype, max_context, padded_context};
+    if (k_dtype == DType::BF16) { cache.k_bf16 = to_bf16_bits(logical_k); }
+    if (v_dtype == DType::BF16) { cache.v_bf16 = to_bf16_bits(logical_v); }
     const std::size_t scales = scale_elements(geometry, padded_context);
-    cache.k_scale.assign(scales, 0);
-    cache.v_scale.assign(scales, 0);
+    if (k_dtype == DType::I8) {
+        cache.k_i8.assign(elements, 0);
+        cache.k_scale.assign(scales, 0);
+    }
+    if (v_dtype == DType::I8) {
+        cache.v_i8.assign(elements, 0);
+        cache.v_scale.assign(scales, 0);
+    }
+    if (k_dtype == DType::BF16 && v_dtype == DType::BF16) { return cache; }
+
     for (std::int32_t head = 0; head < geometry.kv_heads; ++head) {
         for (std::int32_t position = 0; position < padded_context; ++position) {
             for (std::int32_t group = 0; group < kQuantGroups; ++group) {
@@ -250,8 +261,12 @@ HostCache make_cache(const Geometry& geometry, DType dtype, std::int32_t max_con
                 const std::size_t code = cache_index(geometry, padded_context, head, position, d);
                 const std::size_t scale =
                     scale_index(geometry, padded_context, head, position, group);
-                encode_group(logical_k, code, cache.k_i8, code, cache.k_scale, scale);
-                encode_group(logical_v, code, cache.v_i8, code, cache.v_scale, scale);
+                if (k_dtype == DType::I8) {
+                    encode_group(logical_k, code, cache.k_i8, code, cache.k_scale, scale);
+                }
+                if (v_dtype == DType::I8) {
+                    encode_group(logical_v, code, cache.v_i8, code, cache.v_scale, scale);
+                }
             }
         }
     }
@@ -264,26 +279,41 @@ void append_cache(HostCache& cache, const std::vector<float>& k, const std::vect
     for (std::int32_t token = 0; token < static_cast<std::int32_t>(positions.size()); ++token) {
         const std::int32_t position = positions[static_cast<std::size_t>(token)];
         for (std::int32_t head = 0; head < geometry.kv_heads; ++head) {
-            if (cache.dtype == DType::BF16) {
+            if (cache.k_dtype == DType::BF16) {
                 for (std::int32_t d = 0; d < kHeadDim; ++d) {
                     const std::size_t source = kv_input_index(geometry, head, d, token);
                     const std::size_t target =
                         cache_index(geometry, cache.padded_context, head, position, d);
                     cache.k_bf16[target] = f32_to_bf16(k[source]);
+                }
+            } else {
+                for (std::int32_t group = 0; group < kQuantGroups; ++group) {
+                    const std::int32_t d     = group * kQuantGroup;
+                    const std::size_t source = kv_input_index(geometry, head, d, token);
+                    const std::size_t target =
+                        cache_index(geometry, cache.padded_context, head, position, d);
+                    const std::size_t scale =
+                        scale_index(geometry, cache.padded_context, head, position, group);
+                    encode_group(k, source, cache.k_i8, target, cache.k_scale, scale);
+                }
+            }
+            if (cache.v_dtype == DType::BF16) {
+                for (std::int32_t d = 0; d < kHeadDim; ++d) {
+                    const std::size_t source = kv_input_index(geometry, head, d, token);
+                    const std::size_t target =
+                        cache_index(geometry, cache.padded_context, head, position, d);
                     cache.v_bf16[target] = f32_to_bf16(v[source]);
                 }
-                continue;
-            }
-
-            for (std::int32_t group = 0; group < kQuantGroups; ++group) {
-                const std::int32_t d     = group * kQuantGroup;
-                const std::size_t source = kv_input_index(geometry, head, d, token);
-                const std::size_t target =
-                    cache_index(geometry, cache.padded_context, head, position, d);
-                const std::size_t scale =
-                    scale_index(geometry, cache.padded_context, head, position, group);
-                encode_group(k, source, cache.k_i8, target, cache.k_scale, scale);
-                encode_group(v, source, cache.v_i8, target, cache.v_scale, scale);
+            } else {
+                for (std::int32_t group = 0; group < kQuantGroups; ++group) {
+                    const std::int32_t d     = group * kQuantGroup;
+                    const std::size_t source = kv_input_index(geometry, head, d, token);
+                    const std::size_t target =
+                        cache_index(geometry, cache.padded_context, head, position, d);
+                    const std::size_t scale =
+                        scale_index(geometry, cache.padded_context, head, position, group);
+                    encode_group(v, source, cache.v_i8, target, cache.v_scale, scale);
+                }
             }
         }
     }
@@ -291,8 +321,9 @@ void append_cache(HostCache& cache, const std::vector<float>& k, const std::vect
 
 double cache_value(const HostCache& cache, bool key, std::int32_t head, std::int32_t position,
                    std::int32_t d) {
-    const std::size_t code = cache_index(cache.geometry, cache.padded_context, head, position, d);
-    if (cache.dtype == DType::BF16) {
+    const std::size_t code  = cache_index(cache.geometry, cache.padded_context, head, position, d);
+    const DType side_dtype  = key ? cache.k_dtype : cache.v_dtype;
+    if (side_dtype == DType::BF16) {
         return static_cast<double>(bf16_to_f32(key ? cache.k_bf16[code] : cache.v_bf16[code]));
     }
 
@@ -364,24 +395,28 @@ std::vector<T> copy_from_guarded(const GuardedDeviceBuffer& buffer, std::size_t 
 class DeviceCache {
 public:
     explicit DeviceCache(const HostCache& cache)
-        : geometry_(cache.geometry), dtype_(cache.dtype), max_context_(cache.max_context),
+        : geometry_(cache.geometry), k_dtype_(cache.k_dtype), v_dtype_(cache.v_dtype),
+          max_context_(cache.max_context),
           padded_context_(cache.padded_context),
           code_elements_(cache_elements(geometry_, padded_context_)),
           scale_elements_(scale_elements(geometry_, padded_context_)),
           k_(code_elements_ *
-             (dtype_ == DType::BF16 ? sizeof(std::uint16_t) : sizeof(std::int8_t))),
+             (k_dtype_ == DType::BF16 ? sizeof(std::uint16_t) : sizeof(std::int8_t))),
           v_(code_elements_ *
-             (dtype_ == DType::BF16 ? sizeof(std::uint16_t) : sizeof(std::int8_t))),
-          k_scale_(dtype_ == DType::I8 ? scale_elements_ * sizeof(std::uint16_t) : 1),
-          v_scale_(dtype_ == DType::I8 ? scale_elements_ * sizeof(std::uint16_t) : 1) {
-        if (dtype_ == DType::BF16) {
+             (v_dtype_ == DType::BF16 ? sizeof(std::uint16_t) : sizeof(std::int8_t))),
+          k_scale_(k_dtype_ == DType::I8 ? scale_elements_ * sizeof(std::uint16_t) : 1),
+          v_scale_(v_dtype_ == DType::I8 ? scale_elements_ * sizeof(std::uint16_t) : 1) {
+        if (k_dtype_ == DType::BF16) {
             k_.copy_from_host(cache.k_bf16.data(), cache.k_bf16.size() * sizeof(std::uint16_t));
-            v_.copy_from_host(cache.v_bf16.data(), cache.v_bf16.size() * sizeof(std::uint16_t));
         } else {
             k_.copy_from_host(cache.k_i8.data(), cache.k_i8.size() * sizeof(std::int8_t));
-            v_.copy_from_host(cache.v_i8.data(), cache.v_i8.size() * sizeof(std::int8_t));
             k_scale_.copy_from_host(cache.k_scale.data(),
                                     cache.k_scale.size() * sizeof(std::uint16_t));
+        }
+        if (v_dtype_ == DType::BF16) {
+            v_.copy_from_host(cache.v_bf16.data(), cache.v_bf16.size() * sizeof(std::uint16_t));
+        } else {
+            v_.copy_from_host(cache.v_i8.data(), cache.v_i8.size() * sizeof(std::int8_t));
             v_scale_.copy_from_host(cache.v_scale.data(),
                                     cache.v_scale.size() * sizeof(std::uint16_t));
         }
@@ -389,32 +424,39 @@ public:
 
     KVCacheLayerView view() {
         KVCacheLayerView result;
-        result.k = Tensor(k_.data(), dtype_, {kHeadDim, padded_context_, geometry_.kv_heads});
-        result.v = Tensor(v_.data(), dtype_, {kHeadDim, padded_context_, geometry_.kv_heads});
+        result.k = Tensor(k_.data(), k_dtype_, {kHeadDim, padded_context_, geometry_.kv_heads});
+        result.v = Tensor(v_.data(), v_dtype_, {kHeadDim, padded_context_, geometry_.kv_heads});
         result.max_context    = static_cast<std::uint32_t>(max_context_);
         result.padded_context = static_cast<std::uint32_t>(padded_context_);
         result.num_kv_heads   = geometry_.kv_heads;
         result.head_dim       = kHeadDim;
-        result.dtype          = dtype_;
-        if (dtype_ == DType::I8) {
+        result.k_dtype        = k_dtype_;
+        result.v_dtype        = v_dtype_;
+        if (k_dtype_ == DType::I8) {
             result.k_scale     = Tensor(k_scale_.data(), DType::FP16,
                                         {kQuantGroups, padded_context_, geometry_.kv_heads});
+            result.k_quant_group = kQuantGroup;
+        }
+        if (v_dtype_ == DType::I8) {
             result.v_scale     = Tensor(v_scale_.data(), DType::FP16,
                                         {kQuantGroups, padded_context_, geometry_.kv_heads});
-            result.quant_group = kQuantGroup;
+            result.v_quant_group = kQuantGroup;
         }
         return result;
     }
 
     HostCache snapshot() const {
-        HostCache cache{geometry_, dtype_, max_context_, padded_context_};
-        if (dtype_ == DType::BF16) {
+        HostCache cache{geometry_, k_dtype_, v_dtype_, max_context_, padded_context_};
+        if (k_dtype_ == DType::BF16) {
             cache.k_bf16 = copy_from_guarded<std::uint16_t>(k_, code_elements_);
-            cache.v_bf16 = copy_from_guarded<std::uint16_t>(v_, code_elements_);
         } else {
             cache.k_i8    = copy_from_guarded<std::int8_t>(k_, code_elements_);
-            cache.v_i8    = copy_from_guarded<std::int8_t>(v_, code_elements_);
             cache.k_scale = copy_from_guarded<std::uint16_t>(k_scale_, scale_elements_);
+        }
+        if (v_dtype_ == DType::BF16) {
+            cache.v_bf16 = copy_from_guarded<std::uint16_t>(v_, code_elements_);
+        } else {
+            cache.v_i8    = copy_from_guarded<std::int8_t>(v_, code_elements_);
             cache.v_scale = copy_from_guarded<std::uint16_t>(v_scale_, scale_elements_);
         }
         return cache;
@@ -424,8 +466,10 @@ public:
         int failures = 0;
         failures += k_.verify_guards((label + " cache-k").c_str());
         failures += v_.verify_guards((label + " cache-v").c_str());
-        if (dtype_ == DType::I8) {
+        if (k_dtype_ == DType::I8) {
             failures += k_scale_.verify_guards((label + " cache-k-scale").c_str());
+        }
+        if (v_dtype_ == DType::I8) {
             failures += v_scale_.verify_guards((label + " cache-v-scale").c_str());
         }
         return failures;
@@ -433,7 +477,8 @@ public:
 
 private:
     Geometry geometry_;
-    DType dtype_;
+    DType k_dtype_;
+    DType v_dtype_;
     std::int32_t max_context_;
     std::int32_t padded_context_;
     std::size_t code_elements_;
@@ -446,13 +491,16 @@ private:
 
 int verify_cache(const std::string& label, const HostCache& got, const HostCache& expected) {
     int failures = 0;
-    if (expected.dtype == DType::BF16) {
+    if (expected.k_dtype == DType::BF16) {
         failures += verify_exact((label + " cache-k").c_str(), got.k_bf16, expected.k_bf16);
-        failures += verify_exact((label + " cache-v").c_str(), got.v_bf16, expected.v_bf16);
     } else {
         failures += verify_exact((label + " cache-k-code").c_str(), got.k_i8, expected.k_i8);
-        failures += verify_exact((label + " cache-v-code").c_str(), got.v_i8, expected.v_i8);
         failures += verify_exact((label + " cache-k-scale").c_str(), got.k_scale, expected.k_scale);
+    }
+    if (expected.v_dtype == DType::BF16) {
+        failures += verify_exact((label + " cache-v").c_str(), got.v_bf16, expected.v_bf16);
+    } else {
+        failures += verify_exact((label + " cache-v-code").c_str(), got.v_i8, expected.v_i8);
         failures += verify_exact((label + " cache-v-scale").c_str(), got.v_scale, expected.v_scale);
     }
     return failures;
@@ -474,10 +522,16 @@ int verify_positions(const std::string& label, const GuardedDeviceBuffer& device
     return failures;
 }
 
-const char* cache_name(DType dtype) { return dtype == DType::BF16 ? "bf16" : "int8-g64"; }
+const char* side_name(DType dtype) { return dtype == DType::BF16 ? "bf16" : "int8-g64"; }
 
-ReductionCriterion attention_criterion(DType dtype) {
-    return dtype == DType::BF16 ? kAttentionBf16Criterion : kAttentionInt8Criterion;
+std::string cache_name(DType k_dtype, DType v_dtype) {
+    if (k_dtype == v_dtype) { return side_name(k_dtype); }
+    return std::string("k-") + side_name(k_dtype) + "/v-" + side_name(v_dtype);
+}
+
+ReductionCriterion attention_criterion(DType k_dtype, DType v_dtype) {
+    if (k_dtype != v_dtype) { return kAttentionMixedCriterion; }
+    return k_dtype == DType::BF16 ? kAttentionBf16Criterion : kAttentionInt8Criterion;
 }
 
 int verify_attention(const std::string& label, const std::vector<double>& actual,
@@ -485,16 +539,16 @@ int verify_attention(const std::string& label, const std::vector<double>& actual
     return verify_reduction(label.c_str(), actual, reference, criterion);
 }
 
-std::string case_label(const char* entry, const Geometry& geometry, DType dtype,
+std::string case_label(const char* entry, const Geometry& geometry, DType k_dtype, DType v_dtype,
                        const AttentionCase& test_case) {
-    return std::string(entry) + " " + geometry.name + " " + cache_name(dtype) +
+    return std::string(entry) + " " + geometry.name + " " + cache_name(k_dtype, v_dtype) +
            " T=" + std::to_string(test_case.tokens) +
            " keys=" + std::to_string(test_case.base + test_case.tokens) +
            " envelope_max=" + std::to_string(test_case.envelope_max);
 }
 
 void inject_codec_edges(const Geometry& geometry, std::int32_t tokens, std::vector<float>& k,
-                        std::vector<float>& v) {
+                         std::vector<float>& v) {
     if (tokens == 0) return;
     for (std::int32_t d = 0; d < kQuantGroup; ++d) {
         k[kv_input_index(geometry, 0, d, 0)]               = 0.0f;
@@ -504,7 +558,21 @@ void inject_codec_edges(const Geometry& geometry, std::int32_t tokens, std::vect
     v[kv_input_index(geometry, geometry.kv_heads - 1, 0, tokens - 1)] = 1.0f;
 }
 
-int run_append_case(const Geometry& geometry, DType dtype, std::uint32_t seed) {
+void zero_cached_group(HostCache& cache, bool key, std::int32_t group) {
+    const DType dtype = key ? cache.k_dtype : cache.v_dtype;
+    if (dtype != DType::I8) return;
+    constexpr std::int32_t head     = 0;
+    constexpr std::int32_t position = 0;
+    const std::int32_t d             = group * kQuantGroup;
+    const std::size_t code =
+        cache_index(cache.geometry, cache.padded_context, head, position, d);
+    auto& codes = key ? cache.k_i8 : cache.v_i8;
+    std::fill_n(codes.begin() + static_cast<std::ptrdiff_t>(code), kQuantGroup, 0);
+    auto& scales = key ? cache.k_scale : cache.v_scale;
+    scales[scale_index(cache.geometry, cache.padded_context, head, position, group)] = 0;
+}
+
+int run_append_case(const Geometry& geometry, DType k_dtype, DType v_dtype, std::uint32_t seed) {
     constexpr std::int32_t tokens      = 3;
     constexpr std::int32_t base        = 5;
     constexpr std::int32_t max_context = 16;
@@ -517,7 +585,7 @@ int run_append_case(const Geometry& geometry, DType dtype, std::uint32_t seed) {
     const std::vector<std::uint16_t> v_bits   = to_bf16_bits(v);
     const std::vector<std::int32_t> positions = {base, base + 1, base + 2};
 
-    const HostCache initial = make_cache(geometry, dtype, max_context, seed + 10u);
+    const HostCache initial = make_cache(geometry, k_dtype, v_dtype, max_context, seed + 10u);
     HostCache expected      = initial;
     append_cache(expected, k, v, positions);
     DeviceCache cache(initial);
@@ -536,7 +604,7 @@ int run_append_case(const Geometry& geometry, DType dtype, std::uint32_t seed) {
     cuda_synchronize();
 
     const std::string label =
-        std::string("gqa_kv_append ") + geometry.name + " " + cache_name(dtype);
+        std::string("gqa_kv_append ") + geometry.name + " " + cache_name(k_dtype, v_dtype);
     int failures = verify_cache(label, cache.snapshot(), expected);
     failures += verify_input(label + " k unchanged", dk, k_bits);
     failures += verify_input(label + " v unchanged", dv, v_bits);
@@ -545,7 +613,8 @@ int run_append_case(const Geometry& geometry, DType dtype, std::uint32_t seed) {
     return failures;
 }
 
-int run_a1_case(const Geometry& geometry, DType dtype, const AttentionCase& test_case) {
+int run_a1_case(const Geometry& geometry, DType k_dtype, DType v_dtype,
+                 const AttentionCase& test_case, bool graph_replay = false) {
     const std::int32_t total       = test_case.base + test_case.tokens;
     const std::int32_t max_context = static_cast<std::int32_t>(
         std::max<std::uint32_t>(static_cast<std::uint32_t>(total + 3), test_case.envelope_max));
@@ -564,7 +633,8 @@ int run_a1_case(const Geometry& geometry, DType dtype, const AttentionCase& test
         positions[static_cast<std::size_t>(token)] = test_case.base + token;
     }
 
-    const HostCache initial = make_cache(geometry, dtype, max_context, test_case.seed + 10u);
+    const HostCache initial =
+        make_cache(geometry, k_dtype, v_dtype, max_context, test_case.seed + 10u);
     HostCache expected      = initial;
     append_cache(expected, k, v, positions);
     const std::vector<double> reference = ideal_attention(q, expected, positions);
@@ -597,15 +667,36 @@ int run_a1_case(const Geometry& geometry, DType dtype, const AttentionCase& test
     const ops::GqaExecutionEnvelope envelope{static_cast<std::uint32_t>(total),
                                              test_case.envelope_max};
 
-    ops::gqa_attention(tq, tk, tv, tp, kAttentionScale, cache.view(), envelope, workspace, tout,
-                       nullptr);
-    cuda_synchronize();
+    if (graph_replay) {
+        cudaStream_t stream        = nullptr;
+        cudaGraph_t graph          = nullptr;
+        cudaGraphExec_t executable = nullptr;
+        cuda_check(cudaStreamCreate(&stream), "create mixed GQA graph stream");
+        cuda_check(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
+                   "begin mixed GQA graph capture");
+        ops::gqa_attention(tq, tk, tv, tp, kAttentionScale, cache.view(), envelope, workspace, tout,
+                           stream);
+        cuda_check(cudaStreamEndCapture(stream, &graph), "end mixed GQA graph capture");
+        cuda_check(cudaGraphInstantiate(&executable, graph, nullptr, nullptr, 0),
+                   "instantiate mixed GQA graph");
+        cuda_check(cudaGraphLaunch(executable, stream), "launch mixed GQA graph first replay");
+        cuda_check(cudaGraphLaunch(executable, stream), "launch mixed GQA graph second replay");
+        cuda_synchronize(stream);
+        cudaGraphExecDestroy(executable);
+        cudaGraphDestroy(graph);
+        cudaStreamDestroy(stream);
+    } else {
+        ops::gqa_attention(tq, tk, tv, tp, kAttentionScale, cache.view(), envelope, workspace, tout,
+                           nullptr);
+        cuda_synchronize();
+    }
 
-    const std::string label = case_label("gqa_attention", geometry, dtype, test_case);
+    std::string label = case_label("gqa_attention", geometry, k_dtype, v_dtype, test_case);
+    if (graph_replay) label += " graph-replay";
     const std::vector<std::uint16_t> output_bits =
         copy_from_guarded<std::uint16_t>(dout, q_bits.size());
     int failures = verify_attention(label, bf16_bits_to_double(output_bits), reference,
-                                    attention_criterion(dtype));
+                                    attention_criterion(k_dtype, v_dtype));
     failures += verify_cache(label, cache.snapshot(), expected);
     failures += verify_input(label + " q unchanged", dq, q_bits);
     failures += verify_input(label + " k unchanged", dk, k_bits);
@@ -617,7 +708,8 @@ int run_a1_case(const Geometry& geometry, DType dtype, const AttentionCase& test
     return failures;
 }
 
-int run_a3_case(const Geometry& geometry, DType dtype, const AttentionCase& test_case) {
+int run_a3_case(const Geometry& geometry, DType k_dtype, DType v_dtype,
+                const AttentionCase& test_case) {
     const std::int32_t total       = test_case.base + test_case.tokens;
     const std::int32_t max_context = static_cast<std::int32_t>(
         std::max<std::uint32_t>(static_cast<std::uint32_t>(total + 3), test_case.envelope_max));
@@ -630,7 +722,9 @@ int run_a3_case(const Geometry& geometry, DType dtype, const AttentionCase& test
         positions[static_cast<std::size_t>(token)] = test_case.base + token;
     }
 
-    const HostCache cache_host = make_cache(geometry, dtype, max_context, test_case.seed + 10u);
+    HostCache cache_host = make_cache(geometry, k_dtype, v_dtype, max_context, test_case.seed + 10u);
+    zero_cached_group(cache_host, true, 0);
+    zero_cached_group(cache_host, false, 1);
     const std::vector<double> reference = ideal_attention(q, cache_host, positions);
     DeviceCache cache(cache_host);
 
@@ -657,11 +751,12 @@ int run_a3_case(const Geometry& geometry, DType dtype, const AttentionCase& test
                               nullptr);
     cuda_synchronize();
 
-    const std::string label = case_label("gqa_attention_cached", geometry, dtype, test_case);
+    const std::string label =
+        case_label("gqa_attention_cached", geometry, k_dtype, v_dtype, test_case);
     const std::vector<std::uint16_t> output_bits =
         copy_from_guarded<std::uint16_t>(dout, q_bits.size());
     int failures = verify_attention(label, bf16_bits_to_double(output_bits), reference,
-                                    attention_criterion(dtype));
+                                    attention_criterion(k_dtype, v_dtype));
     failures += verify_cache(label + " cache unchanged", cache.snapshot(), cache_host);
     failures += verify_input(label + " q unchanged", dq, q_bits);
     failures += verify_positions(label + " positions unchanged", dp, positions);
@@ -673,15 +768,24 @@ int run_a3_case(const Geometry& geometry, DType dtype, const AttentionCase& test
 
 int run_geometry(const Geometry& geometry) {
     int failures = 0;
-    for (const DType dtype : {DType::BF16, DType::I8}) {
-        failures += run_append_case(geometry, dtype, 100u + geometry.q_heads);
+    constexpr struct {
+        DType k;
+        DType v;
+    } formats[] = {
+        {DType::BF16, DType::BF16},
+        {DType::I8, DType::I8},
+        {DType::BF16, DType::I8},
+        {DType::I8, DType::BF16},
+    };
+    for (const auto format : formats) {
+        failures += run_append_case(geometry, format.k, format.v, 100u + geometry.q_heads);
 
         const AttentionCase a1_cases[] = {
             {1, 0, 1, 201u},    {6, 17, 23, 202u}, {7, 17, 512, 203u},
             {17, 31, 48, 204u}, {65, 0, 65, 205u},
         };
         for (const AttentionCase& test_case : a1_cases) {
-            failures += run_a1_case(geometry, dtype, test_case);
+            failures += run_a1_case(geometry, format.k, format.v, test_case);
         }
 
         const AttentionCase a3_cases[] = {
@@ -690,16 +794,22 @@ int run_geometry(const Geometry& geometry) {
             {17, 31, 48, 303u},
         };
         for (const AttentionCase& test_case : a3_cases) {
-            failures += run_a3_case(geometry, dtype, test_case);
+            failures += run_a3_case(geometry, format.k, format.v, test_case);
+        }
+
+        if (format.k != format.v) {
+            // Exercise real 1024-key prompt work and replay the captured mixed append/attention.
+            failures +=
+                run_a1_case(geometry, format.k, format.v, {16, 1008, 1024, 350u}, true);
         }
 
         if (geometry.q_heads == 16) {
             // Loose execution envelopes straddle the two registered host-resource frontiers.
             // Device positions, not these bounds, continue to define the oracle result.
-            failures += run_a1_case(geometry, dtype, {7, 17, 513, 401u});
-            failures += run_a3_case(geometry, dtype, {7, 17, 513, 402u});
-            failures += run_a3_case(geometry, dtype, {16, 17, 1024, 403u});
-            failures += run_a3_case(geometry, dtype, {16, 17, 1025, 404u});
+            failures += run_a1_case(geometry, format.k, format.v, {7, 17, 513, 401u});
+            failures += run_a3_case(geometry, format.k, format.v, {7, 17, 513, 402u});
+            failures += run_a3_case(geometry, format.k, format.v, {16, 17, 1024, 403u});
+            failures += run_a3_case(geometry, format.k, format.v, {16, 17, 1025, 404u});
         }
     }
     return failures;

--- a/tests/ops/test_kv_cache_append_prefix.cpp
+++ b/tests/ops/test_kv_cache_append_prefix.cpp
@@ -74,11 +74,14 @@ KVCacheLayerView linear_view(GuardedDeviceBuffer& k, GuardedDeviceBuffer& v) {
         .padded_context = kLinearPadded,
         .num_kv_heads   = kKVHeads,
         .head_dim       = kHeadDim,
-        .dtype          = DType::BF16,
-        .quant_group    = 0,
+        .k_dtype        = DType::BF16,
+        .v_dtype        = DType::BF16,
+        .k_quant_group  = 0,
+        .v_quant_group  = 0,
     };
 }
 
+// DFlash's local cyclic caches are fixed BF16 independently of the target KV format.
 CyclicKVCacheLayerView cyclic_view(GuardedDeviceBuffer& k, GuardedDeviceBuffer& v) {
     return {
         .k               = Tensor(k.data(), DType::BF16, {kHeadDim, kWindow, kKVHeads}),

--- a/tests/ops/test_swa.cpp
+++ b/tests/ops/test_swa.cpp
@@ -114,6 +114,7 @@ void swa_oracle(const std::vector<float>& q, const std::vector<float>& query_k,
     }
 }
 
+// DFlash's local cyclic caches are fixed BF16 independently of the target KV format.
 CyclicKVCacheLayerView make_context_view(DeviceBuffer& k, DeviceBuffer& v) {
     return {
         .k               = Tensor(k.p, DType::BF16, {kD, kWindow, kKVHeads}),

--- a/tests/targets/qwen3_6/test_runtime_mechanisms.cpp
+++ b/tests/targets/qwen3_6/test_runtime_mechanisms.cpp
@@ -39,15 +39,17 @@ void test_topology() {
     }
 }
 
-q36::DecoderStateSpec decoder_spec(ninfer::DType dtype, bool mtp) {
+q36::DecoderStateSpec decoder_spec(ninfer::DType k_dtype, ninfer::DType v_dtype, bool mtp) {
     return q36::DecoderStateSpec{
         .full_attention_layers = 2,
         .mtp_layers            = 1,
         .capacity              = 129,
         .kv_heads              = 2,
         .attention_head_dim    = 64,
-        .kv_dtype              = dtype,
-        .kv_quant_group        = dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
+        .kv_k_dtype            = k_dtype,
+        .kv_v_dtype            = v_dtype,
+        .kv_k_quant_group      = k_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
+        .kv_v_quant_group      = v_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
         .enable_mtp            = mtp,
         .gdn =
             {
@@ -66,7 +68,8 @@ q36::DecoderStateSpec decoder_spec(ninfer::DType dtype, bool mtp) {
 void test_decoder_layout() {
     ninfer::LayoutBuilder bf16_builder;
     const q36::DecoderStateLayout bf16 =
-        q36::plan_decoder_state(bf16_builder, decoder_spec(ninfer::DType::BF16, false));
+        q36::plan_decoder_state(
+            bf16_builder, decoder_spec(ninfer::DType::BF16, ninfer::DType::BF16, false));
     const std::size_t bf16_bytes = bf16_builder.finish(256);
     expect(bf16_bytes != 0, "BF16 decoder layout has storage");
     expect(bf16.text_kv.k.size() == 2 && bf16.text_kv.v.size() == 2, "Text KV layer planes");
@@ -80,7 +83,8 @@ void test_decoder_layout() {
 
     ninfer::LayoutBuilder int8_builder;
     const q36::DecoderStateLayout int8 =
-        q36::plan_decoder_state(int8_builder, decoder_spec(ninfer::DType::I8, true));
+        q36::plan_decoder_state(
+            int8_builder, decoder_spec(ninfer::DType::I8, ninfer::DType::I8, true));
     (void)int8_builder.finish(256);
     expect(int8.text_kv.k_scale.size() == 2 && int8.text_kv.v_scale.size() == 2,
            "INT8 Text KV scale planes");
@@ -89,6 +93,30 @@ void test_decoder_layout() {
            "INT8 MTP KV scale planes");
     expect(int8.kv_payload_bytes() == int8.text_kv.payload_bytes() + int8.mtp_kv->payload_bytes(),
            "INT8 Text/MTP KV payload accounting");
+
+    ninfer::LayoutBuilder mixed_builder;
+    const q36::DecoderStateLayout mixed = q36::plan_decoder_state(
+        mixed_builder, decoder_spec(ninfer::DType::BF16, ninfer::DType::I8, true));
+    (void)mixed_builder.finish(256);
+    expect(mixed.text_kv.k_scale.empty() && mixed.text_kv.v_scale.size() == 2,
+           "mixed Text KV owns only V scales");
+    expect(mixed.mtp_kv && mixed.mtp_kv->k_scale.empty() && mixed.mtp_kv->v_scale.size() == 1,
+           "mixed MTP KV owns only V scales");
+
+    ninfer::LayoutBuilder reverse_mixed_builder;
+    const q36::DecoderStateLayout reverse_mixed = q36::plan_decoder_state(
+        reverse_mixed_builder, decoder_spec(ninfer::DType::I8, ninfer::DType::BF16, true));
+    (void)reverse_mixed_builder.finish(256);
+    expect(reverse_mixed.text_kv.k_dtype == ninfer::DType::I8 &&
+               reverse_mixed.text_kv.v_dtype == ninfer::DType::BF16 &&
+               reverse_mixed.text_kv.k_scale.size() == 2 &&
+               reverse_mixed.text_kv.v_scale.empty(),
+           "reverse mixed Text KV owns only K scales");
+    expect(reverse_mixed.mtp_kv && reverse_mixed.mtp_kv->k_dtype == ninfer::DType::I8 &&
+               reverse_mixed.mtp_kv->v_dtype == ninfer::DType::BF16 &&
+               reverse_mixed.mtp_kv->k_scale.size() == 1 &&
+               reverse_mixed.mtp_kv->v_scale.empty(),
+           "reverse mixed MTP KV owns only K scales");
 }
 
 void test_round_layout() {

--- a/tests/targets/qwen3_6_27b/test_activation_parity.py
+++ b/tests/targets/qwen3_6_27b/test_activation_parity.py
@@ -1,0 +1,62 @@
+"""Activation parity metadata contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from tools.parity.qwen3_6_27b.activations import compare
+
+
+def _write_dump(root: Path, kv_dtype: str) -> None:
+    root.mkdir()
+    tensor = root / "embed.f32"
+    np.array([1.0, -2.0], dtype=np.float32).tofile(tensor)
+    manifest = {
+        "format": "ninfer_activation_dump_v1",
+        "kv_dtype": kv_dtype,
+        "tensors": [
+            {
+                "phase": "prefill",
+                "step": 0,
+                "chunk": 0,
+                "name": "embed",
+                "shape": [2],
+                "file": tensor.name,
+            }
+        ],
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def test_matching_mixed_kv_dtype_is_compared(tmp_path: Path) -> None:
+    reference = tmp_path / "reference"
+    candidate = tmp_path / "candidate"
+    _write_dump(reference, "int8:bf16")
+    _write_dump(candidate, "int8:bf16")
+
+    report = compare(reference, candidate, kv_dtype="int8:bf16")
+
+    assert [item["status"] for item in report] == ["ok"]
+    assert report[0]["kv_dtype"] == "int8:bf16"
+
+
+def test_cross_format_comparison_is_rejected(tmp_path: Path) -> None:
+    reference = tmp_path / "reference"
+    candidate = tmp_path / "candidate"
+    _write_dump(reference, "bf16")
+    _write_dump(candidate, "bf16:int8")
+
+    report = compare(reference, candidate, kv_dtype="bf16:int8")
+
+    assert report == [
+        {
+            "key": ["metadata", "kv_dtype"],
+            "status": "kv_dtype",
+            "side": "reference",
+            "expected": "bf16:int8",
+            "actual": "bf16",
+        }
+    ]

--- a/tests/targets/qwen3_6_27b/test_convert.py
+++ b/tests/targets/qwen3_6_27b/test_convert.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
+import pytest
 import torch
 
 from tools.artifact.container import (
@@ -16,13 +18,14 @@ from tools.artifact.layouts import decode_direct, dequantize_row_split, encoded_
 from tools.convert.qwen3_6_27b import convert, inventory, recipe
 
 
-OFFICIAL_MODEL = Path(
-    "/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16"
-)
-
-
 def test_official_config_uses_only_nested_mtp_field():
-    config = json.loads((OFFICIAL_MODEL / "config.json").read_text())
+    model = os.environ.get("NINFER_QWEN3_6_27B_MODEL")
+    if not model:
+        pytest.skip("NINFER_QWEN3_6_27B_MODEL is not set")
+    config_path = Path(model) / "config.json"
+    if not config_path.is_file():
+        pytest.skip(f"official model config is unavailable: {config_path}")
+    config = json.loads(config_path.read_text())
 
     assert "mtp_num_hidden_layers" not in config
     summary = convert.validate_config(config)
@@ -125,7 +128,7 @@ def test_synthetic_encode_seam_and_descriptive_report(tmp_path):
     assert report["model_id"] == inventory.MODEL_ID
     assert report["target_key"] == inventory.TARGET_KEY
     assert report["recipe_id"] == convert.RECIPE_ID
-    assert report["source"]["model_path"].endswith("/model")
+    assert Path(report["source"]["model_path"]).name == "model"
     assert report["arguments"]["device"] == "cpu"
     assert report["source_preflight"] == {
         "recipes": 2,

--- a/tests/targets/qwen3_6_27b/test_engine_prefix_real.cpp
+++ b/tests/targets/qwen3_6_27b/test_engine_prefix_real.cpp
@@ -14,6 +14,8 @@ ninfer::EngineOptions engine_options(const char* artifact) {
     options.artifact_path             = artifact;
     options.max_context               = 4096;
     options.prefill_chunk             = 1024;
+    options.kv_cache                  = {ninfer::KvCacheFormat::BFloat16,
+                                         ninfer::KvCacheFormat::Int8Group64};
     options.speculative.backend       = ninfer::SpeculativeBackend::Mtp;
     options.speculative.draft_tokens  = 3;
     options.speculative.proposal_head = ninfer::ProposalHead::Optimized;
@@ -197,6 +199,22 @@ int exercise_prefix(ninfer::Engine& engine) {
     return 0;
 }
 
+int exercise_prefill_chunk_boundary(ninfer::Engine& engine) {
+    std::vector<ninfer::TokenId> prompt(1025, 198);
+    ninfer::RequestOptions options;
+    options.execution.requested_output_tokens = 1;
+    options.execution.sampling.temperature    = 0.0F;
+    options.execution.allow_prefix_reuse      = false;
+    options.stop.include_model_defaults       = false;
+    const ninfer::GenerationResult result =
+        engine.generate(engine.prepare_tokens(std::move(prompt)), options);
+    if (result.prompt.prompt_tokens != 1025 || result.generated_token_ids.size() != 1) {
+        std::cerr << "mixed-KV prefill did not cross the 1024-token chunk boundary\n";
+        return 1;
+    }
+    return 0;
+}
+
 int exercise_vision(ninfer::Engine& engine) {
     const auto image_bytes = gradient_ppm();
     auto image_part        = [](const std::vector<std::uint8_t>& bytes, std::string name) {
@@ -347,7 +365,9 @@ int verify_loaded_product(const ninfer::Engine& engine) {
         return 1;
     }
     const ninfer::MemorySummary memory = engine.memory_summary();
-    if (memory.weights.capacity_bytes == 0 ||
+    if (memory.kv_cache != ninfer::KvCacheStorage{ninfer::KvCacheFormat::BFloat16,
+                                                  ninfer::KvCacheFormat::Int8Group64} ||
+        memory.weights.capacity_bytes == 0 ||
         memory.weights.used_bytes != memory.weights.capacity_bytes) {
         std::cerr << "Engine construction has incomplete materialized backing\n";
         return 1;
@@ -368,6 +388,7 @@ int main() {
     if (const int result = verify_loaded_product(engine); result != 0) { return result; }
     if (const int result = exercise_registered_frontend(engine); result != 0) { return result; }
     if (const int result = exercise_prefix(engine); result != 0) { return result; }
+    if (const int result = exercise_prefill_chunk_boundary(engine); result != 0) { return result; }
     if (const int result = exercise_vision(engine); result != 0) { return result; }
     std::cout << "ok\n";
     return 0;

--- a/tests/targets/qwen3_6_27b/test_official_resources.py
+++ b/tests/targets/qwen3_6_27b/test_official_resources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -12,22 +13,25 @@ from tools.convert.qwen3_6_27b import convert as convert_27b
 from tools.convert.qwen3_6_35b_a3b import convert as convert_35b
 
 
-MODEL_27B = Path(
-    "/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16"
-)
-MODEL_35B = Path(
-    "/home/neroued/models/llm/qwen/Qwen3.6-35B-A3B/base-hf-bf16"
-)
 UNSLOTH_TOKENIZER_SHA256 = (
     "87a7830d63fcf43bf241c3c5242e96e62dd3fdc29224ca26fed8ea333db72de4"
 )
 
 
 @pytest.mark.parametrize(
-    ("loader", "model_dir"),
-    ((convert_27b.load_resources, MODEL_27B), (convert_35b.load_resources, MODEL_35B)),
+    ("loader", "environment"),
+    (
+        (convert_27b.load_resources, "NINFER_QWEN3_6_27B_MODEL"),
+        (convert_35b.load_resources, "NINFER_QWEN3_6_35B_A3B_MODEL"),
+    ),
 )
-def test_both_official_sources_pass_the_shared_preflight(loader, model_dir):
+def test_both_official_sources_pass_the_shared_preflight(loader, environment):
+    value = os.environ.get(environment)
+    if not value:
+        pytest.skip(f"{environment} is not set")
+    model_dir = Path(value)
+    if not model_dir.is_dir():
+        pytest.skip(f"official model directory is unavailable: {model_dir}")
     resources = loader(model_dir)
 
     assert tuple(resource.name for resource in resources) == tuple(

--- a/tests/targets/qwen3_6_27b/test_reference_frontend.py
+++ b/tests/targets/qwen3_6_27b/test_reference_frontend.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from tools.reference.qwen3_6.common.frontend import Frontend
 
 
-MODEL = Path("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16")
 CONFIG_ONLY_TOKENS = {
     "<|audio_start|>": 248070,
     "<|audio_end|>": 248071,
@@ -19,14 +21,15 @@ CONFIG_ONLY_TOKENS = {
 
 
 class _OfficialSourceBinding:
-    frontend = SimpleNamespace(
-        tokenizer_json=MODEL / "tokenizer.json",
-        tokenizer_config_json=MODEL / "tokenizer_config.json",
-        chat_template_jinja=MODEL / "chat_template.jinja",
-        generation_config_json=MODEL / "generation_config.json",
-        preprocessor_config_json=MODEL / "preprocessor_config.json",
-        video_preprocessor_config_json=MODEL / "video_preprocessor_config.json",
-    )
+    def __init__(self, model: Path):
+        self.frontend = SimpleNamespace(
+            tokenizer_json=model / "tokenizer.json",
+            tokenizer_config_json=model / "tokenizer_config.json",
+            chat_template_jinja=model / "chat_template.jinja",
+            generation_config_json=model / "generation_config.json",
+            preprocessor_config_json=model / "preprocessor_config.json",
+            video_preprocessor_config_json=model / "video_preprocessor_config.json",
+        )
 
     @staticmethod
     def resource_bytes(resource: Path) -> bytes:
@@ -34,7 +37,14 @@ class _OfficialSourceBinding:
 
 
 def test_reference_consumes_the_raw_official_resource_pair():
-    frontend = Frontend(_OfficialSourceBinding())
+    pytest.importorskip("transformers")
+    value = os.environ.get("NINFER_QWEN3_6_27B_MODEL")
+    if not value:
+        pytest.skip("NINFER_QWEN3_6_27B_MODEL is not set")
+    model = Path(value)
+    if not (model / "tokenizer.json").is_file():
+        pytest.skip(f"official model resources are unavailable: {model}")
+    frontend = Frontend(_OfficialSourceBinding(model))
 
     assert len(frontend.tokenizer) == 248077
     assert {

--- a/tests/targets/qwen3_6_27b/test_reference_ops.py
+++ b/tests/targets/qwen3_6_27b/test_reference_ops.py
@@ -15,6 +15,7 @@ from tools.reference.qwen3_6_27b.ops import (
     gated_delta_rule,
 )
 from tools.reference.qwen3_6_27b.state import KVCache
+from tools.reference.qwen3_6_27b.weights import estimate_fixed_bytes
 from tools.reference.qwen3_6.common.vision_ops import vision_attention
 
 
@@ -58,6 +59,26 @@ def test_int8_kv_codec_matches_fp16_scale_contract() -> None:
     expected_code[expected_scale == 0] = 0
     assert np.array_equal(scale.numpy().view(np.uint16), expected_scale.view(np.uint16))
     assert np.array_equal(code.numpy(), expected_code.reshape(code.shape))
+
+
+def test_fixed_memory_estimate_accounts_for_each_kv_side() -> None:
+    expected = {
+        "bf16": 20_557_987_840,
+        "bf16:int8": 16_137_191_424,
+        "int8:bf16": 16_137_191_424,
+        "int8": 11_716_395_008,
+    }
+    for kv_dtype, expected_bytes in expected.items():
+        assert (
+            estimate_fixed_bytes(
+                262_144,
+                kv_dtype,
+                text=True,
+                mtp=True,
+                prefill_chunk=1024,
+            )
+            == expected_bytes
+        )
 
 
 def test_t1_gdn_matches_sequential_oracle() -> None:

--- a/tests/targets/qwen3_6_35b_a3b/test_engine_dflash_real.cpp
+++ b/tests/targets/qwen3_6_35b_a3b/test_engine_dflash_real.cpp
@@ -16,7 +16,8 @@ ninfer::EngineOptions ordinary_engine_options(const char* artifact) {
     options.artifact_path  = artifact;
     options.max_context    = 128;
     options.prefill_chunk  = 128;
-    options.kv_cache       = ninfer::KvCacheStorage::BFloat16;
+    options.kv_cache       = {ninfer::KvCacheFormat::BFloat16,
+                              ninfer::KvCacheFormat::Int8Group64};
     options.use_cuda_graph = false;
     options.enable_vision  = false;
     return options;
@@ -99,8 +100,10 @@ int verify_dflash_load(const ninfer::Engine& engine) {
         return 1;
     }
     const ninfer::MemorySummary memory = engine.memory_summary();
-    if (memory.max_context != 4352 || memory.kv_cache != ninfer::KvCacheStorage::BFloat16 ||
-        memory.kv_payload_bytes != 274'726'912ULL ||
+    if (memory.max_context != 4352 ||
+        memory.kv_cache != ninfer::KvCacheStorage{ninfer::KvCacheFormat::BFloat16,
+                                                  ninfer::KvCacheFormat::Int8Group64} ||
+        memory.kv_payload_bytes != 253'140'992ULL ||
         memory.weights.used_bytes != memory.weights.capacity_bytes) {
         std::cerr << "DFlash Engine has an invalid frozen memory layout\n";
         return 1;

--- a/tests/targets/qwen3_6_35b_a3b/test_engine_real.cpp
+++ b/tests/targets/qwen3_6_35b_a3b/test_engine_real.cpp
@@ -15,7 +15,8 @@ ninfer::EngineOptions engine_options(const char* artifact) {
     options.artifact_path             = artifact;
     options.max_context               = 4096;
     options.prefill_chunk             = 1024;
-    options.kv_cache                  = ninfer::KvCacheStorage::Int8Group64;
+    options.kv_cache                  = {ninfer::KvCacheFormat::Int8Group64,
+                                         ninfer::KvCacheFormat::BFloat16};
     options.speculative.backend       = ninfer::SpeculativeBackend::Mtp;
     options.speculative.draft_tokens  = 3;
     options.speculative.proposal_head = ninfer::ProposalHead::Optimized;
@@ -27,6 +28,8 @@ ninfer::EngineOptions engine_options(const char* artifact) {
 ninfer::EngineOptions maximum_engine_options(const char* artifact) {
     ninfer::EngineOptions options     = engine_options(artifact);
     options.max_context               = 262144;
+    options.kv_cache                  =
+        ninfer::kv_cache_uniform(ninfer::KvCacheFormat::Int8Group64);
     options.speculative.backend       = ninfer::SpeculativeBackend::Mtp;
     options.speculative.draft_tokens  = 5;
     options.speculative.proposal_head = ninfer::ProposalHead::Optimized;
@@ -67,7 +70,9 @@ int verify_loaded_product(const ninfer::Engine& engine) {
     }
 
     const ninfer::MemorySummary memory = engine.memory_summary();
-    if (memory.weights.capacity_bytes != 22'360'207'360ULL ||
+    if (memory.kv_cache != ninfer::KvCacheStorage{ninfer::KvCacheFormat::Int8Group64,
+                                                  ninfer::KvCacheFormat::BFloat16} ||
+        memory.weights.capacity_bytes != 22'360'207'360ULL ||
         memory.weights.used_bytes != memory.weights.capacity_bytes ||
         memory.sequence.capacity_bytes == 0 || memory.workspace.capacity_bytes == 0) {
         std::cerr << "35B Engine construction has an invalid memory summary\n";
@@ -168,7 +173,8 @@ int exercise_vision(ninfer::Engine& engine) {
 int exercise_maximum_configuration(const char* artifact) {
     ninfer::Engine engine(maximum_engine_options(artifact));
     const ninfer::MemorySummary memory = engine.memory_summary();
-    if (memory.max_context != 262144 || memory.kv_cache != ninfer::KvCacheStorage::Int8Group64 ||
+    if (memory.max_context != 262144 ||
+        memory.kv_cache != ninfer::kv_cache_uniform(ninfer::KvCacheFormat::Int8Group64) ||
         memory.kv_payload_bytes != 3'045'064'704ULL ||
         memory.sequence.used_bytes != memory.sequence.capacity_bytes ||
         memory.workspace.capacity_bytes < 1024ULL * 1024ULL * 1024ULL) {

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -32,7 +32,7 @@ def test_schema_v8_report_is_flattened_for_matrix_summary(tmp_path) -> None:
                 "config": {
                     "max_context": 4096,
                     "prefill_chunk": 1024,
-                    "kv_cache": "int8-group64",
+                    "kv_cache": "bf16:int8-group64",
                     "mtp_draft_tokens": 5,
                     "proposal_head": "optimized",
                     "decode_path": "cuda-graph",
@@ -93,6 +93,7 @@ def test_schema_v8_report_is_flattened_for_matrix_summary(tmp_path) -> None:
     assert row["host_to_device_bytes"] == 17_400_000_000
     assert row["workspace_capacity_bytes"] == 100_000_000
     assert row["workspace_peak_bytes"] == 1_048_576
+    assert row["kv_cache"] == "bf16:int8-group64"
     assert row["decode_output_tok_s_mean"] == 4.5
     assert row["decode_engine_tok_s_mean"] == 7.5
     assert row["spec_fallback_steps"] == 3

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -15,11 +15,13 @@ struct PlannedCache {
 };
 
 PlannedCache plan_cache(std::uint32_t layers, std::uint32_t max_context, std::int32_t heads,
-                        std::int32_t head_dim, ninfer::DType dtype = ninfer::DType::BF16,
-                        std::int32_t quant_group = 0) {
+                        std::int32_t head_dim, ninfer::DType k_dtype = ninfer::DType::BF16,
+                        ninfer::DType v_dtype = ninfer::DType::BF16) {
     ninfer::LayoutBuilder builder;
-    auto layout =
-        ninfer::plan_kv_cache(builder, layers, max_context, heads, head_dim, dtype, quant_group);
+    auto layout = ninfer::plan_kv_cache(
+        builder, layers, max_context, heads, head_dim, k_dtype, v_dtype,
+        k_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0,
+        v_dtype == ninfer::DType::I8 ? ninfer::kKvQuantGroup : 0);
     return PlannedCache{std::move(layout), builder.finish(256)};
 }
 
@@ -51,12 +53,35 @@ int check_shape(const ninfer::Tensor& tensor, const std::int32_t (&expected)[4],
     return failures;
 }
 
+int test_payload_accounting() {
+    constexpr struct {
+        ninfer::DType k;
+        ninfer::DType v;
+        std::size_t expected;
+        const char* label;
+    } cases[] = {
+        {ninfer::DType::BF16, ninfer::DType::BF16, 262'144, "BF16/BF16 payload"},
+        {ninfer::DType::BF16, ninfer::DType::I8, 198'656, "BF16/INT8 payload"},
+        {ninfer::DType::I8, ninfer::DType::BF16, 198'656, "INT8/BF16 payload"},
+        {ninfer::DType::I8, ninfer::DType::I8, 135'168, "INT8/INT8 payload"},
+    };
+    int failures = 0;
+    for (const auto& test_case : cases) {
+        const PlannedCache plan = plan_cache(2, 129, 2, 64, test_case.k, test_case.v);
+        failures += expect_size(plan.layout.padded_context, 256, "payload padded context");
+        failures += expect_size(plan.layout.payload_bytes(), test_case.expected, test_case.label);
+    }
+    return failures;
+}
+
 } // namespace
 
 int main() {
+    int failures = test_payload_accounting();
     int count                   = 0;
     const cudaError_t count_err = cudaGetDeviceCount(&count);
     if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        if (failures != 0) { return fail("kv cache payload accounting failed"); }
         std::cout << "SKIP: no usable CUDA device\n";
         return 0;
     }
@@ -65,7 +90,6 @@ int main() {
         return 1;
     }
 
-    int failures = 0;
     ninfer::DeviceContext ctx(0);
 
     auto bf16_plan = plan_cache(2, 8, 4, 16);
@@ -80,9 +104,10 @@ int main() {
     failures += expect_size(bf16_l0.padded_context, 128, "bf16 padded context");
     failures += expect_size(bf16_l0.num_kv_heads, 4, "bf16 heads");
     failures += expect_size(bf16_l0.head_dim, 16, "bf16 head dim");
-    failures += expect_size(bf16_l0.quant_group, 0, "bf16 quant group");
-    if (bf16_l0.dtype != ninfer::DType::BF16 || bf16_l0.k_scale.data != nullptr ||
-        bf16_l0.v_scale.data != nullptr) {
+    failures += expect_size(bf16_l0.k_quant_group, 0, "bf16 K quant group");
+    failures += expect_size(bf16_l0.v_quant_group, 0, "bf16 V quant group");
+    if (bf16_l0.k_dtype != ninfer::DType::BF16 || bf16_l0.v_dtype != ninfer::DType::BF16 ||
+        bf16_l0.k_scale.data != nullptr || bf16_l0.v_scale.data != nullptr) {
         ++failures;
         std::cerr << "BF16 layer view has invalid dtype or scale planes\n";
     }
@@ -92,7 +117,7 @@ int main() {
         std::cerr << "BF16 physical planes alias\n";
     }
 
-    auto int8_plan = plan_cache(1, 8, 2, 64, ninfer::DType::I8);
+    auto int8_plan = plan_cache(1, 8, 2, 64, ninfer::DType::I8, ninfer::DType::I8);
     ninfer::DeviceArena int8_arena(int8_plan.bytes);
     ninfer::KVCache int8_cache({int8_arena.base(), int8_arena.capacity()}, int8_plan.layout);
     const ninfer::KVCacheLayerView int8 = int8_cache.layer_view(0);
@@ -100,16 +125,69 @@ int main() {
     failures += check_shape(int8.v, {64, 128, 2, 1}, "int8 V");
     failures += check_shape(int8.k_scale, {1, 128, 2, 1}, "int8 K scale");
     failures += check_shape(int8.v_scale, {1, 128, 2, 1}, "int8 V scale");
-    failures += expect_size(int8.quant_group, ninfer::kKvQuantGroup, "int8 quant group");
-    if (int8.dtype != ninfer::DType::I8 || int8.k.dtype != ninfer::DType::I8 ||
-        int8.v.dtype != ninfer::DType::I8 || int8.k_scale.dtype != ninfer::DType::FP16 ||
-        int8.v_scale.dtype != ninfer::DType::FP16) {
+    failures += expect_size(int8.k_quant_group, ninfer::kKvQuantGroup, "int8 K quant group");
+    failures += expect_size(int8.v_quant_group, ninfer::kKvQuantGroup, "int8 V quant group");
+    if (int8.k_dtype != ninfer::DType::I8 || int8.v_dtype != ninfer::DType::I8 ||
+        int8.k.dtype != ninfer::DType::I8 || int8.v.dtype != ninfer::DType::I8 ||
+        int8.k_scale.dtype != ninfer::DType::FP16 || int8.v_scale.dtype != ninfer::DType::FP16) {
         ++failures;
         std::cerr << "INT8 layer view plane dtype mismatch\n";
     }
     if (int8.k.data == int8.v.data || int8.k_scale.data == int8.v_scale.data) {
         ++failures;
         std::cerr << "INT8 physical planes alias\n";
+    }
+
+    // K BF16 with V INT8-G64: only the V side gets codes + scale planes.
+    auto mixed_plan = plan_cache(2, 8, 2, 64, ninfer::DType::BF16, ninfer::DType::I8);
+    ninfer::DeviceArena mixed_arena(mixed_plan.bytes);
+    ninfer::KVCache mixed_cache({mixed_arena.base(), mixed_arena.capacity()}, mixed_plan.layout);
+    const ninfer::KVCacheLayerView mixed = mixed_cache.layer_view(1);
+    failures += check_shape(mixed.k, {64, 128, 2, 1}, "mixed K");
+    failures += check_shape(mixed.v, {64, 128, 2, 1}, "mixed V");
+    failures += check_shape(mixed.v_scale, {1, 128, 2, 1}, "mixed V scale");
+    failures += expect_size(mixed.k_quant_group, 0, "mixed K quant group");
+    failures += expect_size(mixed.v_quant_group, ninfer::kKvQuantGroup, "mixed V quant group");
+    if (mixed.k_dtype != ninfer::DType::BF16 || mixed.v_dtype != ninfer::DType::I8 ||
+        mixed.k.dtype != ninfer::DType::BF16 || mixed.v.dtype != ninfer::DType::I8 ||
+        mixed.k_scale.data != nullptr || mixed.v_scale.dtype != ninfer::DType::FP16) {
+        ++failures;
+        std::cerr << "mixed K-BF16/V-INT8 layer view plane mismatch\n";
+    }
+    if (mixed_plan.layout.k_scale.size() != 0 || mixed_plan.layout.v_scale.size() != 2) {
+        ++failures;
+        std::cerr << "mixed K-BF16/V-INT8 layout scale plane counts wrong\n";
+    }
+    if (mixed.k.data == mixed.v.data) {
+        ++failures;
+        std::cerr << "mixed physical planes alias\n";
+    }
+
+    // K INT8-G64 with V BF16: only the K side gets codes + scale planes.
+    auto reverse_plan = plan_cache(2, 8, 2, 64, ninfer::DType::I8, ninfer::DType::BF16);
+    ninfer::DeviceArena reverse_arena(reverse_plan.bytes);
+    ninfer::KVCache reverse_cache({reverse_arena.base(), reverse_arena.capacity()},
+                                  reverse_plan.layout);
+    const ninfer::KVCacheLayerView reverse = reverse_cache.layer_view(1);
+    failures += check_shape(reverse.k, {64, 128, 2, 1}, "reverse mixed K");
+    failures += check_shape(reverse.v, {64, 128, 2, 1}, "reverse mixed V");
+    failures += check_shape(reverse.k_scale, {1, 128, 2, 1}, "reverse mixed K scale");
+    failures += expect_size(reverse.k_quant_group, ninfer::kKvQuantGroup,
+                            "reverse mixed K quant group");
+    failures += expect_size(reverse.v_quant_group, 0, "reverse mixed V quant group");
+    if (reverse.k_dtype != ninfer::DType::I8 || reverse.v_dtype != ninfer::DType::BF16 ||
+        reverse.k.dtype != ninfer::DType::I8 || reverse.v.dtype != ninfer::DType::BF16 ||
+        reverse.k_scale.dtype != ninfer::DType::FP16 || reverse.v_scale.data != nullptr) {
+        ++failures;
+        std::cerr << "mixed K-INT8/V-BF16 layer view plane mismatch\n";
+    }
+    if (reverse_plan.layout.k_scale.size() != 2 || !reverse_plan.layout.v_scale.empty()) {
+        ++failures;
+        std::cerr << "mixed K-INT8/V-BF16 layout scale plane counts wrong\n";
+    }
+    if (reverse.k.data == reverse.v.data) {
+        ++failures;
+        std::cerr << "reverse mixed physical planes alias\n";
     }
 
     return failures == 0 ? 0 : fail("kv cache test failed");

--- a/tests/test_ninfer_bench_support.cpp
+++ b/tests/test_ninfer_bench_support.cpp
@@ -102,7 +102,9 @@ int test_cli_contract() {
     failures += expect(parsed.repetitions == 3 && parsed.warmup == 2, "repetition settings");
     failures += expect(parsed.max_context == std::optional<std::uint32_t>(4096), "max context");
     failures += expect(parsed.prefill_chunk == 128, "prefill chunk");
-    failures += expect(parsed.kv_cache == ninfer::KvCacheStorage::Int8Group64, "INT8 KV");
+    failures += expect(
+        parsed.kv_cache == ninfer::kv_cache_uniform(ninfer::KvCacheFormat::Int8Group64),
+        "INT8 KV");
     failures += expect(parsed.mtp_draft_tokens == 5, "MTP window");
     failures +=
         expect(parsed.proposal_head == ninfer::ProposalHead::Optimized, "optimized proposal head");
@@ -119,6 +121,20 @@ int test_cli_contract() {
     failures += expect(qb::usage_text("ninfer_bench").find("artifact.ninfer") != std::string::npos,
                        "help names native artifact");
     failures += expect(parse_for_test({"ninfer_bench", "--help"}).help_requested, "help flag");
+
+    const auto mixed = parse_for_test(
+        {"ninfer_bench", "--weights", "model.ninfer", "--kv-dtype", "bf16:int8"});
+    failures += expect(mixed.kv_cache ==
+                            ninfer::KvCacheStorage{ninfer::KvCacheFormat::BFloat16,
+                                                   ninfer::KvCacheFormat::Int8Group64},
+                        "mixed K BF16 / V INT8 KV");
+
+    const auto reverse_mixed = parse_for_test(
+        {"ninfer_bench", "--weights", "model.ninfer", "--kv-dtype", "int8:bf16"});
+    failures += expect(reverse_mixed.kv_cache ==
+                           ninfer::KvCacheStorage{ninfer::KvCacheFormat::Int8Group64,
+                                                  ninfer::KvCacheFormat::BFloat16},
+                       "mixed K INT8 / V BF16 KV");
 
     failures += expect_throws<std::invalid_argument>([] { (void)parse_for_test({"ninfer_bench"}); },
                                                      "missing artifact");
@@ -232,14 +248,16 @@ qb::BenchEnvironment sample_environment() {
                                             .resource_count       = 6};
     env.memory.device                    = 0;
     env.memory.max_context               = 4096;
-    env.memory.kv_cache                  = ninfer::KvCacheStorage::Int8Group64;
+    env.memory.kv_cache                  = {ninfer::KvCacheFormat::BFloat16,
+                                            ninfer::KvCacheFormat::Int8Group64};
     env.memory.weights                   = {17400000000ULL, 17400000000ULL, 17400000000ULL};
     env.memory.sequence                  = {2000000000ULL, 1900000000ULL, 1900000000ULL};
     env.memory.workspace                 = {100000000ULL, 0, 0};
     env.memory.kv_payload_bytes          = 123456ULL;
     env.max_context                      = 4096;
     env.prefill_chunk                    = 1024;
-    env.kv_cache                         = ninfer::KvCacheStorage::Int8Group64;
+    env.kv_cache                         = {ninfer::KvCacheFormat::BFloat16,
+                                            ninfer::KvCacheFormat::Int8Group64};
     env.mtp_draft_tokens                 = 5;
     env.proposal_head                    = ninfer::ProposalHead::Optimized;
     env.use_cuda_graph                   = true;
@@ -270,11 +288,13 @@ int test_report_contract() {
     failures += expect(report.at("load").at("target") == "qwen3_6_27b", "load target");
     failures +=
         expect(report.at("load").at("host_to_device_bytes") == 17400000000ULL, "load H2D bytes");
-    failures += expect(report.at("memory").at("kv_cache") == "int8-group64", "memory KV");
+    failures += expect(report.at("memory").at("kv_cache") == "bf16:int8-group64", "memory KV");
     failures += expect(report.at("memory").at("workspace").at("capacity_bytes") == 100000000ULL,
                        "workspace capacity");
     failures += expect(report.at("memory").at("kv_payload_bytes") == 123456ULL, "KV payload");
     failures += expect(report.at("config").at("proposal_head") == "optimized", "proposal head");
+    failures +=
+        expect(report.at("config").at("kv_cache") == "bf16:int8-group64", "config mixed KV");
     failures += expect(report.at("config").at("decode_graph_prime").at("output_tokens") == 13,
                        "graph prime output count");
 

--- a/tests/test_request_log.cpp
+++ b/tests/test_request_log.cpp
@@ -45,7 +45,8 @@ int main() {
     options.request_log_jsonl         = "requests.jsonl";
     options.max_context               = 262144;
     options.prefill_chunk             = 1024;
-    options.kv_cache                  = ninfer::KvCacheStorage::Int8Group64;
+    options.kv_cache                  = {ninfer::KvCacheFormat::Int8Group64,
+                                         ninfer::KvCacheFormat::BFloat16};
     options.speculative.backend       = ninfer::SpeculativeBackend::Mtp;
     options.speculative.draft_tokens  = 3;
     options.speculative.proposal_head = ninfer::ProposalHead::Optimized;
@@ -65,7 +66,7 @@ int main() {
 
     ninfer::MemorySummary memory;
     memory.max_context              = 262144;
-    memory.kv_cache                 = ninfer::KvCacheStorage::Int8Group64;
+    memory.kv_cache                     = options.kv_cache;
     memory.weights.capacity_bytes   = 100;
     memory.sequence.capacity_bytes  = 200;
     memory.workspace.capacity_bytes = 300;
@@ -94,7 +95,8 @@ int main() {
     failures += check(server.at("engine").at("max_context") == 262144, "max context missing");
     failures += check(server.at("server").at("request_log_jsonl") == "requests.jsonl",
                       "request log path missing");
-    failures += check(server.at("engine").at("kv_cache") == "int8-group64", "KV type missing");
+    failures += check(server.at("engine").at("kv_cache") == "int8-group64:bf16",
+                      "mixed KV type missing");
     failures += check(server.at("engine").at("vision") == false, "Vision state missing");
     failures += check(server.at("engine").at("speculative_backend") == "mtp",
                       "speculative backend missing");

--- a/tests/test_serve_options.cpp
+++ b/tests/test_serve_options.cpp
@@ -64,6 +64,24 @@ int main() {
                       "--no-prefix-reuse did not disable server prefix reuse");
     failures += check(configured.enable_vision, "--vision did not enable Vision");
 
+    const ServeOptions mixed =
+        parse({"ninfer-serve", "model.ninfer", "--kv-dtype", "bf16:int8"});
+    failures += check(mixed.kv_cache ==
+                          ninfer::KvCacheStorage{ninfer::KvCacheFormat::BFloat16,
+                                                 ninfer::KvCacheFormat::Int8Group64},
+                      "--kv-dtype did not preserve independent K/V formats");
+
+    for (const std::string malformed : {"bf16:", ":int8"}) {
+        bool rejected_with_value = false;
+        try {
+            (void)parse({"ninfer-serve", "model.ninfer", "--kv-dtype", malformed});
+        } catch (const std::invalid_argument& error) {
+            rejected_with_value = std::string(error.what()).find(malformed) != std::string::npos;
+        }
+        failures += check(rejected_with_value,
+                          "malformed --kv-dtype did not report the complete value");
+    }
+
     GenerationRequest request;
     request.max_tokens = 1;
     failures += check(to_request_options(request, defaults).execution.allow_prefix_reuse,

--- a/tools/parity/qwen3_6_27b/README.md
+++ b/tools/parity/qwen3_6_27b/README.md
@@ -3,27 +3,34 @@
 These tools compare the independent `.ninfer` Python reference, the C++ target diagnostic, and the
 source BF16 Vision tower at matching semantic boundaries.
 
-Create a C++ activation dump with the target-private tool:
+Create matching Python and C++ activation dumps. Both executions and the comparator must receive
+the same K:V cache format:
 
 ```bash
+KV_DTYPE=bf16:int8
+python3 -m tools.reference.qwen3_6_27b \
+  --weights out/qwen3_6_27b.ninfer \
+  --ids 248045,846,198,5834,248046,198 --decode 2 --greedy \
+  --prefill-chunk 1024 --kv-dtype "$KV_DTYPE" \
+  --activation-dump /tmp/reference-dump
+
 build/tools/ninfer-qwen3_6_27b-dump \
   --weights out/qwen3_6_27b.ninfer \
   --ids 248045,846,198,5834,248046,198 --decode 2 --greedy \
+  --prefill-chunk 1024 --kv-dtype "$KV_DTYPE" \
   --activation-dump /tmp/cpp-dump
-```
 
-Create the corresponding Python reference dump, then compare structured records:
-
-```bash
 python -m tools.parity.qwen3_6_27b.activations \
-  /tmp/reference-dump /tmp/cpp-dump
+  /tmp/reference-dump /tmp/cpp-dump --kv-dtype "$KV_DTYPE"
 ```
 
 The Text comparator is a gate. Its checked-in layer-tap rules require relative RMS/cosine of
 `0.01/0.9999` for embeddings, `0.25/0.94` for every mixer, MLP, and final norm, and `0.35/0.90`
 for logits. Missing or unexpected tensors, a missing requested phase, shape/size mismatch,
 non-finite values, an unregistered tap, or a tolerance failure produces a nonzero exit. Reports
-retain max-absolute, RMS, relative-RMS, and cosine metrics.
+retain max-absolute, RMS, relative-RMS, and cosine metrics. A missing or different `kv_dtype` in
+either manifest is rejected before numerical comparison; cross-format differences are not valid
+cross-runtime parity evidence and are never hidden by a looser tolerance.
 
 Compare quantized artifact Vision activations with the source BF16 tower:
 

--- a/tools/parity/qwen3_6_27b/activations.py
+++ b/tools/parity/qwen3_6_27b/activations.py
@@ -23,6 +23,8 @@ TOLERANCE_RULES: tuple[tuple[str, float, float], ...] = (
     (r"logits", 0.35, 0.90),
 )
 
+KV_DTYPES = ("bf16", "int8", "bf16:int8", "int8:bf16")
+
 
 def load_manifest(root: Path) -> dict:
     path = root / "manifest.json"
@@ -102,10 +104,31 @@ def compare(
     *,
     reference_phase: str = "prefill",
     candidate_phase: str = "prefill",
+    kv_dtype: str = "bf16",
 ) -> list[dict]:
-    ref = load_records(reference, reference_phase)
-    got = load_records(candidate, candidate_phase)
     report: list[dict] = []
+    reference_manifest = load_manifest(reference)
+    candidate_manifest = load_manifest(candidate)
+    for side, manifest in (
+        ("reference", reference_manifest),
+        ("candidate", candidate_manifest),
+    ):
+        actual = manifest.get("kv_dtype")
+        if actual != kv_dtype:
+            report.append(
+                {
+                    "key": ["metadata", "kv_dtype"],
+                    "status": "kv_dtype",
+                    "side": side,
+                    "expected": kv_dtype,
+                    "actual": actual,
+                }
+            )
+    if report:
+        return report
+
+    ref = records(reference_manifest, reference_phase)
+    got = records(candidate_manifest, candidate_phase)
     if not ref:
         report.append(
             {
@@ -193,6 +216,7 @@ def compare(
             {
                 "key": display_key,
                 "status": "ok" if passed else "tolerance",
+                "kv_dtype": kv_dtype,
                 **measured,
                 "tolerance": rule,
             }
@@ -206,6 +230,7 @@ def main() -> None:
     parser.add_argument("candidate")
     parser.add_argument("--reference-phase", choices=["prefill", "decode"], default="prefill")
     parser.add_argument("--candidate-phase", choices=["prefill", "decode"], default="prefill")
+    parser.add_argument("--kv-dtype", choices=KV_DTYPES, default="bf16")
     parser.add_argument("--json")
     args = parser.parse_args()
     report = compare(
@@ -213,6 +238,7 @@ def main() -> None:
         Path(args.candidate),
         reference_phase=args.reference_phase,
         candidate_phase=args.candidate_phase,
+        kv_dtype=args.kv_dtype,
     )
     passed = bool(report) and all(item["status"] == "ok" for item in report)
     for item in report:

--- a/tools/parity/qwen3_6_27b/vision_mtp.py
+++ b/tools/parity/qwen3_6_27b/vision_mtp.py
@@ -36,7 +36,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--cpp", required=True, help="ninfer-qwen3_6_27b-dump executable")
     parser.add_argument("--messages", required=True, help="mixed image/video messages JSON")
     parser.add_argument("--prefill-chunk", type=int, default=1024)
-    parser.add_argument("--kv-dtype", choices=("bf16", "int8"), default="bf16")
+    parser.add_argument(
+        "--kv-dtype",
+        choices=("bf16", "int8", "bf16:int8", "int8:bf16"),
+        default="bf16",
+    )
     parser.add_argument("--mtp-draft-tokens", type=int, default=1)
     parser.add_argument("--proposal-head", choices=("full", "optimized"), default="full")
     parser.add_argument("--device", type=int, default=0)

--- a/tools/qwen3_6_27b_dump/main.cpp
+++ b/tools/qwen3_6_27b_dump/main.cpp
@@ -46,7 +46,7 @@ struct Options {
     std::uint32_t prefill_chunk   = 1024;
     std::uint32_t max_context     = 0;
     std::uint32_t mtp_drafts      = 0;
-    ninfer::KvCacheStorage kv     = ninfer::KvCacheStorage::BFloat16;
+    ninfer::KvCacheStorage kv;
     ninfer::ProposalHead proposal = ninfer::ProposalHead::Full;
     int device                    = 0;
     bool greedy                   = false;
@@ -58,7 +58,8 @@ constexpr std::string_view usage_text() {
     return "usage: ninfer-qwen3_6_27b-dump --weights MODEL.ninfer "
            "(--ids ID,...|--messages FILE.json)\n"
            "       --decode N --greedy --activation-dump DIR [--dump-level layer|vision-mtp]\n"
-           "       [--prefill-chunk N] [--max-context N] [--kv-dtype bf16|int8]\n"
+           "       [--prefill-chunk N] [--max-context N]\n"
+           "       [--kv-dtype bf16|int8|bf16:int8|int8:bf16]\n"
            "       [--stop-ids ID,...] [--mtp-draft-tokens 0..5]\n"
            "       [--proposal-head full|optimized] [--device N] [--no-thinking]\n"
            "\n"
@@ -136,12 +137,18 @@ Options parse_options(int argc, char** argv) {
             options.max_context = parse_u32(value(argument), "max-context");
         } else if (argument == "--kv-dtype") {
             const std::string_view kind = value(argument);
-            if (kind == "bf16") {
-                options.kv = ninfer::KvCacheStorage::BFloat16;
-            } else if (kind == "int8") {
-                options.kv = ninfer::KvCacheStorage::Int8Group64;
+            const auto format         = [](std::string_view side) {
+                if (side == "bf16") { return ninfer::KvCacheFormat::BFloat16; }
+                if (side == "int8") { return ninfer::KvCacheFormat::Int8Group64; }
+                usage_error("--kv-dtype must be bf16, int8, or <k>:<v> of those");
+                return ninfer::KvCacheFormat::BFloat16;
+            };
+            const std::size_t separator = kind.find(':');
+            if (separator == std::string_view::npos) {
+                options.kv = ninfer::kv_cache_uniform(format(kind));
             } else {
-                usage_error("--kv-dtype must be bf16 or int8");
+                options.kv = ninfer::KvCacheStorage{format(kind.substr(0, separator)),
+                                                    format(kind.substr(separator + 1))};
             }
         } else if (argument == "--stop-ids") {
             stop_ids = value(argument);
@@ -547,7 +554,14 @@ int run(const Options& options) {
              {"generated_token_ids", generated},
              {"stop_reason", stop_reason},
              {"sampling", std::move(sampling)},
-             {"kv_dtype", options.kv == ninfer::KvCacheStorage::BFloat16 ? "bf16" : "int8"},
+              {"kv_dtype",
+               [&options] {
+                   const auto side = [](ninfer::KvCacheFormat format) {
+                       return format == ninfer::KvCacheFormat::BFloat16 ? "bf16" : "int8";
+                   };
+                   if (options.kv.k == options.kv.v) { return std::string(side(options.kv.k)); }
+                   return std::string(side(options.kv.k)) + ":" + side(options.kv.v);
+               }()},
              {"prefill_chunk", options.prefill_chunk},
              {"mtp_draft_tokens", options.mtp_drafts},
              {"draft_head", options.proposal == ninfer::ProposalHead::Full ? "full" : "optimized"},

--- a/tools/reference/qwen3_6_27b/README.md
+++ b/tools/reference/qwen3_6_27b/README.md
@@ -31,7 +31,7 @@ drafts, fallback steps, timing, memory planning, and peak CUDA allocation.
 Important runtime controls include:
 
 - `--gpu-memory auto|24GiB` and `--headroom 2GiB`;
-- `--kv-dtype bf16|int8`;
+- `--kv-dtype bf16|int8|bf16:int8|int8:bf16` (K:V order);
 - `--prefill-chunk N`;
 - `--greedy` or sampling overrides for temperature, top-p, top-k, and penalties;
 - `--vision-attention-limit N`;

--- a/tools/reference/qwen3_6_27b/cli.py
+++ b/tools/reference/qwen3_6_27b/cli.py
@@ -72,7 +72,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gpu-memory", default="auto")
     parser.add_argument("--headroom", default="2GiB")
     parser.add_argument("--prefill-chunk", type=int, default=CFG.prefill_chunk)
-    parser.add_argument("--kv-dtype", choices=("bf16", "int8"), default="bf16")
+    parser.add_argument(
+        "--kv-dtype",
+        choices=("bf16", "int8", "bf16:int8", "int8:bf16"),
+        default="bf16",
+    )
     parser.add_argument(
         "--mtp-draft-tokens",
         type=int,

--- a/tools/reference/qwen3_6_27b/ops.py
+++ b/tools/reference/qwen3_6_27b/ops.py
@@ -162,14 +162,12 @@ def gated_delta_rule(
         )
         kt = k[0].float().index_select(0, head_map)
         qt = q[0].float().index_select(0, head_map)
-        next_state = state.float() * torch.exp(g[0].float()).view(1, CFG.gdn_v_heads, 1, 1)
-        prediction = torch.einsum("bhkv,hk->bhv", next_state, kt)
-        delta = beta[0].float().view(1, CFG.gdn_v_heads, 1) * (v[0].float() - prediction)
-        next_state = next_state + kt.view(
-            1, CFG.gdn_v_heads, CFG.gdn_k_dim, 1
-        ) * delta.unsqueeze(-2)
-        out = torch.einsum("bhkv,hk->bhv", next_state, qt) * GDN_SCALE
-        return bf16(out.squeeze(0).unsqueeze(0)), next_state
+        next_state = state[0].float() * torch.exp(g[0].float()).view(CFG.gdn_v_heads, 1, 1)
+        prediction = torch.einsum("hkv,hk->hv", next_state, kt)
+        delta = beta[0].float().unsqueeze(-1) * (v[0].float() - prediction)
+        next_state = next_state + kt.unsqueeze(-1) * delta.unsqueeze(-2)
+        out = torch.einsum("hkv,hk->hv", next_state, qt) * GDN_SCALE
+        return bf16(out.unsqueeze(0)), next_state.unsqueeze(0)
     try:
         from fla.ops.gated_delta_rule import chunk_gated_delta_rule
     except ImportError as exc:

--- a/tools/reference/qwen3_6_27b/state.py
+++ b/tools/reference/qwen3_6_27b/state.py
@@ -11,14 +11,17 @@ from .config import CFG
 
 class KVCache:
     def __init__(self, layers: int, capacity: int, device: torch.device, dtype: str = "bf16"):
-        if dtype not in {"bf16", "int8"}:
-            raise ValueError(f"kv dtype must be bf16/int8, got {dtype!r}")
+        sides = dtype.split(":")
+        if len(sides) == 1:
+            sides *= 2
+        if len(sides) != 2 or any(side not in {"bf16", "int8"} for side in sides):
+            raise ValueError(f"kv dtype must be bf16/int8 or <k>:<v>, got {dtype!r}")
         if capacity <= 0:
             raise ValueError("KV capacity must be positive")
         self.layers = layers
         self.capacity = capacity
         self.device = device
-        self.dtype = dtype
+        self.k_dtype, self.v_dtype = sides
         self.length = 0
         self._k: dict[int, torch.Tensor] = {}
         self._v: dict[int, torch.Tensor] = {}
@@ -29,14 +32,16 @@ class KVCache:
         if layer in self._k:
             return
         shape = (self.capacity, CFG.kv_heads, CFG.head_dim)
-        if self.dtype == "bf16":
+        scales = (self.capacity, CFG.kv_heads, CFG.head_dim // 64)
+        if self.k_dtype == "bf16":
             self._k[layer] = torch.empty(shape, device=self.device, dtype=torch.bfloat16)
-            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.bfloat16)
         else:
             self._k[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
-            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
-            scales = (self.capacity, CFG.kv_heads, CFG.head_dim // 64)
             self._ks[layer] = torch.empty(scales, device=self.device, dtype=torch.float16)
+        if self.v_dtype == "bf16":
+            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.bfloat16)
+        else:
+            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
             self._vs[layer] = torch.empty(scales, device=self.device, dtype=torch.float16)
 
     @staticmethod
@@ -58,26 +63,29 @@ class KVCache:
         if start < 0 or end > self.capacity or v.shape != k.shape:
             raise ValueError("KV write range or shape mismatch")
         self._allocate(layer)
-        if self.dtype == "bf16":
+        if self.k_dtype == "bf16":
             self._k[layer][start:end].copy_(k)
-            self._v[layer][start:end].copy_(v)
         else:
             kc, ks = self._quantize(k)
-            vc, vs = self._quantize(v)
             self._k[layer][start:end].copy_(kc)
-            self._v[layer][start:end].copy_(vc)
             self._ks[layer][start:end].copy_(ks)
+        if self.v_dtype == "bf16":
+            self._v[layer][start:end].copy_(v)
+        else:
+            vc, vs = self._quantize(v)
+            self._v[layer][start:end].copy_(vc)
             self._vs[layer][start:end].copy_(vs)
 
     def read(self, layer: int, end: int) -> tuple[torch.Tensor, torch.Tensor]:
         if end < 0 or end > self.capacity or layer not in self._k:
             raise ValueError("KV read range or layer mismatch")
-        if self.dtype == "bf16":
-            return self._k[layer][:end], self._v[layer][:end]
-        return (
-            self._dequantize(self._k[layer][:end], self._ks[layer][:end]),
-            self._dequantize(self._v[layer][:end], self._vs[layer][:end]),
-        )
+        k = self._k[layer][:end]
+        v = self._v[layer][:end]
+        if self.k_dtype == "int8":
+            k = self._dequantize(k, self._ks[layer][:end])
+        if self.v_dtype == "int8":
+            v = self._dequantize(v, self._vs[layer][:end])
+        return k, v
 
     def rewind(self, position: int) -> None:
         if position < 0 or position > self.length:

--- a/tools/reference/qwen3_6_27b/weights.py
+++ b/tools/reference/qwen3_6_27b/weights.py
@@ -76,14 +76,16 @@ def estimate_fixed_bytes(
     if not text and not mtp:
         return 0
     kv_layers = (CFG.full_layers if text else 0) + (1 if mtp else 0)
-    if kv_dtype == "bf16":
-        kv_per_layer_token = 2 * CFG.kv_heads * CFG.head_dim * 2
-    elif kv_dtype == "int8":
-        kv_per_layer_token = 2 * CFG.kv_heads * (
-            CFG.head_dim + CFG.head_dim // 64 * 2
-        )
-    else:
+    sides = kv_dtype.split(":")
+    if len(sides) == 1:
+        sides *= 2
+    if len(sides) != 2 or any(side not in {"bf16", "int8"} for side in sides):
         raise ValueError(f"unsupported KV dtype: {kv_dtype!r}")
+    side_bytes = {
+        "bf16": CFG.kv_heads * CFG.head_dim * 2,
+        "int8": CFG.kv_heads * (CFG.head_dim + CFG.head_dim // 64 * 2),
+    }
+    kv_per_layer_token = sum(side_bytes[side] for side in sides)
     kv = capacity * kv_layers * kv_per_layer_token
     if text:
         ssm = CFG.gdn_layers * CFG.gdn_v_heads * CFG.gdn_k_dim * CFG.gdn_v_dim * 4

--- a/tools/reference/qwen3_6_35b_a3b/cli.py
+++ b/tools/reference/qwen3_6_35b_a3b/cli.py
@@ -72,7 +72,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gpu-memory", default="auto")
     parser.add_argument("--headroom", default="2GiB")
     parser.add_argument("--prefill-chunk", type=int, default=CFG.prefill_chunk)
-    parser.add_argument("--kv-dtype", choices=("bf16", "int8"), default="bf16")
+    parser.add_argument(
+        "--kv-dtype",
+        choices=("bf16", "int8", "bf16:int8", "int8:bf16"),
+        default="bf16",
+    )
     parser.add_argument(
         "--mtp-draft-tokens",
         type=int,

--- a/tools/reference/qwen3_6_35b_a3b/state.py
+++ b/tools/reference/qwen3_6_35b_a3b/state.py
@@ -17,14 +17,17 @@ class KVCache:
         device: torch.device,
         dtype: str = "bf16",
     ):
-        if dtype not in {"bf16", "int8"}:
-            raise ValueError(f"kv dtype must be bf16/int8, got {dtype!r}")
+        sides = dtype.split(":")
+        if len(sides) == 1:
+            sides *= 2
+        if len(sides) != 2 or any(side not in {"bf16", "int8"} for side in sides):
+            raise ValueError(f"kv dtype must be bf16/int8 or <k>:<v>, got {dtype!r}")
         if capacity <= 0:
             raise ValueError("KV capacity must be positive")
         self.layers = layers
         self.capacity = capacity
         self.device = device
-        self.dtype = dtype
+        self.k_dtype, self.v_dtype = sides
         self.length = 0
         self._k: dict[int, torch.Tensor] = {}
         self._v: dict[int, torch.Tensor] = {}
@@ -35,20 +38,22 @@ class KVCache:
         if layer in self._k:
             return
         shape = (self.capacity, CFG.kv_heads, CFG.head_dim)
-        if self.dtype == "bf16":
+        scales = (self.capacity, CFG.kv_heads, CFG.head_dim // 64)
+        if self.k_dtype == "bf16":
             self._k[layer] = torch.empty(
-                shape, device=self.device, dtype=torch.bfloat16
-            )
-            self._v[layer] = torch.empty(
                 shape, device=self.device, dtype=torch.bfloat16
             )
         else:
             self._k[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
-            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
-            scales = (self.capacity, CFG.kv_heads, CFG.head_dim // 64)
             self._ks[layer] = torch.empty(
                 scales, device=self.device, dtype=torch.float16
             )
+        if self.v_dtype == "bf16":
+            self._v[layer] = torch.empty(
+                shape, device=self.device, dtype=torch.bfloat16
+            )
+        else:
+            self._v[layer] = torch.empty(shape, device=self.device, dtype=torch.int8)
             self._vs[layer] = torch.empty(
                 scales, device=self.device, dtype=torch.float16
             )
@@ -86,26 +91,29 @@ class KVCache:
         if start < 0 or end > self.capacity or v.shape != k.shape:
             raise ValueError("KV write range or shape mismatch")
         self._allocate(layer)
-        if self.dtype == "bf16":
+        if self.k_dtype == "bf16":
             self._k[layer][start:end].copy_(k)
-            self._v[layer][start:end].copy_(v)
         else:
             kc, ks = self._quantize(k)
-            vc, vs = self._quantize(v)
             self._k[layer][start:end].copy_(kc)
-            self._v[layer][start:end].copy_(vc)
             self._ks[layer][start:end].copy_(ks)
+        if self.v_dtype == "bf16":
+            self._v[layer][start:end].copy_(v)
+        else:
+            vc, vs = self._quantize(v)
+            self._v[layer][start:end].copy_(vc)
             self._vs[layer][start:end].copy_(vs)
 
     def read(self, layer: int, end: int) -> tuple[torch.Tensor, torch.Tensor]:
         if end < 0 or end > self.capacity or layer not in self._k:
             raise ValueError("KV read range or layer mismatch")
-        if self.dtype == "bf16":
-            return self._k[layer][:end], self._v[layer][:end]
-        return (
-            self._dequantize(self._k[layer][:end], self._ks[layer][:end]),
-            self._dequantize(self._v[layer][:end], self._vs[layer][:end]),
-        )
+        k = self._k[layer][:end]
+        v = self._v[layer][:end]
+        if self.k_dtype == "int8":
+            k = self._dequantize(k, self._ks[layer][:end])
+        if self.v_dtype == "int8":
+            v = self._dequantize(v, self._vs[layer][:end])
+        return k, v
 
     def rewind(self, position: int) -> None:
         if position < 0 or position > self.length:

--- a/tools/reference/qwen3_6_35b_a3b/weights.py
+++ b/tools/reference/qwen3_6_35b_a3b/weights.py
@@ -72,14 +72,16 @@ def estimate_fixed_bytes(
     if not text and not mtp:
         return 0
     kv_layers = (CFG.full_layers if text else 0) + (1 if mtp else 0)
-    if kv_dtype == "bf16":
-        kv_per_layer_token = 2 * CFG.kv_heads * CFG.head_dim * 2
-    elif kv_dtype == "int8":
-        kv_per_layer_token = 2 * CFG.kv_heads * (
-            CFG.head_dim + CFG.head_dim // 64 * 2
-        )
-    else:
+    sides = kv_dtype.split(":")
+    if len(sides) == 1:
+        sides *= 2
+    if len(sides) != 2 or any(side not in {"bf16", "int8"} for side in sides):
         raise ValueError(f"unsupported KV dtype: {kv_dtype!r}")
+    side_bytes = {
+        "bf16": CFG.kv_heads * CFG.head_dim * 2,
+        "int8": CFG.kv_heads * (CFG.head_dim + CFG.head_dim // 64 * 2),
+    }
+    kv_per_layer_token = sum(side_bytes[side] for side in sides)
     kv = capacity * kv_layers * kv_per_layer_token
     if text:
         ssm = (


### PR DESCRIPTION
## Summary
- Select K and V cache formats independently across the public API, layouts, runtime state, reporting, and tooling.
- Add mixed BF16/INT8-G64 prefill and decode kernels while retaining specialized symmetric paths.
- Extend CLI, serving, benchmarks, parity tooling, documentation, and real-artifact coverage for both mixed orders.

## Verification
- Windows CTest: 67/67 passed with the 27B and 35B-A3B artifacts.
- Windows pytest: 67 passed, 4 skipped because source checkpoint directories were unavailable.
- WSL CTest: 67/67 passed with the 27B and 35B-A3B artifacts.
- WSL pytest: 67 passed, 4 skipped because source checkpoint directories were unavailable.
- git diff --check passed.