### PR TITLE
feat(serve): add --preserve-thinking flag to keep thinking blocks in cached prefix

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -79,7 +79,8 @@ The endpoint supports:
 - non-streaming responses and server-sent event streams;
 - `stream_options.include_usage`;
 - function tools, tool choices, assistant tool-call history, and tool-result messages;
-- the `enable_thinking` extension.
+- the `enable_thinking` extension (thinking on/off); and
+- the `preserve_thinking` extension (keep thinking blocks in prefix cache across user turns).
 
 The request `model` must equal the public model ID: the artifact `identity.model_id` by default, or
 the explicit `--model-id` override. Reasoning is returned separately as `reasoning_content`; answer
@@ -406,6 +407,7 @@ curl http://127.0.0.1:8080/v1/models \
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-prefix-reuse` | disable compatible-prefix caching | prefix reuse on |
 | `--no-thinking` | disable thinking by default | thinking on |
+| `--preserve-thinking` | keep thinking blocks in cached prefix across user turns | off |
 | `--cors` | permissive browser CORS headers | off |
 | `--greedy` | force exact argmax for all requests | off |
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -80,7 +80,8 @@ The endpoint supports:
 - `stream_options.include_usage`;
 - function tools, tool choices, assistant tool-call history, and tool-result messages;
 - the `enable_thinking` extension (thinking on/off); and
-- the `preserve_thinking` extension (keep thinking blocks in prefix cache across user turns).
+- the `preserve_thinking` extension (keep thinking blocks in the cached prefix across user turns;
+  see [Preserved thinking history](#preserved-thinking-history)).
 
 The request `model` must equal the public model ID: the artifact `identity.model_id` by default, or
 the explicit `--model-id` override. Reasoning is returned separately as `reasoning_content`; answer
@@ -179,7 +180,8 @@ wire response contains typed `output` Items.
 | `stream_options` | omitted or `{"include_obfuscation":false}` |
 
 Unknown top-level fields fail with `unknown_parameter`. Recognized but unsupported features fail
-with a field-specific 400 error instead of being silently ignored.
+with a field-specific 400 error instead of being silently ignored. Responses has no per-request
+`preserve_thinking` field; Responses requests follow the server-wide `--preserve-thinking` setting.
 
 ### Input Item contract
 
@@ -416,6 +418,25 @@ Server sampling defaults are temperature `0.6`, top-p `0.95`, top-k `20`, presen
 server was started with `--greedy`.
 
 Run `./build/apps/ninfer-serve --help` for the exact option contract.
+
+### Preserved thinking history
+
+The official Qwen chat template strips `<think>` blocks from every assistant turn at or before the
+last user query. Each new user message therefore re-renders the earlier assistant turns without
+their thinking, so the conversation's cached prefix changes and resident KV cannot be reused past
+the first divergent turn.
+
+`--preserve-thinking` keeps those blocks in place, making turn N's rendering a byte-exact prefix of
+turn N+1's. Chat Completions requests may override it per request with `preserve_thinking`;
+Anthropic Messages has no equivalent concept and Responses exposes no per-request field, so both
+follow the server setting.
+
+This is an intentional, opt-in departure from official template rendering, traded for prefix
+stability; it is off by default because the codebase otherwise treats HF template parity as a locked
+invariant. It also costs KV: preserved thinking makes every prompt strictly longer, and admission
+reserves the full prompt-plus-output page entitlement from one shared pool. At
+`--max-concurrency 1` that is free, but at `2` or more it is a real trade — more prefix reuse per
+request against less pool for the others, and therefore more FIFO waiting.
 
 ## Structured request log
 

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -336,7 +336,7 @@ PreparedRequest GenerationService::prepare(const GenerationRequest& request,
     prepared.tool_capable                  = request.uses_tools() || request.has_tool_history();
     prepared.tool_name_max_length          = request.tool_name_max_length;
     prepared.enable_thinking      = request.enable_thinking.value_or(options_.enable_thinking);
-    prepared.preserve_thinking  = request.preserve_thinking.value_or(options_.preserve_thinking);
+    prepared.preserve_thinking    = request.preserve_thinking.value_or(options_.preserve_thinking);
     const std::size_t media_items = media_item_count(request);
     const bool request_has_media  = media_items != 0;
     if (request_has_media && !options_.enable_vision) {

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -336,6 +336,7 @@ PreparedRequest GenerationService::prepare(const GenerationRequest& request,
     prepared.tool_capable                  = request.uses_tools() || request.has_tool_history();
     prepared.tool_name_max_length          = request.tool_name_max_length;
     prepared.enable_thinking      = request.enable_thinking.value_or(options_.enable_thinking);
+    prepared.preserve_thinking  = request.preserve_thinking.value_or(options_.preserve_thinking);
     const std::size_t media_items = media_item_count(request);
     const bool request_has_media  = media_items != 0;
     if (request_has_media && !options_.enable_vision) {

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -70,6 +70,7 @@ struct PreparedRequest {
     bool tool_capable                = false;
     std::size_t tool_name_max_length = 64;
     bool enable_thinking             = true;
+    bool preserve_thinking          = false;
     std::shared_ptr<RequestLifetime> lifetime;
 };
 

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -70,7 +70,7 @@ struct PreparedRequest {
     bool tool_capable                = false;
     std::size_t tool_name_max_length = 64;
     bool enable_thinking             = true;
-    bool preserve_thinking          = false;
+    bool preserve_thinking           = false;
     std::shared_ptr<RequestLifetime> lifetime;
 };
 

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -497,6 +497,9 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
     if (body.contains("enable_thinking") && !body.at("enable_thinking").is_null()) {
         out.enable_thinking = get_bool(body, "enable_thinking", false);
     }
+    if (body.contains("preserve_thinking") && !body.at("preserve_thinking").is_null()) {
+        out.preserve_thinking = get_bool(body, "preserve_thinking", false);
+    }
 
     std::optional<int> max_tokens = get_int(body, "max_completion_tokens");
     if (!max_tokens) { max_tokens = get_int(body, "max_tokens"); }

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -126,8 +126,8 @@ struct GenerationRequest {
     bool max_tokens_set = false;
     bool stream         = false;
     bool include_usage  = false;
-    std::optional<bool> enable_thinking;     // non-standard extension; falls back to server default
-    std::optional<bool> preserve_thinking;  // keep thinking in prefix cache across user turns
+    std::optional<bool> enable_thinking;   // non-standard extension; falls back to server default
+    std::optional<bool> preserve_thinking; // keep thinking in prefix cache across user turns
     SamplingParams sampling;
 
     [[nodiscard]] bool uses_tools() const noexcept {

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -126,7 +126,8 @@ struct GenerationRequest {
     bool max_tokens_set = false;
     bool stream         = false;
     bool include_usage  = false;
-    std::optional<bool> enable_thinking; // non-standard extension; falls back to server default
+    std::optional<bool> enable_thinking;     // non-standard extension; falls back to server default
+    std::optional<bool> preserve_thinking;  // keep thinking in prefix cache across user turns
     SamplingParams sampling;
 
     [[nodiscard]] bool uses_tools() const noexcept {

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -235,7 +235,8 @@ std::string format_request_start(const RequestLogContext& context) {
         << " tools=" << context.tool_count
         << " tool_choice=" << tool_choice_name(context.tool_choice)
         << " tool_history=" << (context.has_tool_history ? "yes" : "no")
-        << " thinking=" << (context.enable_thinking ? "on" : "off") << " preserve_thinking=" << (context.preserve_thinking ? "on" : "off") << " sampler=["
+        << " thinking=" << (context.enable_thinking ? "on" : "off")
+        << " preserve_thinking=" << (context.preserve_thinking ? "on" : "off") << " sampler=["
         << sampler_str(context.sampling) << "] \xE2\x86\x92 submitted";
     return out.str();
 }
@@ -319,7 +320,7 @@ std::string format_server_start_json(const std::string& server_instance_id, std:
                               {"request_log_jsonl", options.request_log_jsonl},
                               {"default_output_tokens", options.default_max_tokens},
                               {"default_thinking", options.enable_thinking},
-                             {"default_preserve_thinking", options.preserve_thinking}};
+                              {"default_preserve_thinking", options.preserve_thinking}};
     record["artifact"] = Json{{"path", options.artifact_path},
                               {"size_bytes", std::move(artifact_size)},
                               {"target", load.target},

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -134,6 +134,7 @@ Json request_json(const RequestLogContext& context) {
                 {"tool_choice", tool_choice_name(context.tool_choice)},
                 {"has_tool_history", context.has_tool_history},
                 {"enable_thinking", context.enable_thinking},
+                {"preserve_thinking", context.preserve_thinking},
                 {"sampling", sampler_json(context.sampling)}};
 }
 
@@ -220,6 +221,7 @@ RequestLogContext make_request_log_context(std::uint64_t id, std::string protoco
     context.tool_choice                        = request.tool_choice;
     context.has_tool_history                   = request.has_tool_history();
     context.enable_thinking                    = prepared.enable_thinking;
+    context.preserve_thinking                  = prepared.preserve_thinking;
     context.sampling                           = prepared.sampling;
     return context;
 }
@@ -233,7 +235,7 @@ std::string format_request_start(const RequestLogContext& context) {
         << " tools=" << context.tool_count
         << " tool_choice=" << tool_choice_name(context.tool_choice)
         << " tool_history=" << (context.has_tool_history ? "yes" : "no")
-        << " thinking=" << (context.enable_thinking ? "on" : "off") << " sampler=["
+        << " thinking=" << (context.enable_thinking ? "on" : "off") << " preserve_thinking=" << (context.preserve_thinking ? "on" : "off") << " sampler=["
         << sampler_str(context.sampling) << "] \xE2\x86\x92 submitted";
     return out.str();
 }
@@ -316,7 +318,8 @@ std::string format_server_start_json(const std::string& server_instance_id, std:
                               {"max_request_bytes", options.max_request_bytes},
                               {"request_log_jsonl", options.request_log_jsonl},
                               {"default_output_tokens", options.default_max_tokens},
-                              {"default_thinking", options.enable_thinking}};
+                              {"default_thinking", options.enable_thinking},
+                             {"default_preserve_thinking", options.preserve_thinking}};
     record["artifact"] = Json{{"path", options.artifact_path},
                               {"size_bytes", std::move(artifact_size)},
                               {"target", load.target},

--- a/src/serve/request_log.h
+++ b/src/serve/request_log.h
@@ -32,6 +32,7 @@ struct RequestLogContext {
     ToolChoice tool_choice;
     bool has_tool_history = false;
     bool enable_thinking  = true;
+    bool preserve_thinking = false;
     ninfer::SamplingParameters sampling;
 };
 

--- a/src/serve/request_log.h
+++ b/src/serve/request_log.h
@@ -30,8 +30,8 @@ struct RequestLogContext {
     bool requested_output_tokens_client_set = false;
     std::size_t tool_count                  = 0;
     ToolChoice tool_choice;
-    bool has_tool_history = false;
-    bool enable_thinking  = true;
+    bool has_tool_history  = false;
+    bool enable_thinking   = true;
     bool preserve_thinking = false;
     ninfer::SamplingParameters sampling;
 };

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -72,7 +72,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
-           "[--lm-head-draft] [--no-thinking] [--cors] "
+           "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
            "       serves OpenAI Responses/Chat Completions and Anthropic Messages endpoints\n"
@@ -204,6 +204,8 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {
             options.enable_thinking = false;
+        } else if (arg == "--preserve-thinking") {
+            options.preserve_thinking = true;
         } else if (arg == "--cors") {
             options.enable_cors = true;
         } else if (arg == "--temperature") {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -44,6 +44,7 @@ struct ServeOptions {
     bool allow_prefix_reuse = true;
     bool enable_thinking =
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
+    bool preserve_thinking = false; // keep thinking blocks in cached prefix across user turns
     int default_max_tokens = kDefaultMaxTokens;
     bool enable_cors       = false; // send permissive CORS headers for browser UIs
     // Default sampler applied when a request omits a field. Defaults match the

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -138,7 +138,7 @@ ninfer::PromptInput to_prompt_input(const GenerationRequest& request, const Serv
 
     input.options.add_generation_prompt = true;
     input.options.enable_thinking       = request.enable_thinking.value_or(server.enable_thinking);
-    input.options.preserve_thinking     = false;
+    input.options.preserve_thinking = request.preserve_thinking.value_or(server.preserve_thinking);
     input.options.add_vision_id         = false;
     input.options.tool_jsons            = effective_tool_jsons(request);
     return input;

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -302,6 +302,43 @@ int test_official_chat_template() {
     return failures;
 }
 
+// preserve_thinking is a deliberate, opt-in departure from the official template: the official
+// template strips <think> from every assistant turn at or before the last user query, which
+// rewrites the cached prefix on every new turn. Mirrors the official-template case above.
+int test_preserve_thinking_chat_template() {
+    const std::vector<fi::ChatMessage> history = {
+        chat_message("user", "q1"),
+        chat_message("assistant", "<think>\nold thought\n</think>\n\nold answer"),
+        chat_message("user", "q2")};
+
+    fi::ChatRenderOptions preserve;
+    preserve.preserve_thinking = true;
+    const std::string expected = "<|im_start|>user\nq1<|im_end|>\n"
+                                 "<|im_start|>assistant\n<think>\nold thought\n</think>\n\n"
+                                 "old answer<|im_end|>\n"
+                                 "<|im_start|>user\nq2<|im_end|>\n"
+                                 "<|im_start|>assistant\n<think>\n";
+    const std::string rendered = fi::render_chat(history, preserve);
+    int failures =
+        check(rendered == expected, "preserve_thinking dropped the historical thinking block");
+
+    // The invariant the option exists for: the earlier turn's rendering stays a byte-exact prefix
+    // of the later turn's rendering, so the resident KV prefix survives the new user message.
+    fi::ChatRenderOptions preserve_no_generation = preserve;
+    preserve_no_generation.add_generation_prompt = false;
+    const std::vector<fi::ChatMessage> earlier_history(history.begin(), history.begin() + 2);
+    const std::string earlier_turn = fi::render_chat(earlier_history, preserve_no_generation);
+    failures += check(rendered.starts_with(earlier_turn),
+                      "preserve_thinking prefix was not byte-stable across user turns");
+
+    // Without the option the same history is rewritten, which is what invalidates the prefix.
+    const std::string official = fi::render_chat(history);
+    failures += check(official.find("old thought") == std::string::npos &&
+                          !official.starts_with(earlier_turn),
+                      "official rendering unexpectedly preserved the thinking history");
+    return failures;
+}
+
 int test_official_resource_guards() {
     FrontendResources stale_pad     = resources();
     nlohmann::json tokenizer_config = nlohmann::json::parse(stale_pad.tokenizer_config_json);
@@ -584,6 +621,7 @@ int main() {
     int failures                  = 0;
     failures += test_official_tokenizer_merge();
     failures += test_official_chat_template();
+    failures += test_preserve_thinking_chat_template();
     failures += test_official_resource_guards();
     failures += test_text_and_image_prepare(frontend);
     failures += test_video_prepare(frontend);

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -537,10 +537,9 @@ int test_parse_preserve_thinking() {
 
     // Test that preserve_thinking: true is parsed into GenerationRequest
     {
-        const Json body = {
-            {"model", "m"},
-            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
-            {"preserve_thinking", true}};
+        const Json body             = {{"model", "m"},
+                                       {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+                                       {"preserve_thinking", true}};
         const GenerationRequest req = parse_chat_completion_request(body, default_limits());
         failures += check(req.preserve_thinking.has_value() && *req.preserve_thinking == true,
                           "preserve_thinking true parsed");
@@ -548,10 +547,9 @@ int test_parse_preserve_thinking() {
 
     // Test that preserve_thinking: false is parsed
     {
-        const Json body = {
-            {"model", "m"},
-            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
-            {"preserve_thinking", false}};
+        const Json body             = {{"model", "m"},
+                                       {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+                                       {"preserve_thinking", false}};
         const GenerationRequest req = parse_chat_completion_request(body, default_limits());
         failures += check(req.preserve_thinking.has_value() && *req.preserve_thinking == false,
                           "preserve_thinking false parsed");
@@ -559,21 +557,19 @@ int test_parse_preserve_thinking() {
 
     // Test that when omitted, it defaults to std::nullopt
     {
-        const Json body = {
-            {"model", "m"},
-            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const Json body             = {{"model", "m"},
+                                       {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
         const GenerationRequest req = parse_chat_completion_request(body, default_limits());
-        failures += check(!req.preserve_thinking.has_value(),
-                          "preserve_thinking nullopt when omitted");
+        failures +=
+            check(!req.preserve_thinking.has_value(), "preserve_thinking nullopt when omitted");
     }
 
     // Test that preserve_thinking flows through to_prompt_input into ChatRenderOptions
     {
-        const Json body = {
-            {"model", "m"},
-            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
-            {"preserve_thinking", true}};
-        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const Json body                  = {{"model", "m"},
+                                            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+                                            {"preserve_thinking", true}};
+        const GenerationRequest req      = parse_chat_completion_request(body, default_limits());
         const ninfer::PromptInput prompt = translate(req);
         failures += check(prompt.options.preserve_thinking == true,
                           "preserve_thinking reaches ChatRenderOptions via translate");
@@ -582,11 +578,10 @@ int test_parse_preserve_thinking() {
     // Test server default fallback when per-request value is nullopt
     {
         ServeOptions server;
-        server.preserve_thinking = true;
-        const Json body = {
-            {"model", "m"},
-            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
-        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        server.preserve_thinking         = true;
+        const Json body                  = {{"model", "m"},
+                                            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const GenerationRequest req      = parse_chat_completion_request(body, default_limits());
         const ninfer::PromptInput prompt = to_prompt_input(req, server, fake_media);
         failures += check(prompt.options.preserve_thinking == true,
                           "server preserve_thinking default applied when request omits field");

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -532,6 +532,69 @@ int test_finish_reason_wire() {
     return failures;
 }
 
+int test_parse_preserve_thinking() {
+    int failures = 0;
+
+    // Test that preserve_thinking: true is parsed into GenerationRequest
+    {
+        const Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+            {"preserve_thinking", true}};
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        failures += check(req.preserve_thinking.has_value() && *req.preserve_thinking == true,
+                          "preserve_thinking true parsed");
+    }
+
+    // Test that preserve_thinking: false is parsed
+    {
+        const Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+            {"preserve_thinking", false}};
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        failures += check(req.preserve_thinking.has_value() && *req.preserve_thinking == false,
+                          "preserve_thinking false parsed");
+    }
+
+    // Test that when omitted, it defaults to std::nullopt
+    {
+        const Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        failures += check(!req.preserve_thinking.has_value(),
+                          "preserve_thinking nullopt when omitted");
+    }
+
+    // Test that preserve_thinking flows through to_prompt_input into ChatRenderOptions
+    {
+        const Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+            {"preserve_thinking", true}};
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const ninfer::PromptInput prompt = translate(req);
+        failures += check(prompt.options.preserve_thinking == true,
+                          "preserve_thinking reaches ChatRenderOptions via translate");
+    }
+
+    // Test server default fallback when per-request value is nullopt
+    {
+        ServeOptions server;
+        server.preserve_thinking = true;
+        const Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const ninfer::PromptInput prompt = to_prompt_input(req, server, fake_media);
+        failures += check(prompt.options.preserve_thinking == true,
+                          "server preserve_thinking default applied when request omits field");
+    }
+
+    return failures;
+}
+
 } // namespace
 
 int main() {
@@ -551,6 +614,7 @@ int main() {
     failures += test_tool_chunk_serialization();
     failures += test_models_and_error();
     failures += test_finish_reason_wire();
+    failures += test_parse_preserve_thinking();
     if (failures == 0) { std::cout << "ok\n"; }
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Problem

Every new user message in a multi-turn conversation causes a full prefix cache miss, so TTFT grows with context on every turn after the first (observed ~6-7s at ~50k tokens, worse as context grows). Agent tool-loops within a single turn hit cache fine — it's specifically the **user-turn boundary** that invalidates the prefix.

**Root cause:** The chat template keeps thinking content only for assistant messages rendered *after* the last user query:

```cpp
// src/targets/qwen3_6/impl/frontend/chat_template.cpp
const bool keep_thinking = options.preserve_thinking || (i > last_query_index);
```

On turn N+1, all prior assistant messages sit *before* `last_query_index`, so their thinking blocks are stripped from the re-rendered prompt. But the KV cache from turn N was built with those thinking tokens present → the prefix token sequence no longer matches → full cache miss, and the entire conversation (thinking + tool history) must be re-prefilled.

**Why this was unfixable before:** the engine renderer already supported `preserve_thinking`, but the serve layer hardcoded it off with no way to reach it:

```cpp
// src/serve/translate.cpp (pre-fix)
input.options.preserve_thinking = false;   // always false, no CLI flag, no request field
```

There was no branch point to enable the existing engine capability from a running server — the only options were editing code and rebuilding.

## Fix

Plumb the engine's existing `preserve_thinking` option through the serve layer: a `--preserve-thinking` server flag plus a per-request JSON extension, resolved with `value_or()` so per-request overrides the server default. When enabled, thinking blocks are kept in the rendered prompt across user turns, so the prefix token sequence stays identical and the cache hits.

### Server flag

```bash
ninfer-serve model.ninfer --preserve-thinking
```

### Per-request override (OpenAI Chat Completions)

```json
{
  "model": "qwen3.6-27b",
  "messages": [{"role": "user", "content": "hello"}],
  "preserve_thinking": true
}
```

When omitted, falls back to the server default (`--preserve-thinking` at startup). `anthropic_schema.cpp` intentionally leaves the field as `nullopt` — the Anthropic API has no equivalent concept, so it uses the server default.

### Changes

| File | Change |
|---|---|
| `serve_options.h/cpp` | `bool preserve_thinking` field + `--preserve-thinking` CLI flag |
| `request.h` | `std::optional<bool> preserve_thinking` on `GenerationRequest` |
| `translate.cpp` | Resolves request value with server default via `value_or()` |
| `generation_service.h/cpp` | Carries resolved value in `PreparedRequest` |
| `request_log.h/cpp` | Logs `preserve_thinking` status (console + JSONL) |
| `openai_schema.cpp` | Parses per-request `preserve_thinking` boolean |
| `anthropic_schema.cpp` | Leaves as `nullopt` (Anthropic API has no equivalent; uses server default) |
| `docs/serving.md` | Documents extension + server option |
| `tests/test_openai_schema.cpp` | Schema test: parsing, translate flow, server fallback |

### Evidence

Before (without `--preserve-thinking`):

```
req 1286  USER  prompt=47,843  cache=0       0.0%   6371ms  COLD
req 1287  USER  prompt=49,780  cache=49,465  99.4%  161ms   HIT
```

After (with `--preserve-thinking`):

```
req 2  prompt=120,537  cache=120,523  100%   423ms  HIT
req 3  prompt=120,712  cache=120,535  99.9%  441ms  HIT
req 4  prompt=120,894  cache=120,874  99.98% 419ms  HIT
```

Verified on RTX 5090 with Qwen3.6-27B nvfp4, deployed as systemd service.
