### PR TITLE
feat(serve): preserve reasoning across turns

### DIFF
--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -236,6 +236,7 @@ int main(int argc, char** argv) {
                 ? ninfer::product::prompt_from_text(cli.prompt, cli.enable_thinking)
                 : ninfer::product::prompt_from_messages(cli.messages_path, cli.enable_thinking,
                                                         cli.enable_vision);
+        input.options.preserve_thinking = cli.preserve_thinking;
 
         ninfer::RequestOptions request;
         request.execution.sampling                = cli.sampling;

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -52,6 +52,14 @@ float parse_float(const char* text, std::string_view label, float minimum, float
     return static_cast<float>(value);
 }
 
+bool parse_bool(const char* text, std::string_view label) {
+    const std::string_view value(text == nullptr ? "" : text);
+    if (value == "true") { return true; }
+    if (value == "false") { return false; }
+    throw std::invalid_argument("invalid " + std::string(label) + ": " + std::string(value) +
+                                " (expected true or false)");
+}
+
 KvCacheStorage parse_kv_cache(std::string_view text) {
     if (text == "bf16") { return KvCacheStorage::BFloat16; }
     if (text == "int8") { return KvCacheStorage::Int8Group64; }
@@ -69,7 +77,9 @@ std::string usage_text(const char* argv0) {
            "       [--temperature F] [--top-p F] [--top-k N] [--min-p F]\n"
            "       [--presence-penalty F] [--frequency-penalty F] [--seed N] [--greedy]\n"
            "       [--stop-token-id N]... [--stop <text>]... [--reasoning-stop <text>]...\n"
-           "       [--raw-output] [--print-token-ids] [--no-thinking] [--vision]\n"
+           "       [--raw-output] [--print-token-ids] [--no-thinking]\n"
+           "       [--preserve_thinking true|false]\n"
+           "       [--vision]\n"
            "       [--no-cuda-graph]\n"
            "\n"
            "Streams answer content to stdout and reasoning plus diagnostics to stderr.\n"
@@ -121,6 +131,8 @@ Options parse_options(int argc, char** argv) {
             options.print_token_ids = true;
         } else if (arg == "--no-thinking") {
             options.enable_thinking = false;
+        } else if (arg == "--preserve_thinking") {
+            options.preserve_thinking = parse_bool(value(arg), "preserve_thinking");
         } else if (arg == "--vision") {
             options.enable_vision = true;
         } else if (arg == "--no-cuda-graph") {

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -29,6 +29,7 @@ struct Options {
     bool raw_output      = false;
     bool print_token_ids = false;
     bool enable_thinking = true;
+    bool preserve_thinking = true;
 
     std::vector<TokenId> stop_token_ids;
     std::vector<StopString> stop_strings;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,8 +23,9 @@ speculative-decoding statistics are written to stderr, so stdout can be redirect
   > answer.txt 2> run.log
 ```
 
-Thinking is enabled by default. Add `--no-thinking` for direct-response prompt rendering or
-`--greedy` for exact argmax decoding.
+Thinking is enabled by default. Add `--no-thinking` for direct-response prompt rendering,
+`--preserve_thinking true` to retain non-empty reasoning from assistant history, or `--greedy` for
+exact argmax decoding.
 
 ## Startup memory profile
 
@@ -138,6 +139,7 @@ measured recommendation rather than a semantic limit.
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |
+| `--preserve_thinking true\|false` | retain non-empty reasoning from assistant history | `true` |
 | `--greedy` | exact argmax decoding | off |
 | `--temperature F` | sampling temperature | `0.6` |
 | `--top-p F` | nucleus threshold | `0.95` |

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -34,6 +34,10 @@ server must accept image or video input. Speculative residency is likewise froze
 `--lm-head-draft` additionally loads the optimized proposal head. DFlash is 35B-A3B text-only and
 cannot be combined with `--vision`. A later request cannot enable a capability omitted at startup.
 
+Assistant `reasoning_content` in prior turns is replayed into the prompt by default, as Qwen
+recommends for agentic tasks. Pass `--preserve_thinking false` to discard it for every request,
+including clients that do not send a NInfer-specific option.
+
 ## Endpoints
 
 | Method and path | Behavior |

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -139,7 +139,7 @@ struct ChatMessage {
 struct PromptOptions {
     bool add_generation_prompt = true;
     bool enable_thinking       = true;
-    bool preserve_thinking     = false;
+    bool preserve_thinking     = true;
     bool add_vision_id         = false;
     std::vector<std::string> tool_jsons;
 };

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -51,6 +51,14 @@ KvCacheStorage parse_kv_dtype(const char* text) {
     throw std::invalid_argument("invalid kv-dtype: " + value);
 }
 
+bool parse_bool(const char* text, const char* label) {
+    const std::string value(text == nullptr ? "" : text);
+    if (value == "true") { return true; }
+    if (value == "false") { return false; }
+    throw std::invalid_argument("invalid " + std::string(label) + ": " + value +
+                                " (expected true or false)");
+}
+
 } // namespace
 
 std::string serve_usage_text(const char* argv0) {
@@ -61,7 +69,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
-           "[--lm-head-draft] [--no-thinking] [--cors] "
+           "[--lm-head-draft] [--no-thinking] [--preserve_thinking true|false] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
            "       serves an OpenAI-compatible Chat Completions endpoint\n"
@@ -72,6 +80,7 @@ std::string serve_usage_text(const char* argv0) {
            "       --request-log-jsonl appends full-precision server/request records\n"
            "       --vision enables media and loads the fixed Vision GPU allocations\n"
            "       --no-prefix-reuse disables compatible-prefix caching (enabled by default)\n"
+           "       --preserve_thinking controls whether assistant reasoning in history is retained\n"
            "       sampler defaults to Qwen3 thinking (temperature 0.6, top-p 0.95, "
            "top-k 20, presence-penalty 1.0); a request may override any field.\n"
            "       --greedy forces temperature 0 (exact argmax).\n";
@@ -153,6 +162,9 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {
             options.enable_thinking = false;
+        } else if (arg == "--preserve_thinking") {
+            options.preserve_thinking =
+                parse_bool(require_value("--preserve_thinking"), "preserve_thinking");
         } else if (arg == "--cors") {
             options.enable_cors = true;
         } else if (arg == "--temperature") {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -34,6 +34,7 @@ struct ServeOptions {
     bool allow_prefix_reuse = true;
     bool enable_thinking =
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
+    bool preserve_thinking = true; // preserve assistant reasoning in prompt history by default
     int default_max_tokens = kDefaultMaxTokens;
     bool enable_cors       = false; // send permissive CORS headers for browser UIs
     // Default sampler applied when a request omits a field. Defaults match the

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -138,7 +138,7 @@ ninfer::PromptInput to_prompt_input(const GenerationRequest& request, const Serv
 
     input.options.add_generation_prompt = true;
     input.options.enable_thinking       = request.enable_thinking.value_or(server.enable_thinking);
-    input.options.preserve_thinking     = false;
+    input.options.preserve_thinking     = server.preserve_thinking;
     input.options.add_vision_id         = false;
     input.options.tool_jsons            = effective_tool_jsons(request);
     return input;

--- a/src/targets/qwen3_6/impl/frontend/chat_template.h
+++ b/src/targets/qwen3_6/impl/frontend/chat_template.h
@@ -67,7 +67,7 @@ struct ChatMessage {
 struct ChatRenderOptions {
     bool add_generation_prompt = true;
     bool enable_thinking       = true;
-    bool preserve_thinking     = false;
+    bool preserve_thinking     = true;
     bool add_vision_id         = false;
     std::vector<std::string> tool_jsons;
 };

--- a/tests/test_serve_options.cpp
+++ b/tests/test_serve_options.cpp
@@ -35,6 +35,19 @@ int main() {
                       "request JSONL logging is not disabled by default");
     failures += check(defaults.speculative.backend == ninfer::SpeculativeBackend::None,
                       "speculative decoding is not disabled by default");
+    failures += check(defaults.preserve_thinking,
+                      "reasoning preservation is not enabled by default");
+
+    const ServeOptions discard_thinking =
+        parse({"ninfer-serve", "model.ninfer", "--preserve_thinking", "false"});
+    failures += check(!discard_thinking.preserve_thinking,
+                      "--preserve_thinking false did not disable reasoning preservation");
+
+    GenerationRequest thinking_history;
+    thinking_history.messages.push_back(
+        ChatTurn{.role = "assistant", .reasoning_content = "reasoning"});
+    failures += check(to_prompt_input(thinking_history, defaults, {}).options.preserve_thinking,
+                      "server reasoning-preservation default did not reach prompt options");
 
     const ServeOptions dflash = parse({"ninfer-serve", "model.ninfer", "--spec", "dflash",
                                        "--draft-tokens", "15", "--lm-head-draft"});
@@ -76,6 +89,9 @@ int main() {
               "serve help omits --no-prefix-reuse");
     failures += check(serve_usage_text("ninfer-serve").find("--vision") != std::string::npos,
                       "serve help omits --vision");
+    failures += check(serve_usage_text("ninfer-serve").find("--preserve_thinking") !=
+                          std::string::npos,
+                      "serve help omits --preserve_thinking");
 
     const ServeOptions logged = parse({"ninfer-serve", "model.ninfer", "--request-log-jsonl",
                                        "requests.jsonl", "--api-key", "do-not-log"});


### PR DESCRIPTION
- Add `--preserve_thinking true|false` to `ninfer` and `ninfer-serve`.
- Default reasoning preservation to `true` across prompt rendering.
- Based on [Qwen3.6 preserve_thinking discussion](https://www.reddit.com/r/LocalLLaMA/comments/1sne4gh/psa_qwen36_ships_with_preserve_thinking_make_sure/).