### PR TITLE
fix(vision): remove the cumulative attention_pairs budget

### DIFF
--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/prepared_prompt.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/prepared_prompt.h
@@ -49,7 +49,7 @@ struct PrepareStats {
     std::size_t media_items       = 0;
     std::uint64_t raw_patches     = 0;
     std::uint64_t vision_tokens   = 0;
-    std::uint64_t attention_pairs = 0;
+    std::uint64_t attention_pairs = 0; // Informational; not enforced against any budget.
     std::size_t patch_bytes       = 0;
 };
 

--- a/src/targets/qwen3_6/impl/frontend/processor.cpp
+++ b/src/targets/qwen3_6/impl/frontend/processor.cpp
@@ -404,10 +404,6 @@ void enforce_budget(const PreprocessStats& stats, const ProcessorOptions& option
         throw ProcessorError(ProcessorErrorKind::BudgetExceeded,
                              "vision tokens exceed processor budget");
     }
-    if (stats.attention_pairs > options.max_attention_pairs) {
-        throw ProcessorError(ProcessorErrorKind::BudgetExceeded,
-                             "vision attention pairs exceed processor budget");
-    }
     if (stats.prompt_tokens > options.max_prompt_tokens) {
         throw ProcessorError(ProcessorErrorKind::BudgetExceeded,
                              "prompt tokens exceed processor budget");

--- a/src/targets/qwen3_6/impl/frontend/processor.h
+++ b/src/targets/qwen3_6/impl/frontend/processor.h
@@ -80,7 +80,6 @@ struct ProcessorOptions {
     std::size_t max_media_items            = 16;
     std::uint64_t max_raw_patches          = 131'072;
     std::uint64_t max_vision_tokens        = 32'768;
-    std::uint64_t max_attention_pairs      = 128ULL * 1024ULL * 1024ULL;
     std::size_t max_prompt_tokens          = 32'768;
     double video_fps                       = 2.0;
     int video_min_frames                   = 4;

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -146,6 +146,31 @@ std::vector<std::uint8_t> gradient_ppm() {
     return ppm;
 }
 
+std::vector<std::uint8_t> block_ppm(int width, int height, std::uint8_t seed) {
+    std::vector<std::uint8_t> ppm;
+    const std::string header =
+        "P6\n" + std::to_string(width) + " " + std::to_string(height) + "\n255\n";
+    for (const char byte : header) {
+        ppm.push_back(static_cast<std::uint8_t>(static_cast<unsigned char>(byte)));
+    }
+    for (std::size_t index = 0; index < static_cast<std::size_t>(width) * height; ++index) {
+        ppm.push_back(static_cast<std::uint8_t>((index + seed) & 0xff));
+        ppm.push_back(static_cast<std::uint8_t>((index * 3 + seed) & 0xff));
+        ppm.push_back(static_cast<std::uint8_t>((index * 7 + seed) & 0xff));
+    }
+    return ppm;
+}
+
+ninfer::MessagePart ppm_image_part(int width, int height, std::uint8_t seed) {
+    ninfer::MessagePart image;
+    image.kind              = ninfer::MessagePartKind::Media;
+    image.media.kind        = ninfer::MediaKind::Image;
+    image.media.bytes       = block_ppm(width, height, seed);
+    image.media.media_type  = "image/x-portable-pixmap";
+    image.media.source_name = "inline.ppm";
+    return image;
+}
+
 ninfer::PromptInput image_input() {
     ninfer::MessagePart image;
     image.kind              = ninfer::MessagePartKind::Media;
@@ -630,6 +655,41 @@ int test_video_prepare(const Frontend& frontend) {
     return failures;
 }
 
+int test_multi_image_attention_pairs_not_enforced(const Frontend& frontend) {
+    // The removed attention_pairs guard rejected media requests whose cumulative
+    // t*(h*w)^2 exceeded 128 Mi. Two 2048x1600 images sum to ~328M pairs and must
+    // now prepare cleanly, with the statistic still reported (informational only).
+    constexpr std::uint64_t old_attention_cap = 128ULL * 1024ULL * 1024ULL;
+    ninfer::ChatMessage message;
+    message.role = "user";
+    message.parts.push_back(ppm_image_part(2048, 1600, 11));
+    message.parts.push_back(ppm_image_part(2048, 1600, 97));
+    ninfer::PromptInput input;
+    input.messages.push_back(std::move(message));
+
+    int failures = 0;
+    try {
+        auto prepared    = frontend.prepare(std::move(input));
+        const auto& data = FrontendFactory::inspect(prepared);
+        failures += check(data.vision_items.size() == 2,
+                          "multi-image prepare did not retain both vision items");
+        std::uint64_t expected_pairs = 0;
+        for (const auto& item : data.vision_items) {
+            const std::uint64_t spatial =
+                static_cast<std::uint64_t>(item.grid.height) * item.grid.width;
+            expected_pairs += static_cast<std::uint64_t>(item.grid.temporal) * spatial * spatial;
+        }
+        failures += check(data.prepare.attention_pairs == expected_pairs,
+                          "multi-image prepare misreported the attention_pairs statistic");
+        failures += check(expected_pairs > old_attention_cap,
+                          "multi-image fixture no longer exceeds the removed 128 Mi cap");
+    } catch (const std::exception& error) {
+        std::cerr << "multi-image prepare threw after guard removal: " << error.what() << '\n';
+        ++failures;
+    }
+    return failures;
+}
+
 int test_cross_round_stop(const Frontend& frontend) {
     auto prompt = frontend.prepare_tokens({0});
     ninfer::StopPolicy stop;
@@ -801,6 +861,7 @@ int main() {
     failures += test_official_resource_guards();
     failures += test_text_and_image_prepare(frontend);
     failures += test_video_prepare(frontend);
+    failures += test_multi_image_attention_pairs_not_enforced(frontend);
     failures += test_cross_round_stop(frontend);
     failures += test_same_token_stop_priority(frontend);
     failures += test_terminal_flush(frontend);


### PR DESCRIPTION
> made by a coding agent running on ninfer/qwen3.8-27b

## Problem

`ProcessorOptions.max_attention_pairs` rejects ordinary single-image requests on a Vision-enabled
server. Minimal reproduction: one 2560×1440 (or larger) screenshot in a single
`POST /v1/chat/completions` message is rejected before the request reaches the scheduler, with an
HTTP body of a few MiB and a prompt of a few thousand tokens. The client sees a `413`
(`request_too_large`) even though the payload is tiny.

The cap is `128 Mi` pairs and the accumulated quantity is `t·(h·w)²`, so a single image is rejected
once `h·w > sqrt(134217728) ≈ 11585` patches. At the 16×16 px effective patch pitch of this
processor that is **≈2.97 Mpx** — while the same model's `preprocessor_config.json` sets
`size.longest_edge = 16777216`, i.e. it permits **16 Mpx (65536 patches) per image** and resizes
anything larger down to that. The frontend budget therefore contradicts the model's own
configuration by 5.4× in pixels and 32× in pairs, and rejects every screenshot at 1440p or above
(1080p = ~65.6M pairs passes; 1440p = ~207M pairs fails).

Because the value is summed across items rather than taken per item, an ordinary multi-image
conversation reaches the cap even faster: the second or third 1080p image tips a request over even
though each image individually passed. This is the "first image works, the next one breaks" symptom.

## Root cause

`enforce_budget()` (`src/targets/qwen3_6/impl/frontend/processor.cpp`) compares the cumulative
`stats.attention_pairs` against a compile-time constant:

```cpp
stats.attention_pairs += t * (h*w) * (h*w);              // accumulated per item
...
if (stats.attention_pairs > options.max_attention_pairs) // 128 Mi, compile-time only
    throw ProcessorError(BudgetExceeded, "vision attention pairs exceed processor budget");
```

The quantity bounds neither of the two resources the engine actually reserves, and both of those
are already checked exactly, per item, elsewhere:

1. **Peak vision memory is per item, and is already admitted exactly.**
   `VisionContext::encode` takes exactly one item per call
   (`src/targets/qwen3_6/impl/runtime/vision_context_impl.h:203`), the session resets the workspace
   between items (`:408`), and requires strictly increasing item order (`:388`). Accordingly the plan
   sizes the output transient from `max_merged` — the largest item, not the sum
   (`src/targets/qwen3_6/impl/runtime/request_plan_impl.h:143-144`) — and admits each item against
   the real envelope with `if (VisionContext::workspace_bytes(item) > work.capacity()) throw ...`
   (`request_plan_impl.h:138-140`). A cumulative frontend proxy cannot improve on a per-item byte
   comparison against the actual workspace capacity.

2. **Vision attention memory is linear in patches, not quadratic.** The packed attention Op
   allocates only tile descriptors: `scratch_tiles()` is `ceil(patches/64) + segments - 1`
   (`src/ops/wrapper/vision_attention.cpp:18-30`), so no `n²` score matrix is ever materialised.
   `attention_pairs` tracks FLOPs, and FLOPs are not the resource that fails.

The remaining vision budgets do bound the reserved resources and are unchanged:
`max_raw_patches = 131072` and `max_vision_tokens = 32768` (four patches per token) together cap a
request at the equivalent of two maximum-size images, `max_media_items = 16` caps the item count,
and `max_decoded_pixels = 64 Mi` caps decode.

The option is also not reachable by configuration: `processor_options()`
(`src/targets/qwen3_6/impl/frontend/frontend.cpp`) populates only the pixel and video-frame fields
from the preprocessor config; every other budget keeps its compile-time default, and there is no CLI
surface for any of them.

The reference tooling already treats this quantity as informational. `attention_limit` in
`tools/reference/qwen3_6_27b/vision.py` defaults to `None`, is enforced only when set, and **no
caller anywhere in the repository sets it**; the reference's actual admission test is
`_estimate_peak(patches)` against free device memory, which is linear in patches. This change makes
the C++ path agree with that: always compute `attention_pairs`, never enforce it.

## Change

Remove the enforcement branch and the `max_attention_pairs` member — 5 deleted lines across
`processor.h` / `processor.cpp`, no logic additions. Also:

- Add a regression test, `test_multi_image_attention_pairs_not_enforced`
  (`tests/targets/qwen3_6/test_frontend.cpp`), which prepares a two-image request whose cumulative
  `attention_pairs` is ~2.4× the removed cap and asserts it succeeds with the statistic still
  reported (synthetic fixtures, no model files required).
- Mark the exported `PrepareStats::attention_pairs` field as informational
  (`prepared_prompt.h`): `// Informational; not enforced against any budget.`

`attention_pairs` is kept as a reported statistic: `PreprocessStats`, its `add_budget()`
accumulation, the `summary()` line, the exported field and its assignment in `frontend.cpp`, and the
reference/parity tooling are all untouched, so no public ABI, artifact, or tooling contract changes.

A configurable limit was considered and rejected. No caller in this repository sets the reference's
optional `attention_limit`, no processor budget has a CLI surface today, and a per-item byte
comparison against the real workspace capacity already exists at admission — so a new option would be
an unused knob whose only correct value is "off".

## Affected behaviour and contract

- `POST /v1/chat/completions` (and the other chat entry points) with vision content: images between
  ~2.97 Mpx and the model's configured 16 Mpx ceiling, and multi-image requests whose *sum* of
  `t·(h·w)²` exceeded `128 Mi`, now proceed instead of being rejected. Requests are still bounded by
  `max_media_items`, `max_raw_patches`, `max_vision_tokens`, `max_decoded_pixels`, the per-item
  workspace admission above, and the context window.
- `ProcessorOptions` loses `max_attention_pairs`. `PreprocessStats::attention_pairs` and the
  exported `PrepareStats::attention_pairs` are unchanged (the latter now documented as informational).
- No active documentation references the removed option (checked `docs/`), so nothing else required
  updating with this change.

## Verification

Hardware/toolchain: RTX 5090 (32 GB) under WSL2 (Ubuntu 24.04), CUDA 13.3, Ninja.
Model: `qwen3.8-27b` NInfer `groupwise-int` artifact.
Server: `--max-context 262144 --kv-dtype int8 --vision --max-concurrency 2 --spec mtp --draft-tokens 3`.
Branch is based on `Neroued/ninfer@master` (`9005987`); the same change was applied to the build tree
serving these requests and rebuilt there.

Build, format, and unit tests:

```
cmake --build build -j16                                  # all targets
clang-format --dry-run --Werror \
  src/targets/qwen3_6/impl/frontend/processor.{h,cpp} \
  src/targets/qwen3_6/export/ninfer/targets/qwen3_6/prepared_prompt.h \
  tests/targets/qwen3_6/test_frontend.cpp                  # clean (clang-format 18.1.3)
./build/tests/ninfer_serve_options_test                    # ok (exit 0)
./build/tests/ninfer_qwen3_6_frontend_test                 # ok (exit 0)
```

The new `test_multi_image_attention_pairs_not_enforced` passes, and the suite is negative-checked:
temporarily restoring the guard makes it fail with `vision attention pairs exceed processor budget`.

End-to-end, against the running server:

| Request | Result |
| --- | --- |
| 3440×1440 single image (≈3.7×10⁸ pairs, 2.8× the removed cap; previously `413`) | `200` |
| 3440×1440 + 3744×4016 in one request (≈3.9×10⁹ pairs, 29× the removed cap) | `200` |
| 4000×4000 = 16.0 Mpx (62 464 patches, ≈3.9×10⁹ pairs) | `200` |
| 8000×8000 = 64.0 Mpx, resized to the configured 16 Mpx ceiling (65 504 patches — the largest single item this configuration produces) | `200` |
| 9000×9000 = 81.0 Mpx (above `max_decoded_pixels = 64 Mi`) | rejected before decode |
| 17 items (above `max_media_items = 16`) | rejected |
| Text prompt of ≈3.4×10⁵ tokens (above `--max-context`) | `400 context_length_exceeded` |

The 8000×8000 case is the boundary that matters: after this change the largest single vision item
the model configuration admits is 65 536 patches, and `max_raw_patches` still caps a request at two
of them. That workload is accepted and served normally, and the service remained `active` with
`NRestarts=0` and `/v1/models` serving throughout.

Checks that could not be run, and why:

- One test in `ninfer_qwen3_6_frontend_test` loads a hard-coded absolute model path
  (`tests/targets/qwen3_6/test_frontend.cpp:206-210`) that exists only on the maintainer's machine;
  it was skipped locally and the remainder of the suite ran clean. This is environmental and predates
  the change.

## Related defects found while diagnosing (not fixed here)

These are separate from this change and are reported for completeness because they affect how the
symptom above is observed; each warrants its own fix.

1. **Every application `413` is relabelled.** `HttpServer::register_routes()` installs an httplib
   error handler that rewrites the body of any response with status `413`
   (`src/serve/http_server.cpp:186-194`), and httplib invokes it for every status `>= 400`
   (`third_party/cpp-httplib/httplib.h`). Since `MediaBudgetExceeded` maps to `413`
   (`src/serve/generation_service.cpp:179-181`), the `media_budget_exceeded` code is unreachable in
   practice: clients receive `request_too_large` / "request body exceeds the configured payload
   limit" instead. Confirmed with a **3 000-byte** request body carrying 17 one-pixel images.
2. **A multimodal prompt is capped at 32 768 tokens regardless of `--max-context`.**
   `Frontend::prepare()` constructs the processor with the default `max_prompt_tokens`
   (`frontend.cpp`), while text-only prompts bypass the processor entirely. On a server started
   with `--max-context 262144`, a ~40 000-token text prompt returns `200`, and the byte-identical
   request with a single 1×1 image attached is rejected. `Frontend::count_prompt_tokens()` already
   disables this budget for the media path (`frontend.cpp`). This is very likely the other half of
   the "second/third image in a long conversation fails" symptom.
3. **Budget rejections are not logged.** They are thrown during frontend preparation, before
   scheduler admission, so none of the rejections above produced any line in the request journal or
   the service log.

## AI-assistance disclosure

- **Implementation and initial end-to-end validation** were produced by a coding agent running on
  NInfer serving `qwen3.8-27b` (the server under test).
- **Independent review, additional verification, and the primary description** — the
  pixel-threshold arithmetic, the 4000×4000 / 8000×8000 / 9000×9000 boundary probes, the per-item
  workspace-admission and linear-attention analysis, the three related defects above, and the
  3 000-byte `413`-clobber proof — were produced by a second reviewer, **Claude Opus 5**
  (`claude-opus-5`).
- **Independent review and additional verification** — the 32 768-token media-cap boundary probe,
  the `413`-clobber reproduction on the rebuilt binary, the runnable regression test
  (`test_multi_image_attention_pairs_not_enforced`) and its negative check, and running the frontend
  suite with the hard-coded-path test skipped — were produced by a third reviewer, **Qwen3.8-Max**
  (`qwen3.8-max`).

The diff is a 5-line removal plus one regression test and one comment, reviewed line by line; every
claim above is either arithmetic from the quoted formula or a measurement listed in the verification
table.