### PR TITLE
feat(serve): advertise configured model context in models api

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -54,6 +54,39 @@ cannot be combined with `--vision`. A later request cannot enable a capability o
 | `POST /v1/messages` | Anthropic-style message generation |
 | `POST /v1/messages/count_tokens` | checkpoint-native expanded input-token count |
 
+### Models
+
+`GET /v1/models` returns a `list` object holding a single `data` entry, and
+`GET /v1/models/{id}` returns that same model object directly. Both describe the
+one registered artifact's public model ID: the artifact `identity.model_id` by
+default, or the explicit `--model-id` override. A `GET /v1/models/{id}` request
+for any other ID returns HTTP 404 with code `model_not_found`.
+
+Each model object is:
+
+```json
+{
+  "id": "qwen3.6-27b",
+  "object": "model",
+  "created": 1786813490,
+  "owned_by": "ninfer",
+  "max_model_len": 16384
+}
+```
+
+- `id` — the public model ID, identical to the `model` value the other OpenAI
+  endpoints require.
+- `object` — always `"model"`.
+- `created` — the server's current unix time in seconds at request time.
+- `owned_by` — always `"ninfer"`.
+- `max_model_len` — the process's configured context window in tokens, exactly the
+  `--max-context` value used to size every sequence. It is a per-server property,
+  not a per-model one: the `list` and single-object forms report the same value,
+  and it does not change with the request. Clients using these endpoints for
+  context discovery should treat `max_model_len` as the hard per-sequence ceiling;
+  `--kv-capacity` is a separate limit that sizes the shared KV pool and is not
+  advertised here.
+
 ## OpenAI Chat Completions
 
 ```bash

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -300,7 +300,8 @@ void HttpServer::register_routes() {
 }
 
 void HttpServer::handle_models(const httplib::Request&, httplib::Response& res) const {
-    res.set_content(make_models_list(public_model_id_, unix_time_now()), "application/json");
+    res.set_content(make_models_list(public_model_id_, unix_time_now(), options_.max_context),
+                    "application/json");
 }
 
 void HttpServer::handle_model(const httplib::Request& req, httplib::Response& res) const {
@@ -314,7 +315,8 @@ void HttpServer::handle_model(const httplib::Request& req, httplib::Response& re
         write_error(res, error);
         return;
     }
-    res.set_content(make_model_object(public_model_id_, unix_time_now()), "application/json");
+    res.set_content(make_model_object(public_model_id_, unix_time_now(), options_.max_context),
+                    "application/json");
 }
 
 void HttpServer::handle_chat_completions(const httplib::Request& req, httplib::Response& res) {

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -675,18 +675,24 @@ std::string make_chat_chunk_usage(const std::string& id, const std::string& mode
 
 std::string sse_done() { return "data: [DONE]\n\n"; }
 
-std::string make_models_list(const std::string& model_id, std::int64_t created) {
+std::string make_models_list(const std::string& model_id, std::int64_t created,
+                             std::uint32_t max_model_len) {
     const Json payload = {{"object", "list"},
                           {"data", Json::array({Json{{"id", model_id},
                                                      {"object", "model"},
                                                      {"created", created},
-                                                     {"owned_by", "ninfer"}}})}};
+                                                     {"owned_by", "ninfer"},
+                                                     {"max_model_len", max_model_len}}})}};
     return payload.dump();
 }
 
-std::string make_model_object(const std::string& model_id, std::int64_t created) {
-    const Json payload = {
-        {"id", model_id}, {"object", "model"}, {"created", created}, {"owned_by", "ninfer"}};
+std::string make_model_object(const std::string& model_id, std::int64_t created,
+                              std::uint32_t max_model_len) {
+    const Json payload = {{"id", model_id},
+                          {"object", "model"},
+                          {"created", created},
+                          {"owned_by", "ninfer"},
+                          {"max_model_len", max_model_len}};
     return payload.dump();
 }
 

--- a/src/serve/openai_schema.h
+++ b/src/serve/openai_schema.h
@@ -65,9 +65,11 @@ std::string make_chat_chunk_usage(const std::string& id, const std::string& mode
                                   std::int64_t created, const CompletionUsage& usage);
 std::string sse_done();
 
-// /v1/models payloads.
-std::string make_models_list(const std::string& model_id, std::int64_t created);
-std::string make_model_object(const std::string& model_id, std::int64_t created);
+// /v1/models payloads. max_model_len is the process's configured context window.
+std::string make_models_list(const std::string& model_id, std::int64_t created,
+                             std::uint32_t max_model_len);
+std::string make_model_object(const std::string& model_id, std::int64_t created,
+                              std::uint32_t max_model_len);
 
 // Error object body.
 std::string make_error_body(const ApiError& error);

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -660,15 +660,20 @@ int test_tool_chunk_serialization() {
 
 int test_models_and_error() {
     int failures    = 0;
-    const Json list = Json::parse(make_models_list("qwen3.6-27b", 1));
+    constexpr std::uint32_t configured_context = 131072;
+    const Json list = Json::parse(make_models_list("qwen3.6-27b", 1, configured_context));
     failures += check(list.at("object") == "list", "models list object");
     failures += check(list.at("data").at(0).at("id") == "qwen3.6-27b", "models list id");
     failures += check(list.at("data").at(0).at("object") == "model", "models list entry object");
     failures += check(list.at("data").at(0).at("owned_by") == "ninfer", "models list owner");
+    failures += check(list.at("data").at(0).at("max_model_len") == configured_context,
+                      "models list configured context");
 
-    const Json one = Json::parse(make_model_object("qwen3.6-27b", 1));
+    const Json one = Json::parse(make_model_object("qwen3.6-27b", 1, configured_context));
     failures += check(one.at("id") == "qwen3.6-27b" && one.at("object") == "model", "model object");
     failures += check(one.at("owned_by") == "ninfer", "model owner");
+    failures += check(one.at("max_model_len") == configured_context,
+                      "model object configured context");
 
     ApiError error;
     error.status   = 400;


### PR DESCRIPTION
## Summary
- include `max_model_len` in native `/v1/models` and `/v1/models/{id}` entries
    - This is inline with what llama.cpp & vllm exposes in their models response 
- source the value from the same parsed `--max-context` configuration used for inference