### PR TITLE
feat(serve): add Ollama-compatible chat endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,8 +109,9 @@ a small set of explicitly registered checkpoint artifacts. The supported identit
 `qwen3.6-27b/groupwise-int`, `qwen3.6-27b/nvfp4`, `qwen3.8-27b/groupwise-int`,
 `qwen3.8-27b/nvfp4`, and `qwen3.6-35b-a3b/groupwise-int`. The current implementation is compiled
 for `sm_120a` and tuned and measured on NVIDIA GeForce RTX 5090. All identities execute Text,
-image/video Vision, MTP, prefix reuse, CLI, OpenAI/Anthropic serving, and measurement through the
-same public `.ninfer` Engine route; the 35B-A3B target additionally supports text-only DFlash.
+image/video Vision, MTP, prefix reuse, CLI, OpenAI/Anthropic/Ollama serving, and measurement
+through the same public `.ninfer` Engine route; the 35B-A3B target additionally supports
+text-only DFlash.
 
 The current workload is one GPU and one resident model instance with a startup-fixed one to eight
 active requests. The Engine forms one compact decode batch at every round boundary and uses bounded
@@ -154,7 +155,7 @@ routing map, not a mandatory reading list:
 - `README.md` and executable `--help`: delivered capabilities and exact commands;
 - `docs/README.md`: public documentation map;
 - `docs/cli.md`: CLI input, output, sampling, MTP, and runtime options;
-- `docs/serving.md`: OpenAI/Anthropic HTTP behavior;
+- `docs/serving.md`: OpenAI/Anthropic/Ollama HTTP behavior;
 - `docs/performance.md`: published performance methodology and results;
 - `docs/maintainer/concurrent-inference-architecture.md`: bounded ingress, request/slot lifecycle,
   scheduling, batched execution, CUDA Graph, and speculative-concurrency semantics;
@@ -221,8 +222,8 @@ not preserve backward compatibility. When a task replaces project-owned behavior
 obsolete aliases, fallbacks, transition branches, and tests in the affected contract instead of
 maintaining two paths. Do not turn that rule into unrelated repository-wide cleanup.
 
-The advertised OpenAI and Anthropic protocol surfaces are real external contracts. A change to
-their behavior must update the affected schema tests and serving documentation together.
+The advertised OpenAI, Anthropic, and Ollama protocol surfaces are real external contracts. A
+change to their behavior must update the affected schema tests and serving documentation together.
 
 Integrate stable requirements into the existing active reference. Use a temporary dated plan only
 when active work genuinely needs one; a plan is not a substitute for the requested deliverable.
@@ -292,7 +293,7 @@ The following are typical choices, not a cumulative checklist:
 | CUDA math | independent numerical oracle at relevant shapes |
 | memory/lifetime | the affected execution; sanitizer only for a concrete lifetime risk |
 | performance | measurement at the claimed scope; attribution tools only when needed |
-| serving | affected OpenAI/Anthropic schema tests and observable request/stream behavior |
+| serving | affected OpenAI/Anthropic/Ollama schema tests and observable request/stream behavior |
 
 Do not replace weak verification with low-value tests. State clearly when a relevant check could not
 run and why.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NInfer is a from-scratch C++/CUDA inference engine for explicitly registered Qwen checkpoints on a
 single NVIDIA GeForce RTX 5090. It runs text, image, and video prompts through a local CLI or
-OpenAI-/Anthropic-compatible HTTP APIs.
+OpenAI-/Anthropic-/Ollama-compatible HTTP APIs.
 
 NInfer deliberately supports a closed set of model artifacts instead of acting as a general model
 runtime:
@@ -288,7 +288,8 @@ curl http://127.0.0.1:8080/v1/chat/completions \
 ```
 
 The server also implements OpenAI Responses Core (typed Items, semantic SSE, local continuation
-state, and function calls) plus Anthropic Messages, token counting, and multimodal input. See
+state, and function calls), Anthropic Messages, token counting, multimodal input, and Ollama chat
+with per-request prefill/decode timings for Ollama clients such as Open WebUI. See
 [HTTP serving](docs/serving.md).
 
 ## Capabilities
@@ -304,8 +305,8 @@ All three registered model IDs support:
 - model- and thinking-mode-aware official sampling defaults, with explicit greedy, temperature,
   top-k, top-p, min-p, and presence/frequency-penalty overrides;
 - compatible-prefix reuse;
-- OpenAI Responses Core, OpenAI Chat Completions, and Anthropic Messages, including streaming and
-  usage accounting;
+- OpenAI Responses Core, OpenAI Chat Completions, Anthropic Messages, and Ollama chat, including
+  streaming and usage accounting;
 - prompt-rendered function tools and parsed tool calls.
 
 The 35B-A3B target additionally supports text-only DFlash speculative decoding with draft windows

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ run the CLI or HTTP server.
 | Document | Purpose |
 |---|---|
 | [CLI](cli.md) | text, chat-history, image/video input, output streams, sampling, MTP, and common runtime options |
-| [HTTP serving](serving.md) | OpenAI Responses/Chat Completions, Anthropic Messages, state, streaming, token counting, authentication, and tool calls |
+| [HTTP serving](serving.md) | OpenAI Responses/Chat Completions, Anthropic Messages, Ollama chat, state, streaming, token counting, authentication, and tool calls |
 | [Performance](performance.md) | RTX 5090 single-request and concurrent-decode results, MTP/DFlash measurements, and reproduction commands |
 | [CLI examples](../examples/cli/) | committed text, multimodal, thinking, long-decode, and long-context inputs |
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -460,13 +460,18 @@ boolean or one of the Ollama levels `low`, `medium`, `high`, and `stream`, which
 effort-capable template exposes `low`, `medium`, and `xhigh`, so `high` returns
 `reasoning_effort_not_supported` (Ollama's vocabulary has no `xhigh`). `options`
 maps `temperature`, `top_p`, `top_k`, `min_p`, `seed`, `presence_penalty`, `frequency_penalty`,
-`stop`, `num_predict` (`-1` and `-2` keep the server default output budget), and `num_ctx`, which
-must not exceed `--max-context`. Sampler options the Engine does not implement (`repeat_penalty`,
-`mirostat*`, `typical_p`, ...) and unknown options are rejected with `option_not_supported`; runner
-options (`num_gpu`, `num_thread`, `use_mmap`, ...) and `keep_alive` are accepted without effect
-because residency is fixed at startup. `format` is rejected because the Engine has no constrained
-decoding. `model` must be the advertised model id or its `:latest` spelling, which Ollama-native
-clients use for untagged names; the response echoes the requested spelling.
+`stop`, `num_predict`, and `num_ctx`. `num_ctx` may narrow, but not widen, the `--max-context`
+window for one request: the expanded prompt must fit it (otherwise HTTP 400
+`context_length_exceeded` at preparation, rather than Ollama's silent prompt truncation) and the
+output budget is clamped to what remains. `num_predict: -1` keeps the server default output budget
+and `-2` fills the request window (`num_ctx` if given, else `--max-context`), ending with
+`done_reason: "length"` when it is reached. Sampler options the Engine does not implement
+(`repeat_penalty`, `mirostat*`, `typical_p`, ...) and unknown options are rejected with
+`option_not_supported`; runner options (`num_gpu`, `num_thread`, `use_mmap`, ...) and `keep_alive`
+are accepted without effect because residency is fixed at startup. `format` is rejected because the
+Engine has no constrained decoding. `model` must be the advertised model id or its `:latest`
+spelling, which Ollama-native clients use for untagged names; the response echoes the requested
+spelling.
 
 An empty `messages` array is Ollama's preload request. It is answered immediately with an empty
 assistant message, `done: true`, and `done_reason: "load"` (never `"unload"`: `keep_alive: 0` has

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -1,7 +1,7 @@
 # HTTP serving
 
-`build/apps/ninfer-serve` loads one registered artifact and exposes OpenAI- and
-Anthropic-compatible HTTP endpoints over one resident NInfer Engine.
+`build/apps/ninfer-serve` loads one registered artifact and exposes OpenAI-, Anthropic-, and
+Ollama-compatible HTTP endpoints over one resident NInfer Engine.
 
 ## Start the server
 
@@ -53,6 +53,11 @@ cannot be combined with `--vision`. A later request cannot enable a capability o
 | `GET /v1/responses/{id}/input_items` | list that Response's normalized input Items |
 | `POST /v1/messages` | Anthropic-style message generation |
 | `POST /v1/messages/count_tokens` | checkpoint-native expanded input-token count |
+| `POST /api/chat` | Ollama-style chat generation with per-request phase timings |
+| `GET /api/tags` | Ollama model list for the resident model |
+| `POST /api/show` | Ollama model details and capabilities |
+| `GET /api/ps` | Ollama loaded-model list |
+| `GET /api/version` | advertised Ollama API level |
 
 ## OpenAI Chat Completions
 
@@ -435,9 +440,83 @@ curl http://127.0.0.1:8080/v1/messages/count_tokens \
   }'
 ```
 
+## Ollama chat
+
+```bash
+curl http://127.0.0.1:8080/api/chat \
+  -d '{
+    "model": "qwen3.6-27b",
+    "messages": [{"role": "user", "content": "Explain MTP in one sentence."}],
+    "stream": false
+  }'
+```
+
+`POST /api/chat` accepts the Ollama chat request: `system`/`user`/`assistant`/`tool` history with
+string content (a `tool` result may be empty), user `images` as bare base64 payloads, assistant
+`thinking` and `tool_calls` with object arguments, OpenAI-shaped function `tools` (a missing
+`parameters` schema defaults to the empty object schema, as on the OpenAI surfaces), `think` as a
+boolean or one of the Ollama levels `low`, `medium`, `high`, and `stream`, which defaults to true.
+`think` levels are checked against the loaded chat template like `reasoning_effort`; the registered
+effort-capable template exposes `low`, `medium`, and `xhigh`, so `high` returns
+`reasoning_effort_not_supported` (Ollama's vocabulary has no `xhigh`). `options`
+maps `temperature`, `top_p`, `top_k`, `min_p`, `seed`, `presence_penalty`, `frequency_penalty`,
+`stop`, `num_predict` (`-1` and `-2` keep the server default output budget), and `num_ctx`, which
+must not exceed `--max-context`. Sampler options the Engine does not implement (`repeat_penalty`,
+`mirostat*`, `typical_p`, ...) and unknown options are rejected with `option_not_supported`; runner
+options (`num_gpu`, `num_thread`, `use_mmap`, ...) and `keep_alive` are accepted without effect
+because residency is fixed at startup. `format` is rejected because the Engine has no constrained
+decoding. `model` must be the advertised model id or its `:latest` spelling, which Ollama-native
+clients use for untagged names; the response echoes the requested spelling.
+
+An empty `messages` array is Ollama's preload request. It is answered immediately with an empty
+assistant message, `done: true`, and `done_reason: "load"` (never `"unload"`: `keep_alive: 0` has
+no effect because the model stays resident); it is not a generation request and does not appear in
+the request log.
+
+A non-streaming reply is one JSON object; a stream is `application/x-ndjson` with one frame per
+line: content deltas in `message.content`, reasoning deltas in `message.thinking`, one
+`message.tool_calls` frame after generation when the model called tools, then a final frame with
+`done: true`, `done_reason` (`stop` or `length`), and the Ollama timing fields:
+
+```json
+{
+  "model": "qwen3.6-27b",
+  "created_at": "2026-08-15T10:00:00.123456789Z",
+  "message": {"role": "assistant", "content": ""},
+  "done": true,
+  "done_reason": "stop",
+  "total_duration": 1250000000,
+  "load_duration": 0,
+  "prompt_eval_count": 40,
+  "prompt_eval_duration": 500000000,
+  "eval_count": 30,
+  "eval_duration": 750000000
+}
+```
+
+Durations are integer nanoseconds. `prompt_eval_count` is the prompt suffix actually computed by
+prefill, excluding the resident prefix reused by the Engine, and `prompt_eval_duration` is that
+prefill phase; `eval_count` is the number of accepted generated token IDs and `eval_duration` is
+the decode phase that follows the first token. These are the same phase boundaries as
+`request_done.timings_seconds` in the structured request log, so `prompt_eval_count /
+prompt_eval_duration` is the log's prefill rate and `eval_count / eval_duration` is the rate Ollama
+clients such as Open WebUI display; the log's own decode rate divides `completion_tokens - 1` by
+the same phase because the first token is produced by prefill, so `eval_count / eval_duration`
+reads slightly higher for short outputs (and is undefined for a single-token reply, where
+`eval_duration` is `0`), exactly as it does for Ollama's llama.cpp runner. `load_duration` is
+always `0` because the model is resident, and `total_duration` includes CPU/media preparation.
+
+The read-only inventory endpoints describe the one resident model: `GET /api/tags` lists it with
+its artifact size, artifact timestamp, target family, and weight profile; `POST /api/show` (with
+`model` or legacy `name`) adds `model_info` with the frozen context length and the `completion`,
+`tools`, `vision` (only with `--vision`), and `thinking` capabilities; `GET /api/ps` reports it as
+loaded with its resident weight bytes; `GET /api/version` returns the advertised Ollama API level.
+Model management (`pull`, `push`, `create`, `copy`, `delete`), `/api/generate`, and embeddings are
+not served. Errors use the Ollama `{"error": "..."}` body.
+
 ## Authentication and CORS
 
-Pass `--api-key VALUE` to require the same value as an OpenAI bearer token or Anthropic
+Pass `--api-key VALUE` to require the same value as an OpenAI or Ollama bearer token or Anthropic
 `x-api-key` header. `GET /health` and CORS preflight requests remain unauthenticated.
 
 ```bash
@@ -534,8 +613,8 @@ derived downstream from raw token counts and seconds instead of rounded stderr s
 The JSONL file contains no generated response text and never records an API-key value; `argv`
 replaces that value with `<redacted>`. The existing stderr summaries remain available for operators
 but are rounded and are not the aggregation source. Console lines use local
-`[YYYY-MM-DD HH:MM:SS.mmm] [level]` timestamps. OpenAI Responses, OpenAI Chat, and Anthropic
-generation requests receive a request ID when they enter synchronous preparation. Successful
+`[YYYY-MM-DD HH:MM:SS.mmm] [level]` timestamps. OpenAI Responses, OpenAI Chat, Anthropic, and
+Ollama generation requests receive a request ID when they enter synchronous preparation. Successful
 preparation produces `request_start`; a preparation failure produces `request_rejected` without a
 matching start. Later generation failures produce `request_error`. Schema/model validation
 rejections before preparation and token-count-only calls are not measurement requests and do not

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -325,6 +325,7 @@ if(NINFER_BUILD_SERVE)
     serve/openai_schema.cpp
     serve/responses_schema.cpp
     serve/anthropic_schema.cpp
+    serve/ollama_schema.cpp
     serve/response_store.cpp
     serve/tool_call_parser.cpp
     serve/translate.cpp

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -308,6 +308,25 @@ PreparedRequest GenerationService::prepare(const GenerationRequest& request,
         check_preparation_control(prepared.lifetime->deadline, is_cancelled);
         prepared.prompt_tokens = static_cast<int>(prompt.summary().prompt_tokens);
         prepared.preparation   = prompt.preparation_stats();
+        if (request.context_window > 0) {
+            // Same accounting as the Engine's own capacity clamp: the last generated
+            // token needs no context slot, so prompt + output - 1 must fit the window.
+            if (prepared.prompt_tokens > request.context_window) {
+                ApiError error;
+                error.status  = 400;
+                error.type    = "invalid_request_error";
+                error.code    = "context_length_exceeded";
+                error.param   = request.context_window_param;
+                error.message = "prompt of " + std::to_string(prepared.prompt_tokens) +
+                                " tokens exceeds the requested context window of " +
+                                std::to_string(request.context_window) + " tokens";
+                throw ApiException(std::move(error));
+            }
+            const auto remaining =
+                static_cast<std::uint32_t>(request.context_window - prepared.prompt_tokens + 1);
+            request_options.execution.requested_output_tokens =
+                std::min(request_options.execution.requested_output_tokens, remaining);
+        }
         prepared.prepare_seconds =
             std::chrono::duration<double>(Clock::now() - prepared.lifetime->started).count();
         prepared.generation = engine_->submit(std::move(prompt), std::move(request_options),

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -8,11 +8,14 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <exception>
+#include <filesystem>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -61,12 +64,29 @@ void write_messages_error(httplib::Response& res, const ApiError& error) {
     res.set_content(make_messages_error_body(error), "application/json");
 }
 
-void write_exception(httplib::Response& res, const std::exception& ex) {
+// Ollama-shaped error body ({"error":"..."}), used by the /api/* endpoints.
+void write_ollama_error(httplib::Response& res, const ApiError& error) {
+    res.status = error.status;
+    res.set_content(make_ollama_error_body(error), "application/json");
+}
+
+// Render an error in the shape the target endpoint speaks.
+void write_error_for_path(const std::string& path, httplib::Response& res, const ApiError& error) {
+    if (path.rfind("/v1/messages", 0) == 0) {
+        write_messages_error(res, error);
+    } else if (path.rfind("/api/", 0) == 0) {
+        write_ollama_error(res, error);
+    } else {
+        write_error(res, error);
+    }
+}
+
+ApiError make_internal_error(std::string message) {
     ApiError error;
     error.status  = 500;
     error.type    = "internal_error";
-    error.message = ex.what();
-    write_error(res, error);
+    error.message = std::move(message);
+    return error;
 }
 
 std::string sse_error_event(const ApiError& error) {
@@ -101,6 +121,38 @@ std::string_view unstreamed_content(const GenerationOutcome& outcome) {
     return std::string_view(outcome.text).substr(outcome.streamed_content_bytes);
 }
 
+std::string artifact_modified_at(const std::string& path) {
+    std::error_code ec;
+    const std::filesystem::file_time_type written = std::filesystem::last_write_time(path, ec);
+    if (ec) { return ollama_timestamp(0); }
+    const auto system_time = std::chrono::clock_cast<std::chrono::system_clock>(written);
+    return ollama_timestamp(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(system_time.time_since_epoch())
+            .count());
+}
+
+std::uint64_t artifact_size_bytes(const std::string& path) {
+    std::error_code ec;
+    const std::uintmax_t size = std::filesystem::file_size(path, ec);
+    return ec ? 0 : static_cast<std::uint64_t>(size);
+}
+
+OllamaTimings ollama_timings(const GenerationOutcome& outcome) {
+    // Same phase decomposition as the request log: prompt_eval covers the prompt
+    // suffix actually computed by prefill (prefix-cache hits excluded); eval covers
+    // every accepted generated token, timed by the decode phase.
+    const GenerationMetrics& metrics = outcome.metrics;
+    return OllamaTimings{
+        .total_seconds       = metrics.total_seconds,
+        .load_seconds        = 0.0,
+        .prompt_eval_seconds = metrics.prefill_seconds,
+        .eval_seconds        = metrics.decode_seconds,
+        .prompt_eval_count =
+            std::max(0, outcome.prompt_tokens - static_cast<int>(metrics.prefix_cache_hit_tokens)),
+        .eval_count = outcome.completion_tokens,
+    };
+}
+
 } // namespace
 
 httplib::Server::HandlerResponse handle_unrendered_http_error(const ServeOptions& options,
@@ -116,11 +168,7 @@ httplib::Server::HandlerResponse handle_unrendered_http_error(const ServeOptions
     error.code    = "request_too_large";
     error.message = "request body exceeds the configured payload limit of " +
                     std::to_string(options.max_request_bytes) + " bytes";
-    if (request.path.rfind("/v1/messages", 0) == 0) {
-        write_messages_error(response, error);
-    } else {
-        write_error(response, error);
-    }
+    write_error_for_path(request.path, response, error);
     return httplib::Server::HandlerResponse::Handled;
 }
 
@@ -240,29 +288,22 @@ void HttpServer::register_routes() {
             error.type    = "invalid_request_error";
             error.code    = "invalid_api_key";
             error.message = "missing or invalid API key";
-            // Render the 401 in the shape the target endpoint speaks.
-            if (req.path.rfind("/v1/messages", 0) == 0) {
-                write_messages_error(res, error);
-            } else {
-                write_error(res, error);
-            }
+            write_error_for_path(req.path, res, error);
             return httplib::Server::HandlerResponse::Handled;
         }
         return httplib::Server::HandlerResponse::Unhandled;
     });
 
     server_.set_exception_handler(
-        [](const httplib::Request&, httplib::Response& res, std::exception_ptr ep) {
+        [](const httplib::Request& req, httplib::Response& res, std::exception_ptr ep) {
             try {
                 std::rethrow_exception(ep);
             } catch (const ApiException& e) {
-                write_error(res, e.error());
-            } catch (const std::exception& e) { write_exception(res, e); } catch (...) {
-                ApiError error;
-                error.status  = 500;
-                error.type    = "internal_error";
-                error.message = "unknown error";
-                write_error(res, error);
+                write_error_for_path(req.path, res, e.error());
+            } catch (const std::exception& e) {
+                write_error_for_path(req.path, res, make_internal_error(e.what()));
+            } catch (...) {
+                write_error_for_path(req.path, res, make_internal_error("unknown error"));
             }
         });
 
@@ -312,6 +353,21 @@ void HttpServer::register_routes() {
                  });
     server_.Post("/v1/messages", [this](const httplib::Request& req, httplib::Response& res) {
         handle_messages(req, res);
+    });
+    server_.Post("/api/chat", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_ollama_chat(req, res);
+    });
+    server_.Get("/api/tags", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_ollama_tags(req, res);
+    });
+    server_.Post("/api/show", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_ollama_show(req, res);
+    });
+    server_.Get("/api/ps", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_ollama_ps(req, res);
+    });
+    server_.Get("/api/version", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_ollama_version(req, res);
     });
 }
 
@@ -757,15 +813,248 @@ void HttpServer::handle_messages(const httplib::Request& req, httplib::Response&
         [stream](bool) { stream->cancelled.store(true, std::memory_order_release); });
 }
 
+void HttpServer::handle_ollama_chat(const httplib::Request& req, httplib::Response& res) {
+    nlohmann::json body;
+    try {
+        body = nlohmann::json::parse(req.body);
+    } catch (const std::exception&) {
+        ApiError error;
+        error.status  = 400;
+        error.message = "request body is not valid JSON";
+        write_ollama_error(res, error);
+        return;
+    }
+
+    GenerationRequest request;
+    try {
+        // Empty `messages` is Ollama's preload request; the model is resident, so
+        // it is answered immediately without entering the request lifecycle.
+        if (const std::optional<std::string> preload = ollama_preload_model(body)) {
+            require_ollama_model(*preload);
+            res.set_content(make_ollama_chat_load_response(*preload, ollama_timestamp_now()),
+                            "application/json");
+            return;
+        }
+        RequestLimits limits;
+        limits.default_max_tokens = options_.default_max_tokens;
+        limits.max_context        = static_cast<int>(options_.max_context);
+        request                   = parse_ollama_chat_request(body, limits);
+        require_ollama_model(request.model);
+    } catch (const ApiException& e) {
+        write_ollama_error(res, e.error());
+        return;
+    }
+
+    const std::uint64_t req_id = ++request_seq_;
+    PreparedRequest prepared;
+    try {
+        prepared = service_->prepare(
+            request, [&req] { return req.is_connection_alive && !req.is_connection_alive(); });
+    } catch (const ApiException& e) {
+        log_request_rejected(
+            make_request_rejection_log_context(req_id, "ollama_chat", request, e.error()));
+        write_ollama_error(res, e.error());
+        return;
+    } catch (const std::exception& e) {
+        ApiError error;
+        error.status  = 500;
+        error.type    = "internal_error";
+        error.message = e.what();
+        log_request_rejected(
+            make_request_rejection_log_context(req_id, "ollama_chat", request, error));
+        write_ollama_error(res, error);
+        return;
+    }
+
+    const std::string model = request.model; // echo the requested spelling
+
+    const RequestLogContext log_context =
+        make_request_log_context(req_id, "ollama_chat", request, prepared);
+    log_request_start(log_context);
+
+    if (!request.stream) {
+        try {
+            const GenerationOutcome outcome = service_->run(prepared, nullptr, [&req] {
+                return req.is_connection_alive && !req.is_connection_alive();
+            });
+            log_request_done(log_context, outcome);
+            set_owned_content(res,
+                              make_ollama_chat_response(model, ollama_timestamp_now(), outcome.text,
+                                                        outcome.reasoning, outcome.tool_calls,
+                                                        finish_reason_wire(outcome.finish_reason),
+                                                        ollama_timings(outcome)),
+                              prepared.lifetime);
+        } catch (const ApiException& e) {
+            log_request_error(log_context, e.error().message);
+            write_ollama_error(res, e.error());
+        } catch (const std::exception& e) {
+            log_request_error(log_context, e.what());
+            ApiError error;
+            error.status  = 500;
+            error.type    = "internal_error";
+            error.message = e.what();
+            write_ollama_error(res, error);
+        }
+        return;
+    }
+
+    auto stream             = std::make_shared<StreamingRequest>(std::move(prepared));
+    const bool tool_capable = stream->prepared.tool_capable;
+
+    res.set_header("Cache-Control", "no-cache");
+    res.set_header("X-Accel-Buffering", "no");
+
+    res.set_chunked_content_provider(
+        "application/x-ndjson",
+        [this, stream, model, tool_capable, log_context](std::size_t,
+                                                         httplib::DataSink& sink) -> bool {
+            if (stream->started) {
+                sink.done();
+                return true;
+            }
+            stream->started = true;
+            try {
+                StreamSink output;
+                output.on_content = [&](const std::string& text) {
+                    write_stream_item(
+                        sink, *stream,
+                        make_ollama_chat_content_frame(model, ollama_timestamp_now(), text));
+                };
+                output.on_reasoning = [&](const std::string& text) {
+                    write_stream_item(
+                        sink, *stream,
+                        make_ollama_chat_thinking_frame(model, ollama_timestamp_now(), text));
+                };
+                output.is_cancelled = [&] {
+                    return stream->cancelled.load(std::memory_order_acquire) ||
+                           (sink.is_writable && !sink.is_writable());
+                };
+
+                const GenerationOutcome outcome = service_->run(stream->prepared, &output);
+                log_request_done(log_context, outcome);
+                const std::string_view remaining = unstreamed_content(outcome);
+                if (tool_capable && !remaining.empty()) {
+                    write_stream_item(sink, *stream,
+                                      make_ollama_chat_content_frame(model, ollama_timestamp_now(),
+                                                                     std::string(remaining)));
+                }
+                if (!outcome.tool_calls.empty()) {
+                    write_stream_item(sink, *stream,
+                                      make_ollama_chat_tool_calls_frame(
+                                          model, ollama_timestamp_now(), outcome.tool_calls));
+                }
+                write_stream_item(
+                    sink, *stream,
+                    make_ollama_chat_done_frame(model, ollama_timestamp_now(),
+                                                finish_reason_wire(outcome.finish_reason),
+                                                ollama_timings(outcome)));
+                sink.done();
+                return true;
+            } catch (const ClientDisconnected& e) {
+                log_request_error(log_context, e.what());
+                return false;
+            } catch (const ApiException& e) {
+                log_request_error(log_context, e.error().message);
+                try {
+                    write_stream_item(sink, *stream, make_ollama_error_frame(e.error()));
+                    sink.done();
+                    return true;
+                } catch (const ClientDisconnected&) { return false; }
+            } catch (const std::exception& e) {
+                log_request_error(log_context, e.what());
+                ApiError error;
+                error.status  = 500;
+                error.type    = "internal_error";
+                error.message = e.what();
+                try {
+                    write_stream_item(sink, *stream, make_ollama_error_frame(error));
+                    sink.done();
+                    return true;
+                } catch (const ClientDisconnected&) { return false; }
+            }
+        },
+        [stream](bool) { stream->cancelled.store(true, std::memory_order_release); });
+}
+
+void HttpServer::handle_ollama_tags(const httplib::Request&, httplib::Response& res) const {
+    res.set_content(make_ollama_tags(ollama_facts_), "application/json");
+}
+
+void HttpServer::handle_ollama_show(const httplib::Request& req, httplib::Response& res) const {
+    nlohmann::json body;
+    try {
+        body = nlohmann::json::parse(req.body);
+    } catch (const std::exception&) {
+        ApiError error;
+        error.status  = 400;
+        error.message = "request body is not valid JSON";
+        write_ollama_error(res, error);
+        return;
+    }
+    // Ollama accepts `model` and the legacy `name` field.
+    std::string model;
+    for (const char* key : {"model", "name"}) {
+        if (body.is_object() && body.contains(key) && body.at(key).is_string()) {
+            model = body.at(key).get<std::string>();
+            break;
+        }
+    }
+    if (model.empty()) {
+        ApiError error;
+        error.status  = 400;
+        error.message = "missing required field: model";
+        write_ollama_error(res, error);
+        return;
+    }
+    try {
+        require_ollama_model(model);
+    } catch (const ApiException& e) {
+        write_ollama_error(res, e.error());
+        return;
+    }
+    res.set_content(make_ollama_show(ollama_facts_), "application/json");
+}
+
+void HttpServer::require_ollama_model(const std::string& requested) const {
+    if (ollama_model_matches(requested, public_model_id_)) { return; }
+    ApiError error;
+    error.status  = 404;
+    error.type    = "invalid_request_error";
+    error.code    = "model_not_found";
+    error.message = "model '" + requested + "' not found";
+    throw ApiException(std::move(error));
+}
+
+void HttpServer::handle_ollama_ps(const httplib::Request&, httplib::Response& res) const {
+    res.set_content(make_ollama_ps(ollama_facts_), "application/json");
+}
+
+void HttpServer::handle_ollama_version(const httplib::Request&, httplib::Response& res) const {
+    res.set_content(make_ollama_version(), "application/json");
+}
+
 bool HttpServer::bind() { return server_.bind_to_port(options_.host, options_.port); }
 
 void HttpServer::attach(GenerationService& service) {
     if (service_ != nullptr) {
         throw std::logic_error("HTTP generation service is already attached");
     }
-    const ninfer::LoadSummary load = service.load_summary();
-    public_model_id_               = resolve_public_model_id(options_, load.model_id);
-    service_                       = &service;
+    const ninfer::LoadSummary load     = service.load_summary();
+    const ninfer::MemorySummary memory = service.memory_summary();
+    public_model_id_                   = resolve_public_model_id(options_, load.model_id);
+    service_                           = &service;
+    ollama_facts_                      = OllamaModelFacts{
+                             .model_id        = public_model_id_,
+                             .target          = load.target,
+                             .weights_id      = load.weights_id,
+                             .modified_at     = artifact_modified_at(options_.artifact_path),
+                             .size_bytes      = artifact_size_bytes(options_.artifact_path),
+                             .size_vram_bytes = memory.weights.used_bytes,
+                             .max_context     = memory.max_context,
+                             .vision          = options_.enable_vision,
+        // Every registered target is a reasoning checkpoint.
+                             .thinking = true,
+    };
     request_jsonl_.write_server_start(options_, service.sampling_defaults(), public_model_id_, load,
                                       service.memory_summary());
 }

--- a/src/serve/http_server.h
+++ b/src/serve/http_server.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "serve/generation_service.h"
+#include "serve/ollama_schema.h"
 #include "serve/response_store.h"
 #include "serve/request_log.h"
 #include "serve/serve_options.h"
@@ -51,6 +52,13 @@ private:
     void handle_response_compact(const httplib::Request& req, httplib::Response& res);
     void handle_models(const httplib::Request& req, httplib::Response& res) const;
     void handle_model(const httplib::Request& req, httplib::Response& res) const;
+    void handle_ollama_chat(const httplib::Request& req, httplib::Response& res);
+    void handle_ollama_tags(const httplib::Request& req, httplib::Response& res) const;
+    void handle_ollama_show(const httplib::Request& req, httplib::Response& res) const;
+    void handle_ollama_ps(const httplib::Request& req, httplib::Response& res) const;
+    void handle_ollama_version(const httplib::Request& req, httplib::Response& res) const;
+    // Throws a 404 model_not_found ApiException unless `requested` names the served model.
+    void require_ollama_model(const std::string& requested) const;
 
     // The process-wide console logger serializes lines from request and reporter threads.
     void log_line(const std::string& line);
@@ -65,6 +73,7 @@ private:
     GenerationService* service_ = nullptr;
     ServeOptions options_;
     std::string public_model_id_;
+    OllamaModelFacts ollama_facts_;
     ResponseStore response_store_;
     JsonlRequestLog request_jsonl_;
     httplib::Server server_;

--- a/src/serve/ollama_schema.cpp
+++ b/src/serve/ollama_schema.cpp
@@ -335,23 +335,32 @@ void parse_options(const Json& body, GenerationRequest& out, const RequestLimits
 
     if (const std::optional<int> num_ctx = get_int(options, "num_ctx", "options.num_ctx")) {
         if (*num_ctx <= 0) { bad_request("options.num_ctx must be positive", "options.num_ctx"); }
-        // The context window is frozen at server startup; a request may ask for
-        // less (no effect) but not for more.
+        // The server window is frozen at startup, so a request may only narrow it;
+        // the narrower window is enforced at preparation (prompt must fit, output
+        // clamped to the remainder) instead of truncating the prompt as Ollama does.
         if (limits.max_context > 0 && *num_ctx > limits.max_context) {
             bad_request("options.num_ctx exceeds the server context window of " +
                             std::to_string(limits.max_context),
                         "options.num_ctx", "context_length_exceeded");
         }
+        out.context_window = *num_ctx;
     }
 
     if (const std::optional<int> num_predict =
             get_int(options, "num_predict", "options.num_predict")) {
-        // Ollama: -1 => no explicit limit, -2 => fill the context. Both resolve to
-        // the server's default output budget; the Engine always bounds output.
+        // Ollama: -1 => no explicit limit (the server default budget applies);
+        // -2 => fill the context window, i.e. request the whole window and let
+        // preparation/the Engine clamp it to what remains after the prompt.
         if (*num_predict > 0) {
             out.max_tokens     = *num_predict;
             out.max_tokens_set = true;
-        } else if (*num_predict != -1 && *num_predict != -2) {
+        } else if (*num_predict == -2) {
+            const int window = out.context_window > 0 ? out.context_window : limits.max_context;
+            if (window > 0) {
+                out.max_tokens     = window;
+                out.max_tokens_set = true;
+            }
+        } else if (*num_predict != -1) {
             bad_request("options.num_predict must be positive, -1, or -2", "options.num_predict");
         }
     }

--- a/src/serve/ollama_schema.cpp
+++ b/src/serve/ollama_schema.cpp
@@ -1,0 +1,609 @@
+#include "serve/ollama_schema.h"
+
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace ninfer::serve {
+namespace {
+
+using Json = nlohmann::json;
+
+constexpr std::size_t kMaxToolNameLength = 64;
+
+[[noreturn]] void bad_request(std::string message, std::string param = {}, std::string code = {}) {
+    ApiError error;
+    error.status  = 400;
+    error.type    = "invalid_request_error";
+    error.message = std::move(message);
+    error.param   = std::move(param);
+    error.code    = std::move(code);
+    throw ApiException(std::move(error));
+}
+
+std::optional<double> get_number(const Json& obj, const char* key, const char* param) {
+    if (!obj.contains(key) || obj.at(key).is_null()) { return std::nullopt; }
+    if (!obj.at(key).is_number()) { bad_request(std::string(param) + " must be a number", param); }
+    return obj.at(key).get<double>();
+}
+
+std::optional<int> get_int(const Json& obj, const char* key, const char* param) {
+    if (!obj.contains(key) || obj.at(key).is_null()) { return std::nullopt; }
+    const Json& value = obj.at(key);
+    if (value.is_number_integer()) {
+        const std::int64_t v = value.get<std::int64_t>();
+        if (v < std::numeric_limits<int>::min() || v > std::numeric_limits<int>::max()) {
+            bad_request(std::string(param) + " is out of range", param);
+        }
+        return static_cast<int>(v);
+    }
+    if (value.is_number_float()) {
+        // Ollama options are typed loosely by clients; accept integral floats.
+        const double v = value.get<double>();
+        if (std::floor(v) != v || v < std::numeric_limits<int>::min() ||
+            v > std::numeric_limits<int>::max()) {
+            bad_request(std::string(param) + " must be an integer", param);
+        }
+        return static_cast<int>(v);
+    }
+    bad_request(std::string(param) + " must be an integer", param);
+}
+
+std::optional<std::uint64_t> get_u64(const Json& obj, const char* key, const char* param) {
+    if (!obj.contains(key) || obj.at(key).is_null()) { return std::nullopt; }
+    const Json& value = obj.at(key);
+    if (!value.is_number_integer()) {
+        bad_request(std::string(param) + " must be a nonnegative integer", param);
+    }
+    if (value.is_number_unsigned()) { return value.get<std::uint64_t>(); }
+    const std::int64_t v = value.get<std::int64_t>();
+    if (v < 0) { bad_request(std::string(param) + " must be nonnegative", param); }
+    return static_cast<std::uint64_t>(v);
+}
+
+bool is_valid_function_name(const std::string& name) {
+    if (name.empty() || name.size() > kMaxToolNameLength) { return false; }
+    for (const unsigned char c : name) {
+        if (std::isalnum(c) == 0 && c != '_' && c != '-') { return false; }
+    }
+    return true;
+}
+
+std::string require_function_name(const Json& obj, const char* param) {
+    if (!obj.contains("name") || !obj.at("name").is_string()) {
+        bad_request("function name must be a string", param);
+    }
+    std::string name = obj.at("name").get<std::string>();
+    if (!is_valid_function_name(name)) {
+        bad_request("function name must match [A-Za-z0-9_-]{1,64}", param);
+    }
+    return name;
+}
+
+// --- request parsing --------------------------------------------------------
+
+void parse_tools(const Json& body, GenerationRequest& out) {
+    if (!body.contains("tools") || body.at("tools").is_null()) { return; }
+    const Json& tools = body.at("tools");
+    if (!tools.is_array()) { bad_request("tools must be an array", "tools"); }
+    out.tools.reserve(tools.size());
+    for (const Json& item : tools) {
+        if (!item.is_object() || !item.contains("type") || !item.at("type").is_string() ||
+            item.at("type").get<std::string>() != "function") {
+            bad_request("tools entries must be objects with type 'function'", "tools",
+                        "tool_type_not_supported");
+        }
+        if (!item.contains("function") || !item.at("function").is_object()) {
+            bad_request("function tools must contain a function object", "tools");
+        }
+        const Json& fn = item.at("function");
+        ToolDefinition tool;
+        tool.name     = require_function_name(fn, "tools");
+        Json function = Json{{"name", tool.name}};
+        if (fn.contains("description") && !fn.at("description").is_null()) {
+            if (!fn.at("description").is_string()) {
+                bad_request("function description must be a string", "tools");
+            }
+            tool.description        = fn.at("description").get<std::string>();
+            function["description"] = tool.description;
+        }
+        // Same default as the OpenAI surfaces so one tool definition renders
+        // identically into the chat template regardless of endpoint.
+        Json parameters = Json{{"type", "object"}, {"properties", Json::object()}};
+        if (fn.contains("parameters") && !fn.at("parameters").is_null()) {
+            if (!fn.at("parameters").is_object()) {
+                bad_request("function parameters must be a JSON object", "tools");
+            }
+            parameters = fn.at("parameters");
+        }
+        tool.parameters_json   = parameters.dump();
+        function["parameters"] = std::move(parameters);
+        function["strict"]     = false;
+        // Normalized OpenAI-style function tool object consumed verbatim by the
+        // Qwen chat template's <tools> block.
+        tool.definition_json = Json{{"type", "function"}, {"function", std::move(function)}}.dump();
+        out.tools.push_back(std::move(tool));
+    }
+}
+
+// Ollama's chat contract carries only these four roles; 'developer' is an OpenAI
+// extension its clients never send, so it stays rejected here.
+ChatRole parse_ollama_role(const std::string& role) {
+    if (role == "system") { return ChatRole::System; }
+    if (role == "user") { return ChatRole::User; }
+    if (role == "assistant") { return ChatRole::Assistant; }
+    if (role == "tool") { return ChatRole::Tool; }
+    bad_request("message role must be 'system', 'user', 'assistant', or 'tool'", "messages",
+                "unsupported_role");
+}
+
+ContentPart parse_image(const Json& image, std::size_t index) {
+    // Ollama carries images as bare base64 payloads without a media type; the
+    // decoder identifies the container from the bytes.
+    if (!image.is_string() || image.get<std::string>().empty()) {
+        bad_request("message " + std::to_string(index) + " images must be non-empty base64 strings",
+                    "messages");
+    }
+    ContentPart part;
+    part.kind         = ContentKind::Image;
+    part.type_raw     = "image";
+    part.source.kind  = ninfer::product::media_acquire::SourceKind::Data;
+    part.source.value = "data:application/octet-stream;base64," + image.get<std::string>();
+    return part;
+}
+
+std::vector<ToolCall> parse_assistant_tool_calls(const Json& item, std::size_t index) {
+    std::vector<ToolCall> calls;
+    if (!item.contains("tool_calls") || item.at("tool_calls").is_null()) { return calls; }
+    const Json& tool_calls = item.at("tool_calls");
+    if (!tool_calls.is_array()) {
+        bad_request("assistant message " + std::to_string(index) + " tool_calls must be an array",
+                    "messages");
+    }
+    calls.reserve(tool_calls.size());
+    for (const Json& entry : tool_calls) {
+        if (!entry.is_object() || !entry.contains("function") ||
+            !entry.at("function").is_object()) {
+            bad_request("tool_calls entries must contain a function object", "messages");
+        }
+        const Json& fn = entry.at("function");
+        ToolCall call;
+        if (entry.contains("id") && entry.at("id").is_string()) {
+            call.id = entry.at("id").get<std::string>();
+        }
+        call.name = require_function_name(fn, "messages");
+        if (!fn.contains("arguments") || fn.at("arguments").is_null()) {
+            call.arguments_json = "{}";
+        } else if (fn.at("arguments").is_object()) {
+            call.arguments_json = fn.at("arguments").dump();
+        } else {
+            bad_request("tool call arguments must be a JSON object", "messages");
+        }
+        calls.push_back(std::move(call));
+    }
+    return calls;
+}
+
+void parse_messages(const Json& body, GenerationRequest& out) {
+    if (!body.contains("messages")) { bad_request("missing required field: messages", "messages"); }
+    const Json& messages = body.at("messages");
+    if (!messages.is_array() || messages.empty()) {
+        bad_request("messages must be a non-empty array", "messages");
+    }
+    out.messages.reserve(messages.size());
+    for (std::size_t i = 0; i < messages.size(); ++i) {
+        const Json& item = messages.at(i);
+        if (!item.is_object()) {
+            bad_request("message " + std::to_string(i) + " must be an object", "messages");
+        }
+        if (!item.contains("role") || !item.at("role").is_string()) {
+            bad_request("message " + std::to_string(i) + " must have a string role", "messages");
+        }
+        ChatTurn turn;
+        turn.role = parse_ollama_role(item.at("role").get<std::string>());
+
+        std::string content;
+        bool has_content = false;
+        if (item.contains("content") && !item.at("content").is_null()) {
+            if (!item.at("content").is_string()) {
+                bad_request("message " + std::to_string(i) + " content must be a string",
+                            "messages");
+            }
+            content     = item.at("content").get<std::string>();
+            has_content = true;
+        }
+        // A tool result may legitimately be empty; the template still renders the
+        // tool turn (same as the OpenAI and Anthropic surfaces).
+        if (!content.empty() || (has_content && turn.role == ChatRole::Tool)) {
+            turn.content.push_back(ContentPart{ContentKind::Text, std::move(content), "text"});
+        }
+
+        if (item.contains("images") && !item.at("images").is_null()) {
+            if (turn.role != ChatRole::User) {
+                bad_request("only user messages may carry images", "messages");
+            }
+            const Json& images = item.at("images");
+            if (!images.is_array()) {
+                bad_request("message " + std::to_string(i) + " images must be an array",
+                            "messages");
+            }
+            for (const Json& image : images) { turn.content.push_back(parse_image(image, i)); }
+        }
+
+        if (turn.role == ChatRole::Assistant) {
+            if (item.contains("thinking") && !item.at("thinking").is_null()) {
+                if (!item.at("thinking").is_string()) {
+                    bad_request("assistant thinking must be a string", "messages");
+                }
+                turn.reasoning_content = item.at("thinking").get<std::string>();
+            }
+            turn.tool_calls = parse_assistant_tool_calls(item, i);
+            if (turn.content.empty() && turn.tool_calls.empty() && turn.reasoning_content.empty()) {
+                bad_request("assistant message " + std::to_string(i) +
+                                " must have content, thinking, or tool_calls",
+                            "messages");
+            }
+        } else if (turn.role == ChatRole::Tool) {
+            if (!has_content) {
+                bad_request("tool message " + std::to_string(i) + " must have string content",
+                            "messages");
+            }
+        } else if (turn.content.empty()) {
+            bad_request("message " + std::to_string(i) + " content must not be empty", "messages");
+        }
+        // Ollama tool messages carry no call id (`tool_name` is informational);
+        // the Qwen template renders tool responses positionally.
+        out.messages.push_back(std::move(turn));
+    }
+}
+
+void parse_stop(const Json& stop, GenerationRequest& out) {
+    if (stop.is_string()) {
+        if (!stop.get<std::string>().empty()) {
+            out.stop_strings.push_back(stop.get<std::string>());
+        }
+        return;
+    }
+    if (stop.is_array()) {
+        for (const Json& s : stop) {
+            if (!s.is_string()) {
+                bad_request("options.stop entries must be strings", "options.stop");
+            }
+            if (!s.get<std::string>().empty()) { out.stop_strings.push_back(s.get<std::string>()); }
+        }
+        return;
+    }
+    bad_request("options.stop must be a string or array of strings", "options.stop");
+}
+
+constexpr const char* kMappedOptions[] = {
+    "temperature",       "top_p", "top_k", "min_p",   "presence_penalty",
+    "frequency_penalty", "seed",  "stop",  "num_ctx", "num_predict",
+};
+
+// Ollama runner/loader knobs. Residency, threading, and batching are startup
+// properties of ninfer-serve, so these are accepted without effect.
+constexpr const char* kIgnoredRunnerOptions[] = {
+    "num_gpu",   "main_gpu", "num_thread", "num_batch", "num_keep",   "use_mmap",
+    "use_mlock", "numa",     "low_vram",   "f16_kv",    "vocab_only", "logits_all",
+};
+
+template <std::size_t N>
+bool contains_key(const char* const (&keys)[N], const std::string& key) {
+    for (const char* candidate : keys) {
+        if (key == candidate) { return true; }
+    }
+    return false;
+}
+
+void parse_options(const Json& body, GenerationRequest& out, const RequestLimits& limits) {
+    if (!body.contains("options") || body.at("options").is_null()) { return; }
+    const Json& options = body.at("options");
+    if (!options.is_object()) { bad_request("options must be an object", "options"); }
+
+    for (auto it = options.begin(); it != options.end(); ++it) {
+        if (it.value().is_null() || contains_key(kMappedOptions, it.key()) ||
+            contains_key(kIgnoredRunnerOptions, it.key())) {
+            continue;
+        }
+        // Sampler knobs with no Engine counterpart (repeat_penalty, mirostat, ...)
+        // and unknown keys alike: ignoring them would silently change the
+        // requested output, so they are rejected.
+        bad_request("options." + it.key() + " is not supported", "options." + it.key(),
+                    "option_not_supported");
+    }
+
+    SamplingParams& s   = out.sampling;
+    s.temperature       = get_number(options, "temperature", "options.temperature");
+    s.top_p             = get_number(options, "top_p", "options.top_p");
+    s.top_k             = get_int(options, "top_k", "options.top_k");
+    s.min_p             = get_number(options, "min_p", "options.min_p");
+    s.presence_penalty  = get_number(options, "presence_penalty", "options.presence_penalty");
+    s.frequency_penalty = get_number(options, "frequency_penalty", "options.frequency_penalty");
+    s.seed              = get_u64(options, "seed", "options.seed");
+    if (options.contains("stop") && !options.at("stop").is_null()) {
+        parse_stop(options.at("stop"), out);
+    }
+
+    if (const std::optional<int> num_ctx = get_int(options, "num_ctx", "options.num_ctx")) {
+        if (*num_ctx <= 0) { bad_request("options.num_ctx must be positive", "options.num_ctx"); }
+        // The context window is frozen at server startup; a request may ask for
+        // less (no effect) but not for more.
+        if (limits.max_context > 0 && *num_ctx > limits.max_context) {
+            bad_request("options.num_ctx exceeds the server context window of " +
+                            std::to_string(limits.max_context),
+                        "options.num_ctx", "context_length_exceeded");
+        }
+    }
+
+    if (const std::optional<int> num_predict =
+            get_int(options, "num_predict", "options.num_predict")) {
+        // Ollama: -1 => no explicit limit, -2 => fill the context. Both resolve to
+        // the server's default output budget; the Engine always bounds output.
+        if (*num_predict > 0) {
+            out.max_tokens     = *num_predict;
+            out.max_tokens_set = true;
+        } else if (*num_predict != -1 && *num_predict != -2) {
+            bad_request("options.num_predict must be positive, -1, or -2", "options.num_predict");
+        }
+    }
+}
+
+void parse_think(const Json& body, GenerationRequest& out) {
+    if (!body.contains("think") || body.at("think").is_null()) { return; }
+    const Json& think = body.at("think");
+    if (think.is_boolean()) {
+        out.enable_thinking = think.get<bool>();
+        return;
+    }
+    if (think.is_string()) {
+        const std::string value = think.get<std::string>();
+        const std::optional<RequestedReasoningEffort> effort =
+            parse_requested_reasoning_effort(value);
+        if (!effort || (value != "low" && value != "medium" && value != "high")) {
+            bad_request("think must be a boolean or one of low, medium, high", "think");
+        }
+        out.reasoning_effort       = *effort;
+        out.reasoning_effort_param = "think";
+        return;
+    }
+    bad_request("think must be a boolean or one of low, medium, high", "think");
+}
+
+Json tool_calls_json(const std::vector<ToolCall>& tool_calls) {
+    Json out = Json::array();
+    for (std::size_t i = 0; i < tool_calls.size(); ++i) {
+        const ToolCall& call = tool_calls[i];
+        Json arguments       = Json::parse(call.arguments_json, nullptr, false);
+        if (arguments.is_discarded() || !arguments.is_object()) { arguments = Json::object(); }
+        Json function = {{"index", static_cast<int>(i)},
+                         {"name", call.name},
+                         {"arguments", std::move(arguments)}};
+        Json item     = Json{{"function", std::move(function)}};
+        if (!call.id.empty()) { item["id"] = call.id; }
+        out.push_back(std::move(item));
+    }
+    return out;
+}
+
+Json message_json(const std::string& content, const std::string& thinking,
+                  const std::vector<ToolCall>& tool_calls) {
+    Json message = {{"role", "assistant"}, {"content", content}};
+    if (!thinking.empty()) { message["thinking"] = thinking; }
+    if (!tool_calls.empty()) { message["tool_calls"] = tool_calls_json(tool_calls); }
+    return message;
+}
+
+std::int64_t nanoseconds(double seconds) {
+    if (!(seconds > 0.0)) { return 0; }
+    return static_cast<std::int64_t>(std::llround(seconds * 1e9));
+}
+
+void add_timings(Json& frame, const OllamaTimings& timings) {
+    frame["total_duration"]       = nanoseconds(timings.total_seconds);
+    frame["load_duration"]        = nanoseconds(timings.load_seconds);
+    frame["prompt_eval_count"]    = timings.prompt_eval_count;
+    frame["prompt_eval_duration"] = nanoseconds(timings.prompt_eval_seconds);
+    frame["eval_count"]           = timings.eval_count;
+    frame["eval_duration"]        = nanoseconds(timings.eval_seconds);
+}
+
+Json base_frame(const std::string& model, const std::string& created_at) {
+    return Json{{"model", model}, {"created_at", created_at}};
+}
+
+std::string ndjson(const Json& frame) { return frame.dump() + "\n"; }
+
+Json details_json(const OllamaModelFacts& facts) {
+    return Json{{"parent_model", ""},
+                {"format", "ninfer"},
+                {"family", facts.target},
+                {"families", Json::array({facts.target})},
+                {"quantization_level", facts.weights_id}};
+}
+
+Json model_entry(const OllamaModelFacts& facts) {
+    return Json{{"name", facts.model_id},
+                {"model", facts.model_id},
+                {"modified_at", facts.modified_at},
+                {"size", facts.size_bytes},
+                {"details", details_json(facts)}};
+}
+
+std::string require_model(const Json& body) {
+    if (!body.is_object()) { bad_request("request body must be a JSON object"); }
+    if (!body.contains("model") || !body.at("model").is_string() ||
+        body.at("model").get<std::string>().empty()) {
+        bad_request("missing required field: model", "model");
+    }
+    return body.at("model").get<std::string>();
+}
+
+} // namespace
+
+std::optional<std::string> ollama_preload_model(const Json& body) {
+    if (!body.is_object() || !body.contains("messages") || !body.at("messages").is_array() ||
+        !body.at("messages").empty()) {
+        return std::nullopt;
+    }
+    return require_model(body);
+}
+
+bool ollama_model_matches(const std::string& requested, const std::string& model_id) {
+    static constexpr std::string_view kLatest = ":latest";
+    if (requested == model_id) { return true; }
+    return requested.size() == model_id.size() + kLatest.size() &&
+           requested.compare(0, model_id.size(), model_id) == 0 &&
+           requested.compare(model_id.size(), kLatest.size(), kLatest) == 0;
+}
+
+GenerationRequest parse_ollama_chat_request(const Json& body, const RequestLimits& limits) {
+    GenerationRequest out;
+    out.tool_name_max_length = kMaxToolNameLength;
+    out.model                = require_model(body);
+
+    // Structured output requires constrained decoding, which the Engine does not
+    // implement; a request that asks for it is rejected rather than served loosely.
+    if (body.contains("format") && !body.at("format").is_null()) {
+        bad_request("format is not supported", "format", "format_not_supported");
+    }
+    // `keep_alive` describes runner residency, which is fixed for the server
+    // lifetime; the field is accepted without effect.
+
+    parse_tools(body, out);
+    parse_messages(body, out);
+    out.max_tokens     = limits.default_max_tokens;
+    out.max_tokens_set = false;
+    parse_options(body, out, limits);
+    parse_think(body, out);
+
+    if (body.contains("stream") && !body.at("stream").is_null()) {
+        if (!body.at("stream").is_boolean()) { bad_request("stream must be a boolean", "stream"); }
+        out.stream = body.at("stream").get<bool>();
+    } else {
+        out.stream = true;
+    }
+    return out;
+}
+
+std::string make_ollama_chat_response(const std::string& model, const std::string& created_at,
+                                      const std::string& content, const std::string& thinking,
+                                      const std::vector<ToolCall>& tool_calls,
+                                      const char* done_reason, const OllamaTimings& timings) {
+    Json body           = base_frame(model, created_at);
+    body["message"]     = message_json(content, thinking, tool_calls);
+    body["done"]        = true;
+    body["done_reason"] = done_reason;
+    add_timings(body, timings);
+    return body.dump();
+}
+
+std::string make_ollama_chat_load_response(const std::string& model,
+                                           const std::string& created_at) {
+    Json body           = base_frame(model, created_at);
+    body["message"]     = message_json({}, {}, {});
+    body["done"]        = true;
+    body["done_reason"] = "load";
+    return body.dump();
+}
+
+std::string make_ollama_chat_content_frame(const std::string& model, const std::string& created_at,
+                                           const std::string& delta_text) {
+    Json frame       = base_frame(model, created_at);
+    frame["message"] = message_json(delta_text, {}, {});
+    frame["done"]    = false;
+    return ndjson(frame);
+}
+
+std::string make_ollama_chat_thinking_frame(const std::string& model, const std::string& created_at,
+                                            const std::string& delta_text) {
+    Json frame       = base_frame(model, created_at);
+    frame["message"] = message_json({}, delta_text, {});
+    frame["done"]    = false;
+    return ndjson(frame);
+}
+
+std::string make_ollama_chat_tool_calls_frame(const std::string& model,
+                                              const std::string& created_at,
+                                              const std::vector<ToolCall>& tool_calls) {
+    Json frame       = base_frame(model, created_at);
+    frame["message"] = message_json({}, {}, tool_calls);
+    frame["done"]    = false;
+    return ndjson(frame);
+}
+
+std::string make_ollama_chat_done_frame(const std::string& model, const std::string& created_at,
+                                        const char* done_reason, const OllamaTimings& timings) {
+    Json frame           = base_frame(model, created_at);
+    frame["message"]     = message_json({}, {}, {});
+    frame["done"]        = true;
+    frame["done_reason"] = done_reason;
+    add_timings(frame, timings);
+    return ndjson(frame);
+}
+
+std::string make_ollama_tags(const OllamaModelFacts& facts) {
+    return Json{{"models", Json::array({model_entry(facts)})}}.dump();
+}
+
+std::string make_ollama_show(const OllamaModelFacts& facts) {
+    Json capabilities = Json::array({"completion", "tools"});
+    if (facts.vision) { capabilities.push_back("vision"); }
+    if (facts.thinking) { capabilities.push_back("thinking"); }
+    const Json model_info = {{"general.architecture", facts.target},
+                             {"general.name", facts.model_id},
+                             {facts.target + ".context_length", facts.max_context}};
+    return Json{{"modified_at", facts.modified_at},
+                {"details", details_json(facts)},
+                {"model_info", model_info},
+                {"capabilities", std::move(capabilities)}}
+        .dump();
+}
+
+std::string make_ollama_ps(const OllamaModelFacts& facts) {
+    Json entry              = model_entry(facts);
+    entry["size_vram"]      = facts.size_vram_bytes;
+    entry["context_length"] = facts.max_context;
+    return Json{{"models", Json::array({std::move(entry)})}}.dump();
+}
+
+std::string make_ollama_version() { return Json{{"version", kOllamaCompatVersion}}.dump(); }
+
+std::string make_ollama_error_body(const ApiError& error) {
+    return Json{{"error", error.message}}.dump();
+}
+
+std::string make_ollama_error_frame(const ApiError& error) {
+    return make_ollama_error_body(error) + "\n";
+}
+
+std::string ollama_timestamp(std::int64_t unix_nanoseconds) {
+    const std::time_t seconds = static_cast<std::time_t>(unix_nanoseconds / 1'000'000'000);
+    const long nanos          = static_cast<long>(unix_nanoseconds % 1'000'000'000);
+    std::tm utc{};
+#if defined(_WIN32)
+    gmtime_s(&utc, &seconds);
+#else
+    gmtime_r(&seconds, &utc);
+#endif
+    char buffer[64];
+    std::snprintf(buffer, sizeof(buffer), "%04d-%02d-%02dT%02d:%02d:%02d.%09ldZ",
+                  utc.tm_year + 1900, utc.tm_mon + 1, utc.tm_mday, utc.tm_hour, utc.tm_min,
+                  utc.tm_sec, nanos);
+    return buffer;
+}
+
+std::string ollama_timestamp_now() {
+    const auto now = std::chrono::system_clock::now().time_since_epoch();
+    return ollama_timestamp(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+}
+
+} // namespace ninfer::serve

--- a/src/serve/ollama_schema.h
+++ b/src/serve/ollama_schema.h
@@ -1,0 +1,119 @@
+#pragma once
+
+// Ollama API wire-format layer: parses /api/chat request JSON into the internal
+// GenerationRequest and serializes internal results back into Ollama chat bodies
+// and NDJSON stream frames, plus the read-only model inventory endpoints Ollama
+// clients probe (/api/tags, /api/show, /api/ps, /api/version). This is a sibling
+// of openai_schema.h and anthropic_schema.h; all three map onto the same
+// wire-agnostic GenerationRequest / GenerationOutcome, so the engine and the
+// generation service know nothing about the protocol.
+//
+// The Ollama contract carries per-request phase timings in its terminal chat
+// frame. Those are what Ollama-aware clients (Open WebUI and others) render as
+// prompt and response token/s; the OpenAI and Anthropic surfaces have no
+// standard equivalent.
+
+#include "serve/request.h"
+#include "ninfer/types.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ninfer::serve {
+
+// Advertised Ollama API level. Ollama clients probe /api/version to decide which
+// request fields they may send; the parser below understands the chat contract
+// at this level (`think`, assistant `thinking`, tool_calls with object
+// arguments, message `images`).
+constexpr const char* kOllamaCompatVersion = "0.11.0";
+
+// Parse an already-decoded Ollama /api/chat body into a GenerationRequest.
+// `stream` defaults to true. `options` sampling keys map onto SamplingParams;
+// sampler knobs the Engine does not implement (repeat_penalty, mirostat, ...)
+// and non-null `format` are rejected, while Ollama runner/loader knobs
+// (num_gpu, num_thread, keep_alive, ...) are accepted without effect because
+// residency is a startup property of the server. `options.num_ctx` must not
+// exceed `limits.max_context`. Throws ApiException on malformed or unsupported
+// requests.
+GenerationRequest parse_ollama_chat_request(const nlohmann::json& body,
+                                            const RequestLimits& limits);
+
+// Ollama defines POST /api/chat with an empty `messages` array as a model
+// preload request that returns immediately with `done_reason: "load"`. Returns
+// the requested model name when `body` has that shape; throws ApiException when
+// `model` is missing or not a string. Callers still validate the model name.
+std::optional<std::string> ollama_preload_model(const nlohmann::json& body);
+
+// True when a client-supplied model name addresses the served model. Ollama
+// clients normalize untagged names to `name:latest`, so that spelling is
+// accepted alongside the bare id advertised by /api/tags.
+bool ollama_model_matches(const std::string& requested, const std::string& model_id);
+
+// Read-only model facts rendered by /api/tags, /api/show, and /api/ps.
+struct OllamaModelFacts {
+    std::string model_id;              // public model id, also the Ollama model name
+    std::string target;                // registered target (family)
+    std::string weights_id;            // weight profile, reported as quantization_level
+    std::string modified_at;           // RFC 3339 artifact timestamp
+    std::uint64_t size_bytes      = 0; // artifact bytes
+    std::uint64_t size_vram_bytes = 0; // resident device bytes
+    std::uint32_t max_context     = 0;
+    bool vision                   = false;
+    bool thinking                 = false;
+};
+
+// Terminal timing fields of an Ollama chat response. Durations are wall seconds
+// and are serialized as integer nanoseconds. `load_seconds` is always zero for
+// a resident model but the field is part of the contract.
+struct OllamaTimings {
+    double total_seconds       = 0.0;
+    double load_seconds        = 0.0;
+    double prompt_eval_seconds = 0.0; // computed-prefill phase
+    double eval_seconds        = 0.0; // decode phase
+    int prompt_eval_count      = 0; // prompt tokens actually computed (excludes prefix-cache hits)
+    int eval_count             = 0; // accepted generated tokens
+};
+
+// Non-streaming /api/chat response body (one JSON object with the complete
+// message, `done: true`, `done_reason`, and timings).
+std::string make_ollama_chat_response(const std::string& model, const std::string& created_at,
+                                      const std::string& content, const std::string& thinking,
+                                      const std::vector<ToolCall>& tool_calls,
+                                      const char* done_reason, const OllamaTimings& timings);
+
+// Reply to a preload request: an empty assistant message with `done: true` and
+// `done_reason: "load"`. The model is always resident, so no work is done.
+std::string make_ollama_chat_load_response(const std::string& model, const std::string& created_at);
+
+// NDJSON stream frames ("{...}\n"). Content and thinking deltas are separate
+// frames; tool calls are emitted in one frame once they are complete; the final
+// frame carries an empty message, `done: true`, `done_reason`, and timings.
+std::string make_ollama_chat_content_frame(const std::string& model, const std::string& created_at,
+                                           const std::string& delta_text);
+std::string make_ollama_chat_thinking_frame(const std::string& model, const std::string& created_at,
+                                            const std::string& delta_text);
+std::string make_ollama_chat_tool_calls_frame(const std::string& model,
+                                              const std::string& created_at,
+                                              const std::vector<ToolCall>& tool_calls);
+std::string make_ollama_chat_done_frame(const std::string& model, const std::string& created_at,
+                                        const char* done_reason, const OllamaTimings& timings);
+
+// Inventory endpoints.
+std::string make_ollama_tags(const OllamaModelFacts& facts);
+std::string make_ollama_show(const OllamaModelFacts& facts);
+std::string make_ollama_ps(const OllamaModelFacts& facts);
+std::string make_ollama_version();
+
+// Error body ({"error": "..."}) shared by HTTP errors and mid-stream error frames.
+std::string make_ollama_error_body(const ApiError& error);
+std::string make_ollama_error_frame(const ApiError& error);
+
+// RFC 3339 UTC timestamp with nanosecond precision, the Ollama `created_at` shape.
+std::string ollama_timestamp_now();
+std::string ollama_timestamp(std::int64_t unix_nanoseconds);
+
+} // namespace ninfer::serve

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -46,6 +46,7 @@ private:
 // Server-side context needed while parsing/validating a request.
 struct RequestLimits {
     int default_max_tokens = 8192;
+    int max_context        = 0; // startup-frozen prompt+output window; 0 => not validated
 };
 
 struct CompletionUsage {
@@ -104,13 +105,15 @@ struct ChatTurn {
                                    // template)
 };
 
-// OpenAI sampling fields carried by the protocol adapter. `logit_bias` remains
+// Sampling fields carried by the protocol adapters. `logit_bias` remains
 // parsed for wire compatibility; the current public engine sampler has no bias
-// input, so it does not affect generation.
+// input, so it does not affect generation. `min_p` is reachable only from the
+// Ollama surface; the OpenAI and Anthropic contracts have no such field.
 struct SamplingParams {
     std::optional<double> temperature;
     std::optional<double> top_p;
     std::optional<int> top_k;
+    std::optional<double> min_p;
     std::optional<double> presence_penalty;
     std::optional<double> frequency_penalty;
     std::optional<std::uint64_t> seed;

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -184,6 +184,10 @@ struct GenerationRequest {
     std::optional<bool> preserve_thinking;
     bool preserve_thinking_semantic_change = false;
     SamplingParams sampling;
+    // Per-request prompt+output window (Ollama num_ctx); 0 => the server window.
+    // The prompt must fit and the output budget is clamped to the remainder.
+    int context_window               = 0;
+    std::string context_window_param = "options.num_ctx";
 
     [[nodiscard]] bool uses_tools() const noexcept {
         return !tools.empty() && tool_choice.mode != ToolChoiceMode::None;

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -77,7 +77,8 @@ std::string serve_usage_text(const char* argv0) {
            "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
-           "       serves OpenAI Responses/Chat Completions and Anthropic Messages endpoints\n"
+           "       serves OpenAI Responses/Chat Completions, Anthropic Messages, and Ollama chat "
+           "endpoints\n"
            "       --default-max-tokens defaults to " +
            std::to_string(kDefaultMaxTokens) +
            " when omitted\n"

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -37,6 +37,7 @@ ninfer::SamplingOverrides resolve_sampling_overrides(const SamplingParams& reque
     if (request.temperature) { sampling.temperature = static_cast<float>(*request.temperature); }
     if (request.top_p) { sampling.top_p = static_cast<float>(*request.top_p); }
     if (request.top_k) { sampling.top_k = static_cast<std::int32_t>(*request.top_k); }
+    if (request.min_p) { sampling.min_p = static_cast<float>(*request.min_p); }
     if (request.presence_penalty) {
         sampling.presence_penalty = static_cast<float>(*request.presence_penalty);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,9 @@ ninfer_add_test(ninfer_response_store_test
 ninfer_add_test(ninfer_anthropic_schema_test
   SOURCES test_anthropic_schema.cpp
   LIBRARIES ninfer_serve)
+ninfer_add_test(ninfer_ollama_schema_test
+  SOURCES test_ollama_schema.cpp
+  LIBRARIES ninfer_serve)
 ninfer_add_test(ninfer_tool_call_parser_test
   SOURCES test_tool_call_parser.cpp
   LIBRARIES ninfer_serve)

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,8 +29,9 @@ benchmark-report, and external protocol behavior. Repository verification princi
 - `test_request_memory.cpp` — startup-frozen request-transient capacity, stable address,
   activation alignment, rejection, and peak semantics;
 - `test_openai_schema.cpp`, `test_responses_schema.cpp`, `test_response_store.cpp`,
-  `test_anthropic_schema.cpp`, and `test_tool_call_parser.cpp` — current protocol translation,
-  Responses Item/state/SSE behavior, and incremental tool-call behavior;
+  `test_anthropic_schema.cpp`, `test_ollama_schema.cpp`, and `test_tool_call_parser.cpp` — current
+  protocol translation, Responses Item/state/SSE behavior, Ollama NDJSON/timing behavior, and
+  incremental tool-call behavior;
 - `test_request_log.cpp` and `test_http_error_handler.cpp` — generation lifecycle records,
   preparation rejections, protocol-shaped payload-limit errors, and application-error preservation;
 - `test_ninfer_bench_support.cpp` — product benchmark CLI, timing boundary, and schema-v9 reports;
@@ -147,7 +148,7 @@ python3 -m tools.smoke.serve_contract \
 
 This smoke check is intentionally not a CTest: it needs the real artifact, a supported GPU, and a
 server process that remains alive while the client exercises OpenAI Responses/Chat, Anthropic,
-state, streaming, and multimodal requests.
+Ollama, state, streaming, and multimodal requests.
 
 The thinking-preservation fixture starts and stops its own server, submits a fixed two-step tool
 history, compares restored and cold greedy output, compares stripped and preserved closed-turn
@@ -173,7 +174,7 @@ A permanent test should protect one current risk, such as:
 - a numerical operator contract with an independent oracle;
 - family Frontend or Program frontier, prefix, MTP, or multimodal behavior;
 - generated-token commit/stop/cancel consistency;
-- public benchmark or OpenAI/Anthropic observable behavior;
+- public benchmark or OpenAI/Anthropic/Ollama observable behavior;
 - a reproduced supported bug.
 
 Performance-only assertions belong in benchmarks and profiler review. Source scans,

--- a/tests/test_http_error_handler.cpp
+++ b/tests/test_http_error_handler.cpp
@@ -69,6 +69,19 @@ int main() {
                               "1234 bytes") != std::string::npos,
                       "empty OpenAI 413 did not become a payload-limit error");
 
+    httplib::Request ollama_request;
+    ollama_request.path = "/api/chat";
+    httplib::Response ollama_response;
+    ollama_response.status = 413;
+    const auto ollama_result =
+        ninfer::serve::handle_unrendered_http_error(options, ollama_request, ollama_response);
+    const Json ollama_body = Json::parse(ollama_response.body);
+    failures += check(ollama_result == httplib::Server::HandlerResponse::Handled &&
+                          ollama_body.at("error").is_string() &&
+                          ollama_body.at("error").get<std::string>().find("1234 bytes") !=
+                              std::string::npos,
+                      "empty Ollama 413 did not become a flat Ollama payload-limit error");
+
     httplib::Response authored_response;
     authored_response.status = 413;
     authored_response.set_content(R"({"error":{"code":"application_error"}})", "application/json");

--- a/tests/test_ollama_schema.cpp
+++ b/tests/test_ollama_schema.cpp
@@ -1,0 +1,474 @@
+// Contract test for the Ollama serving layer: /api/chat request parsing
+// (messages/images/thinking/tool_calls, options mapping and rejection, think,
+// num_ctx/num_predict, format rejection, stream default), preload detection and
+// model-name matching (`name:latest`), non-streaming response
+// and NDJSON frame shapes including the terminal timing fields, inventory
+// endpoint bodies, and the Ollama error body. This is the schema boundary
+// consumed by Open WebUI and other Ollama clients.
+
+#include "serve/ollama_schema.h"
+#include "serve/request.h"
+#include "serve/translate.h"
+
+#include <nlohmann/json.hpp>
+
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <string>
+
+namespace {
+
+using Json = nlohmann::json;
+using namespace ninfer::serve;
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << '\n';
+    return 1;
+}
+
+int check(bool condition, const std::string& message) { return condition ? 0 : fail(message); }
+
+std::string api_code(const std::function<void()>& f) {
+    try {
+        f();
+    } catch (const ApiException& error) { return error.error().code; } catch (...) {
+        return "wrong_exception";
+    }
+    return {};
+}
+
+std::string api_param(const std::function<void()>& f) {
+    try {
+        f();
+    } catch (const ApiException& error) { return error.error().param; } catch (...) {
+        return "wrong_exception";
+    }
+    return {};
+}
+
+RequestLimits default_limits() {
+    RequestLimits limits;
+    limits.default_max_tokens = 512;
+    limits.max_context        = 4096;
+    return limits;
+}
+
+Json user_only(const char* text) {
+    return Json{{"model", "m"},
+                {"messages", Json::array({Json{{"role", "user"}, {"content", text}}})}};
+}
+
+// One NDJSON frame is a JSON object followed by exactly one newline.
+Json parse_frame(const std::string& frame) {
+    if (frame.empty() || frame.back() != '\n' || frame.find('\n') != frame.size() - 1) {
+        throw std::runtime_error("bad NDJSON framing: " + frame);
+    }
+    return Json::parse(frame.substr(0, frame.size() - 1));
+}
+
+int test_parse_basic() {
+    int failures                = 0;
+    const GenerationRequest req = parse_ollama_chat_request(user_only("hello"), default_limits());
+    failures += check(req.model == "m", "model parsed");
+    failures += check(req.stream, "stream defaults true");
+    failures += check(req.max_tokens == 512 && !req.max_tokens_set, "server default budget");
+    failures +=
+        check(req.messages.size() == 1 && req.messages[0].role == ninfer::ChatRole::User &&
+                  req.messages[0].content.size() == 1 && req.messages[0].content[0].text == "hello",
+              "user text carried");
+
+    Json body                  = user_only("x");
+    body["stream"]             = false;
+    body["keep_alive"]         = "5m";
+    body["metadata"]           = Json{{"chat_id", "abc"}};
+    const GenerationRequest r2 = parse_ollama_chat_request(body, default_limits());
+    failures += check(!r2.stream, "stream false honored");
+
+    Json no_model = Json{{"messages", Json::array()}};
+    failures +=
+        check(api_param([&] { parse_ollama_chat_request(no_model, default_limits()); }) == "model",
+              "missing model rejected");
+    // Empty messages is the preload shape, never a generation request.
+    Json empty        = user_only("x");
+    empty["messages"] = Json::array();
+    failures +=
+        check(api_param([&] { parse_ollama_chat_request(empty, default_limits()); }) == "messages",
+              "empty messages rejected by the generation parser");
+    failures += check(ollama_preload_model(empty) == std::optional<std::string>("m"),
+                      "empty messages detected as preload");
+    failures += check(!ollama_preload_model(user_only("x")).has_value(),
+                      "non-empty messages is not preload");
+    failures += check(api_param([&] { ollama_preload_model(no_model); }) == "model",
+                      "preload still requires model");
+    Json missing_messages = Json{{"model", "m"}};
+    failures += check(!ollama_preload_model(missing_messages).has_value(),
+                      "missing messages is not preload");
+    failures += check(api_param([&] {
+                          parse_ollama_chat_request(missing_messages, default_limits());
+                      }) == "messages",
+                      "missing messages rejected");
+    const Json load = Json::parse(make_ollama_chat_load_response("m", "2026-01-01T00:00:00Z"));
+    failures += check(load.at("model") == "m" && load.at("done") == true &&
+                          load.at("done_reason") == "load" &&
+                          load.at("message").at("role") == "assistant" &&
+                          load.at("message").at("content") == "" && !load.contains("eval_count"),
+                      "load response shape");
+
+    failures += check(ollama_model_matches("m", "m"), "bare model name matches");
+    failures += check(ollama_model_matches("m:latest", "m"), "name:latest matches");
+    failures += check(ollama_model_matches("m:latest", "m:latest"), "exact tagged id matches");
+    failures += check(!ollama_model_matches("m:v2", "m") && !ollama_model_matches("mm", "m") &&
+                          !ollama_model_matches("m:latest:latest", "m") &&
+                          !ollama_model_matches("x:latest", "m"),
+                      "other tags and names do not match");
+    Json bad_role =
+        Json{{"model", "m"}, {"messages", Json::array({Json{{"role", "bot"}, {"content", "x"}}})}};
+    failures += check(api_code([&] { parse_ollama_chat_request(bad_role, default_limits()); }) ==
+                          "unsupported_role",
+                      "unknown role rejected");
+    Json empty_user =
+        Json{{"model", "m"}, {"messages", Json::array({Json{{"role", "user"}, {"content", ""}}})}};
+    failures += check(api_param([&] { parse_ollama_chat_request(empty_user, default_limits()); }) ==
+                          "messages",
+                      "empty user content rejected");
+    return failures;
+}
+
+int test_parse_history_thinking_tools_images() {
+    int failures    = 0;
+    const Json body = {
+        {"model", "m"},
+        {"tools", Json::array({Json{
+                      {"type", "function"},
+                      {"function",
+                       Json{{"name", "get_weather"},
+                            {"description", "weather"},
+                            {"parameters",
+                             Json{{"type", "object"},
+                                  {"properties", Json{{"city", Json{{"type", "string"}}}}}}}}}}})},
+        {"messages",
+         Json::array(
+             {Json{{"role", "system"}, {"content", "be terse"}},
+              Json{{"role", "user"}, {"content", "look"}, {"images", Json::array({"aGVsbG8="})}},
+              Json{
+                  {"role", "assistant"},
+                  {"content", ""},
+                  {"thinking", "I should call the tool"},
+                  {"tool_calls",
+                   Json::array({Json{{"function", Json{{"name", "get_weather"},
+                                                       {"arguments", Json{{"city", "Oslo"}}}}}}})}},
+              Json{{"role", "tool"}, {"content", "{\"temp\": 5}"}, {"tool_name", "get_weather"}},
+              Json{{"role", "user"}, {"content", "thanks"}}})}};
+    const GenerationRequest req = parse_ollama_chat_request(body, default_limits());
+    failures += check(req.tools.size() == 1 && req.tools[0].name == "get_weather", "tool parsed");
+    const Json definition = Json::parse(req.tools[0].definition_json);
+    failures += check(definition.at("type") == "function" &&
+                          definition.at("function").at("parameters").at("type") == "object",
+                      "tool normalized to OpenAI function object");
+    failures += check(req.uses_tools() && req.has_tool_history(), "tool history detected");
+    failures += check(req.messages.size() == 5, "all turns kept");
+    failures += check(req.messages[0].role == ninfer::ChatRole::System, "system turn first");
+    const ChatTurn& user = req.messages[1];
+    failures += check(user.content.size() == 2 && user.content[0].kind == ContentKind::Text &&
+                          user.content[1].kind == ContentKind::Image,
+                      "text then image parts");
+    failures +=
+        check(user.content[1].source.kind == ninfer::product::media_acquire::SourceKind::Data &&
+                  user.content[1].source.value.ends_with(";base64,aGVsbG8="),
+              "image is a base64 data source");
+    const ChatTurn& assistant = req.messages[2];
+    failures += check(assistant.reasoning_content == "I should call the tool",
+                      "assistant thinking round-tripped");
+    failures +=
+        check(assistant.tool_calls.size() == 1 && assistant.tool_calls[0].name == "get_weather" &&
+                  Json::parse(assistant.tool_calls[0].arguments_json).at("city") == "Oslo",
+              "tool call arguments serialized to JSON text");
+    failures += check(assistant.content.empty(), "empty assistant content dropped");
+    failures += check(req.messages[3].role == ninfer::ChatRole::Tool &&
+                          req.messages[3].content[0].text == "{\"temp\": 5}",
+                      "tool turn carried");
+
+    // The translated prompt keeps roles and reasoning for the template.
+    ServeOptions server;
+    ninfer::PromptCapabilities capabilities;
+    const ninfer::PromptInput input = to_prompt_input(
+        req, resolve_prompt_semantics(req, server, capabilities), [](const ContentPart& part) {
+            ninfer::OwnedMedia media;
+            media.kind = ninfer::MediaKind::Image;
+            media.bytes.push_back(0);
+            media.source_name = part.type_raw;
+            return media;
+        });
+    failures += check(input.messages.size() == 5 &&
+                          input.messages[2].reasoning_content == "I should call the tool",
+                      "reasoning reaches the prompt input");
+    failures += check(input.options.tool_jsons.size() == 1, "tool json reaches the prompt");
+
+    // An empty tool result is a legal turn (matches the OpenAI surface); a tool
+    // turn without content is not.
+    Json empty_tool                      = body;
+    empty_tool["messages"][3]["content"] = "";
+    const GenerationRequest empty_tool_req =
+        parse_ollama_chat_request(empty_tool, default_limits());
+    failures += check(empty_tool_req.messages[3].role == ninfer::ChatRole::Tool &&
+                          empty_tool_req.messages[3].content.size() == 1 &&
+                          empty_tool_req.messages[3].content[0].text.empty(),
+                      "empty tool content accepted as an empty text part");
+    Json no_tool_content = body;
+    no_tool_content["messages"][3].erase("content");
+    failures += check(api_param([&] {
+                          parse_ollama_chat_request(no_tool_content, default_limits());
+                      }) == "messages",
+                      "tool turn without content rejected");
+
+    // Missing parameters default to the same empty object schema as the OpenAI
+    // surfaces, so the template sees one shape per tool.
+    Json bare_tool = body;
+    bare_tool["tools"][0]["function"].erase("parameters");
+    const GenerationRequest bare_tool_req = parse_ollama_chat_request(bare_tool, default_limits());
+    const Json bare_definition            = Json::parse(bare_tool_req.tools[0].definition_json);
+    failures += check(bare_definition.at("function").at("parameters") ==
+                              Json{{"type", "object"}, {"properties", Json::object()}} &&
+                          bare_definition.at("function").at("strict") == false,
+                      "missing parameters default to the OpenAI empty schema");
+
+    Json bad_args                                                     = body;
+    bad_args["messages"][2]["tool_calls"][0]["function"]["arguments"] = "{\"city\":\"Oslo\"}";
+    failures += check(api_param([&] { parse_ollama_chat_request(bad_args, default_limits()); }) ==
+                          "messages",
+                      "string tool arguments rejected");
+    Json assistant_images                     = body;
+    assistant_images["messages"][2]["images"] = Json::array({"aGVsbG8="});
+    failures += check(api_param([&] {
+                          parse_ollama_chat_request(assistant_images, default_limits());
+                      }) == "messages",
+                      "assistant images rejected");
+    Json bad_tool                = body;
+    bad_tool["tools"][0]["type"] = "code_interpreter";
+    failures += check(api_code([&] { parse_ollama_chat_request(bad_tool, default_limits()); }) ==
+                          "tool_type_not_supported",
+                      "non-function tools rejected");
+    return failures;
+}
+
+int test_options_and_think() {
+    int failures                = 0;
+    Json body                   = user_only("x");
+    body["options"]             = Json{{"temperature", 0.6},
+                                       {"top_p", 0.95},
+                                       {"top_k", 20},
+                                       {"min_p", 0.05},
+                                       {"seed", 7},
+                                       {"num_predict", 128},
+                                       {"num_ctx", 4096},
+                                       {"presence_penalty", 0.5},
+                                       {"stop", Json::array({"<end>", ""})},
+                                       {"num_gpu", 99},
+                                       {"use_mmap", false}};
+    body["think"]               = false;
+    const GenerationRequest req = parse_ollama_chat_request(body, default_limits());
+    failures += check(req.sampling.temperature && *req.sampling.temperature == 0.6, "temperature");
+    failures += check(req.sampling.top_p && *req.sampling.top_p == 0.95, "top_p");
+    failures += check(req.sampling.top_k && *req.sampling.top_k == 20, "top_k");
+    failures += check(req.sampling.min_p && *req.sampling.min_p == 0.05, "min_p");
+    failures += check(req.sampling.seed && *req.sampling.seed == 7, "seed");
+    failures += check(req.sampling.presence_penalty && *req.sampling.presence_penalty == 0.5,
+                      "presence_penalty");
+    failures += check(req.max_tokens == 128 && req.max_tokens_set, "num_predict -> max_tokens");
+    failures += check(req.stop_strings.size() == 1 && req.stop_strings[0] == "<end>",
+                      "stop strings; empty entries dropped");
+    failures += check(req.enable_thinking && !*req.enable_thinking, "think false");
+    failures += check(!req.reasoning_effort, "no effort from boolean think");
+
+    // The Engine sampler is reachable through translation, including min_p.
+    ServeOptions server;
+    const ninfer::RequestOptions options = to_request_options(req, server);
+    failures +=
+        check(options.execution.sampling.min_p && *options.execution.sampling.min_p == 0.05F,
+              "min_p reaches the sampler overrides");
+    failures += check(options.execution.requested_output_tokens == 128, "output budget applied");
+    failures += check(options.stop.strings.size() == 1, "stop reaches request options");
+
+    Json infinite                 = user_only("x");
+    infinite["options"]           = Json{{"num_predict", -1}};
+    const GenerationRequest r_inf = parse_ollama_chat_request(infinite, default_limits());
+    failures += check(r_inf.max_tokens == 512 && !r_inf.max_tokens_set,
+                      "num_predict -1 keeps server default");
+    Json zero       = user_only("x");
+    zero["options"] = Json{{"num_predict", 0}};
+    failures += check(api_param([&] { parse_ollama_chat_request(zero, default_limits()); }) ==
+                          "options.num_predict",
+                      "num_predict 0 rejected");
+
+    Json big_ctx       = user_only("x");
+    big_ctx["options"] = Json{{"num_ctx", 8192}};
+    failures += check(api_code([&] { parse_ollama_chat_request(big_ctx, default_limits()); }) ==
+                          "context_length_exceeded",
+                      "num_ctx above the server window rejected");
+    Json small_ctx       = user_only("x");
+    small_ctx["options"] = Json{{"num_ctx", 1024}};
+    parse_ollama_chat_request(small_ctx, default_limits());
+
+    for (const char* key : {"repeat_penalty", "mirostat", "typical_p", "bogus"}) {
+        Json rejected       = user_only("x");
+        rejected["options"] = Json{{key, 1}};
+        failures += check(api_code([&] {
+                              parse_ollama_chat_request(rejected, default_limits());
+                          }) == "option_not_supported",
+                          std::string("options.") + key + " rejected");
+    }
+    Json null_option       = user_only("x");
+    null_option["options"] = Json{{"repeat_penalty", nullptr}};
+    parse_ollama_chat_request(null_option, default_limits());
+
+    Json format      = user_only("x");
+    format["format"] = "json";
+    failures += check(api_code([&] { parse_ollama_chat_request(format, default_limits()); }) ==
+                          "format_not_supported",
+                      "format rejected");
+
+    Json think_high                = user_only("x");
+    think_high["think"]            = "high";
+    const GenerationRequest r_high = parse_ollama_chat_request(think_high, default_limits());
+    failures += check(r_high.reasoning_effort &&
+                          *r_high.reasoning_effort == RequestedReasoningEffort::High &&
+                          r_high.reasoning_effort_param == "think",
+                      "think level maps to reasoning effort");
+    Json think_bad     = user_only("x");
+    think_bad["think"] = "ultra";
+    failures +=
+        check(api_param([&] { parse_ollama_chat_request(think_bad, default_limits()); }) == "think",
+              "unknown think level rejected");
+    return failures;
+}
+
+int test_response_and_frames() {
+    int failures = 0;
+    OllamaTimings timings;
+    timings.total_seconds       = 1.25;
+    timings.prompt_eval_seconds = 0.5;
+    timings.eval_seconds        = 0.75;
+    timings.prompt_eval_count   = 40;
+    timings.eval_count          = 30;
+
+    std::vector<ToolCall> calls;
+    calls.push_back(ToolCall{"call_1", "get_weather", "{\"city\":\"Oslo\"}"});
+    const Json body = Json::parse(make_ollama_chat_response(
+        "m", "2026-08-15T10:00:00.000000000Z", "answer", "thought", calls, "stop", timings));
+    failures += check(body.at("model") == "m" && body.at("created_at").is_string(), "envelope");
+    failures += check(body.at("done") == true && body.at("done_reason") == "stop", "done fields");
+    failures += check(body.at("message").at("role") == "assistant" &&
+                          body.at("message").at("content") == "answer" &&
+                          body.at("message").at("thinking") == "thought",
+                      "message content and thinking");
+    const Json& call = body.at("message").at("tool_calls").at(0);
+    failures += check(call.at("id") == "call_1" && call.at("function").at("index") == 0 &&
+                          call.at("function").at("name") == "get_weather" &&
+                          call.at("function").at("arguments").at("city") == "Oslo",
+                      "tool call arguments are a JSON object");
+    failures += check(body.at("total_duration") == 1250000000 && body.at("load_duration") == 0 &&
+                          body.at("prompt_eval_count") == 40 &&
+                          body.at("prompt_eval_duration") == 500000000 &&
+                          body.at("eval_count") == 30 && body.at("eval_duration") == 750000000,
+                      "timings in integer nanoseconds");
+
+    const Json content = parse_frame(make_ollama_chat_content_frame("m", "t", "hi"));
+    failures +=
+        check(content.at("done") == false && content.at("message").at("content") == "hi" &&
+                  !content.at("message").contains("thinking") && !content.contains("eval_count"),
+              "content frame");
+    const Json thinking = parse_frame(make_ollama_chat_thinking_frame("m", "t", "hmm"));
+    failures += check(thinking.at("message").at("content") == "" &&
+                          thinking.at("message").at("thinking") == "hmm",
+                      "thinking frame");
+    const Json tools = parse_frame(make_ollama_chat_tool_calls_frame("m", "t", calls));
+    failures += check(tools.at("done") == false && tools.at("message").at("tool_calls").size() == 1,
+                      "tool call frame");
+    const Json done = parse_frame(make_ollama_chat_done_frame("m", "t", "length", timings));
+    failures += check(done.at("done") == true && done.at("done_reason") == "length" &&
+                          done.at("message").at("content") == "" && done.at("eval_count") == 30 &&
+                          done.at("eval_duration") == 750000000,
+                      "done frame carries timings");
+
+    // A minimal non-streaming reply never emits thinking/tool_calls keys.
+    const Json plain =
+        Json::parse(make_ollama_chat_response("m", "t", "", "", {}, "stop", OllamaTimings{}));
+    failures += check(
+        plain.at("message").at("content") == "" && !plain.at("message").contains("thinking") &&
+            !plain.at("message").contains("tool_calls") && plain.at("eval_duration") == 0,
+        "empty outcome shape");
+    return failures;
+}
+
+int test_inventory_and_errors() {
+    int failures = 0;
+    OllamaModelFacts facts;
+    facts.model_id        = "qwen3.8-27b/groupwise-int";
+    facts.target          = "qwen3_8_27b";
+    facts.weights_id      = "groupwise-int";
+    facts.modified_at     = ollama_timestamp(1755000000123456789LL);
+    facts.size_bytes      = 18210531328ULL;
+    facts.size_vram_bytes = 17000000000ULL;
+    facts.max_context     = 16384;
+    facts.vision          = true;
+    facts.thinking        = true;
+
+    failures += check(facts.modified_at == "2025-08-12T12:00:00.123456789Z", "RFC 3339 timestamp");
+
+    const Json tags = Json::parse(make_ollama_tags(facts));
+    const Json& tag = tags.at("models").at(0);
+    failures += check(tags.at("models").size() == 1 && tag.at("model") == facts.model_id &&
+                          tag.at("name") == facts.model_id,
+                      "tags lists the one resident model");
+    failures +=
+        check(tag.at("size") == 18210531328ULL && tag.at("modified_at") == facts.modified_at,
+              "tags size and timestamp");
+    failures += check(tag.at("details").at("family") == "qwen3_8_27b" &&
+                          tag.at("details").at("quantization_level") == "groupwise-int" &&
+                          tag.at("details").at("format") == "ninfer",
+                      "tags details");
+
+    const Json show = Json::parse(make_ollama_show(facts));
+    failures += check(show.at("details").at("family") == "qwen3_8_27b", "show details");
+    failures += check(show.at("model_info").at("qwen3_8_27b.context_length") == 16384,
+                      "show context length");
+    const Json& capabilities = show.at("capabilities");
+    failures += check(capabilities.size() == 4 && capabilities[0] == "completion" &&
+                          capabilities[1] == "tools" && capabilities[2] == "vision" &&
+                          capabilities[3] == "thinking",
+                      "show capabilities");
+    facts.vision = false;
+    failures += check(Json::parse(make_ollama_show(facts)).at("capabilities").size() == 3,
+                      "vision capability follows the server flag");
+
+    const Json ps = Json::parse(make_ollama_ps(facts));
+    failures += check(ps.at("models").at(0).at("size_vram") == 17000000000ULL &&
+                          ps.at("models").at(0).at("model") == facts.model_id,
+                      "ps reports the resident model");
+
+    const Json version = Json::parse(make_ollama_version());
+    failures += check(version.at("version") == kOllamaCompatVersion, "version body");
+
+    ApiError err;
+    err.status  = 404;
+    err.message = "model 'x' not found";
+    failures += check(Json::parse(make_ollama_error_body(err)).at("error") == "model 'x' not found",
+                      "error body");
+    const Json frame = parse_frame(make_ollama_error_frame(err));
+    failures += check(frame.at("error") == "model 'x' not found", "error frame");
+    return failures;
+}
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    failures += test_parse_basic();
+    failures += test_parse_history_thinking_tools_images();
+    failures += test_options_and_think();
+    failures += test_response_and_frames();
+    failures += test_inventory_and_errors();
+    if (failures == 0) { std::cout << "ok\n"; }
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_ollama_schema.cpp
+++ b/tests/test_ollama_schema.cpp
@@ -306,9 +306,32 @@ int test_options_and_think() {
     failures += check(api_code([&] { parse_ollama_chat_request(big_ctx, default_limits()); }) ==
                           "context_length_exceeded",
                       "num_ctx above the server window rejected");
-    Json small_ctx       = user_only("x");
-    small_ctx["options"] = Json{{"num_ctx", 1024}};
-    parse_ollama_chat_request(small_ctx, default_limits());
+    Json small_ctx                  = user_only("x");
+    small_ctx["options"]            = Json{{"num_ctx", 1024}};
+    const GenerationRequest r_small = parse_ollama_chat_request(small_ctx, default_limits());
+    failures += check(r_small.context_window == 1024 && r_small.max_tokens == 512,
+                      "num_ctx narrows the request window without touching the output budget");
+    failures += check(req.context_window == 4096, "num_ctx at the server window carried");
+    failures += check(r_inf.context_window == 0, "no num_ctx => server window");
+
+    // -2 fills the window: the request asks for the whole window (num_ctx if
+    // given, else the server window) and preparation clamps to the remainder.
+    Json fill                      = user_only("x");
+    fill["options"]                = Json{{"num_predict", -2}};
+    const GenerationRequest r_fill = parse_ollama_chat_request(fill, default_limits());
+    failures += check(r_fill.max_tokens == 4096 && r_fill.max_tokens_set,
+                      "num_predict -2 requests the server window");
+    Json fill_ctx                      = user_only("x");
+    fill_ctx["options"]                = Json{{"num_predict", -2}, {"num_ctx", 1024}};
+    const GenerationRequest r_fill_ctx = parse_ollama_chat_request(fill_ctx, default_limits());
+    failures += check(r_fill_ctx.max_tokens == 1024 && r_fill_ctx.max_tokens_set &&
+                          r_fill_ctx.context_window == 1024,
+                      "num_predict -2 with num_ctx requests that window");
+    RequestLimits unbounded;
+    unbounded.default_max_tokens             = 512;
+    const GenerationRequest r_fill_unbounded = parse_ollama_chat_request(fill, unbounded);
+    failures += check(r_fill_unbounded.max_tokens == 512 && !r_fill_unbounded.max_tokens_set,
+                      "num_predict -2 without a known window keeps the server default");
 
     for (const char* key : {"repeat_penalty", "mirostat", "typical_p", "bogus"}) {
         Json rejected       = user_only("x");

--- a/tools/smoke/serve_contract.py
+++ b/tools/smoke/serve_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import time
 import urllib.error
 import urllib.request
@@ -47,6 +48,23 @@ def request(base_url: str, method: str, path: str, payload: Any | None = None) -
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
         raise ContractError(f"{method} {path} returned HTTP {error.code}: {detail}") from error
+
+
+def expect_http_error(
+    base_url: str, method: str, path: str, payload: Any, status: int
+) -> dict[str, Any]:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    req = urllib.request.Request(base_url + path, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=300) as response:
+            raise ContractError(f"{method} {path} returned HTTP {response.status}, expected {status}")
+    except urllib.error.HTTPError as error:
+        if error.code != status:
+            raise ContractError(
+                f"{method} {path} returned HTTP {error.code}, expected {status}"
+            ) from error
+        return json.loads(error.read().decode("utf-8"))
 
 
 def json_response(
@@ -426,6 +444,30 @@ def exercise_ollama(base_url: str, model: str, count_tokens: int) -> dict[str, A
         raise ContractError("Ollama streamed and non-streaming eval_count differ")
     if terminal["done_reason"] != nonstream["done_reason"]:
         raise ContractError("Ollama streamed and non-streaming done_reason differ")
+
+    # num_ctx narrows the request window at preparation: a window the prompt does
+    # not fit is rejected, and num_predict -2 fills what remains of a window it does.
+    too_small = expect_http_error(
+        base_url, "POST", "/api/chat", {**prompt, "options": {"num_ctx": 1}}, 400
+    )
+    match = re.fullmatch(
+        r"prompt of (\d+) tokens exceeds the requested context window of 1 tokens",
+        str(too_small.get("error", "")),
+    )
+    if match is None:
+        raise ContractError("Ollama num_ctx below the prompt length was not rejected")
+    prompt_tokens = int(match.group(1))
+    window = prompt_tokens + 8
+    filled = json_response(
+        base_url,
+        "POST",
+        "/api/chat",
+        {**prompt, "options": {"temperature": 0, "num_ctx": window, "num_predict": -2}},
+    )
+    require_ollama_terminal(filled)
+    # The last generated token needs no context slot: window - prompt + 1 tokens fit.
+    if filled["done_reason"] != "length" or filled["eval_count"] != window - prompt_tokens + 1:
+        raise ContractError("Ollama num_predict -2 did not fill the num_ctx window")
     return {
         "ollama_done_reason": nonstream["done_reason"],
         "ollama_prompt_eval_count": nonstream["prompt_eval_count"],

--- a/tools/smoke/serve_contract.py
+++ b/tools/smoke/serve_contract.py
@@ -323,6 +323,119 @@ def parse_responses_stream(response: Response) -> tuple[str, str, dict[str, Any]
     return terminal_content, terminal_reasoning, terminal
 
 
+_OLLAMA_TIMING_KEYS = (
+    "total_duration",
+    "load_duration",
+    "prompt_eval_count",
+    "prompt_eval_duration",
+    "eval_count",
+    "eval_duration",
+)
+
+
+def require_ollama_terminal(frame: dict[str, Any]) -> None:
+    if frame.get("done") is not True or frame.get("done_reason") not in {"stop", "length"}:
+        raise ContractError(f"invalid Ollama terminal frame: {frame!r}")
+    for key in _OLLAMA_TIMING_KEYS:
+        value = frame.get(key)
+        if not isinstance(value, int) or value < 0:
+            raise ContractError(f"invalid Ollama {key}: {value!r}")
+    if frame["eval_count"] <= 0 or frame["eval_duration"] <= 0:
+        raise ContractError("Ollama terminal frame reports no timed decode")
+    if frame["total_duration"] < frame["prompt_eval_duration"] + frame["eval_duration"]:
+        raise ContractError("Ollama total_duration is shorter than its phases")
+
+
+def parse_ollama_stream(response: Response) -> tuple[str, str, dict[str, Any]]:
+    if response.status != 200 or response.content_type != "application/x-ndjson":
+        raise ContractError(
+            f"Ollama stream returned status={response.status} content-type={response.content_type}"
+        )
+    content: list[str] = []
+    thinking: list[str] = []
+    terminal: dict[str, Any] | None = None
+    for line in response.body.decode("utf-8").split("\n"):
+        if not line:
+            continue
+        if terminal is not None:
+            raise ContractError("Ollama stream continued after the done frame")
+        frame = json.loads(line)
+        if "error" in frame:
+            raise ContractError(f"Ollama stream error: {frame['error']!r}")
+        message = frame.get("message")
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            raise ContractError("Ollama frame is missing the assistant message")
+        content.append(message.get("content", ""))
+        thinking.append(message.get("thinking", ""))
+        if frame.get("done"):
+            terminal = frame
+        elif any(key in frame for key in _OLLAMA_TIMING_KEYS):
+            raise ContractError("Ollama timing fields appeared before the done frame")
+    if terminal is None:
+        raise ContractError("Ollama stream ended without a done frame")
+    require_ollama_terminal(terminal)
+    return "".join(content), "".join(thinking), terminal
+
+
+def exercise_ollama(base_url: str, model: str, count_tokens: int) -> dict[str, Any]:
+    version = json_response(base_url, "GET", "/api/version")
+    if not isinstance(version.get("version"), str):
+        raise ContractError("Ollama version has the wrong shape")
+    tags = json_response(base_url, "GET", "/api/tags")
+    entries = tags.get("models")
+    if not isinstance(entries, list) or len(entries) != 1 or entries[0].get("model") != model:
+        raise ContractError("Ollama tags do not list the configured model")
+    show = json_response(base_url, "POST", "/api/show", {"model": model})
+    if "completion" not in show.get("capabilities", []) or not isinstance(
+        show.get("details"), dict
+    ):
+        raise ContractError("Ollama show has the wrong shape")
+    loaded = json_response(base_url, "GET", "/api/ps")
+    if [entry.get("model") for entry in loaded.get("models", [])] != [model]:
+        raise ContractError("Ollama ps does not report the resident model")
+    # Ollama-native clients address untagged models as name:latest and warm
+    # them with an empty-messages preload call.
+    tagged = f"{model}:latest"
+    if "capabilities" not in json_response(base_url, "POST", "/api/show", {"name": tagged}):
+        raise ContractError("Ollama show does not accept the name:latest spelling")
+    preload = json_response(base_url, "POST", "/api/chat", {"model": tagged, "messages": []})
+    if preload.get("done") is not True or preload.get("done_reason") != "load":
+        raise ContractError("Ollama preload request did not report done_reason load")
+    if preload.get("model") != tagged or preload.get("message", {}).get("content") != "":
+        raise ContractError("Ollama preload response has the wrong shape")
+
+    prompt = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Reply briefly."}],
+        "options": {"temperature": 0, "num_predict": 4},
+        "stream": False,
+    }
+    nonstream = json_response(base_url, "POST", "/api/chat", prompt)
+    require_ollama_terminal(nonstream)
+    message = nonstream.get("message")
+    if not isinstance(message, dict) or not isinstance(message.get("content"), str):
+        raise ContractError("Ollama response is missing the assistant message")
+    if nonstream["prompt_eval_count"] > count_tokens:
+        raise ContractError("Ollama prompt_eval_count exceeds the prompt token count")
+
+    streamed = request(base_url, "POST", "/api/chat", {**prompt, "stream": True})
+    content, thinking, terminal = parse_ollama_stream(streamed)
+    if content != message.get("content", "") or thinking != message.get("thinking", ""):
+        raise ContractError("Ollama streamed output differs from the greedy non-streaming reply")
+    if terminal["eval_count"] != nonstream["eval_count"]:
+        raise ContractError("Ollama streamed and non-streaming eval_count differ")
+    if terminal["done_reason"] != nonstream["done_reason"]:
+        raise ContractError("Ollama streamed and non-streaming done_reason differ")
+    return {
+        "ollama_done_reason": nonstream["done_reason"],
+        "ollama_prompt_eval_count": nonstream["prompt_eval_count"],
+        "ollama_eval_count": nonstream["eval_count"],
+        "ollama_eval_tokens_per_second": round(
+            nonstream["eval_count"] / (nonstream["eval_duration"] / 1e9), 1
+        ),
+    }
+
+
 def exercise(base_url: str, model: str) -> dict[str, Any]:
     models = json_response(base_url, "GET", "/v1/models")
     entries = models.get("data")
@@ -486,8 +599,10 @@ def exercise(base_url: str, model: str) -> dict[str, Any]:
     if anthropic_input_tokens != input_tokens:
         raise ContractError("Anthropic usage input_tokens differs from count_tokens")
 
+    ollama = exercise_ollama(base_url, model, input_tokens)
+
     return {
-        "format": "ninfer_serve_contract_v2",
+        "format": "ninfer_serve_contract_v3",
         "model": model,
         "count_tokens": input_tokens,
         "openai_finish_reason": stream_finish,
@@ -496,6 +611,7 @@ def exercise(base_url: str, model: str) -> dict[str, Any]:
         "responses_output_tokens": response_output_tokens,
         "image_prompt_tokens": image_prompt_tokens,
         "anthropic_stop_reason": anthropic["stop_reason"],
+        **ollama,
     }
 
 


### PR DESCRIPTION
Closes #17.

## Problem

Ollama-aware clients (Open WebUI, Koder, ...) probe `/api/tags`, `/api/show`, `/api/version` and
chat over `/api/chat`. Beyond compatibility, the Ollama terminal frame carries
`prompt_eval_count`/`prompt_eval_duration` and `eval_count`/`eval_duration`, which those clients
render as prompt and response token/s. Neither the OpenAI nor the Anthropic contract can express
per-request phase timings, so users of those clients cannot see NInfer's prefill/decode rates today.

## Design

A new `src/serve/ollama_schema.{h,cpp}` layer, shaped like the existing `openai_schema` /
`anthropic_schema` layers, maps the Ollama chat request onto the wire-agnostic `GenerationRequest`
and serializes `GenerationOutcome` back into Ollama bodies. `http_server.cpp` mounts
`POST /api/chat` (non-streaming and NDJSON streaming) plus the read-only inventory endpoints
`GET /api/tags`, `POST /api/show`, `GET /api/ps`, `GET /api/version`. No Engine or target code
changes; the only shared-layer additions are `SamplingParams::min_p` and `RequestLimits::max_context`
(carried through `translate`), needed to map Ollama `options.min_p` and `options.num_ctx`.

The timing fields use the same phase boundaries as `request_done.timings_seconds` in the structured
request log: `prompt_eval_count` is the prompt suffix actually computed by prefill (excluding the
reused resident prefix), `eval_count` is accepted generated tokens, and `eval_duration` is the decode
phase after the first token. `load_duration` is `0` because the model is resident.

## Contract

- `POST /api/chat`: `system`/`user`/`assistant`/`tool` history with string content, user `images`
  as bare base64, assistant `thinking` and object-argument `tool_calls`, OpenAI-shaped function
  `tools`, `think` as boolean or `low|medium|high` (checked against the loaded template like
  `reasoning_effort`), `stream` defaulting to true, and `options` mapped onto the sampler
  (`temperature`, `top_p`, `top_k`, `min_p`, `seed`, `presence_penalty`, `frequency_penalty`,
  `stop`), `num_predict`, and `num_ctx` bounded by `--max-context`. `format` and sampler knobs the
  Engine does not implement are rejected; runner knobs and `keep_alive` are accepted without
  effect. `model` may be the advertised id or its `:latest` spelling; an empty `messages` array is
  answered as Ollama's preload request (`done_reason: "load"`).
- Inventory endpoints report artifact size/timestamp, weight profile, frozen context length, and
  `completion`/`tools`/`vision`/`thinking` capabilities for the one resident model. Model
  management, `/api/generate`, and embeddings are not served.
- `/api/*` errors use the Ollama `{"error": "..."}` body (including 401/413 and any error escaping
  a handler — the server-wide exception handler now renders by path, as the 401/413 pre-handlers
  already did); the bearer token is the existing `--api-key`. Request log protocol is
  `ollama_chat`, with the same `request_start`/`request_rejected`/`request_done` lifecycle as the
  other generation protocols.
- Full contract in `docs/serving.md` ("Ollama chat"); surface lists updated in `README.md`,
  `docs/README.md`, `tests/README.md`, `AGENTS.md`, and the `ninfer-serve` usage text.

## Verification

Toolchain: `nvidia/cuda:13.1.2-devel-ubuntu24.04` container, `CMAKE_CUDA_ARCHITECTURES=120a`,
Release build, RTX 5090, branch rebased on `master` @ 5f45a26f, single commit 0bfc73da.

```
cmake --build build -j
ctest --test-dir build -R 'ninfer_(request_memory|sampling_defaults|openai_schema|responses_schema|anthropic_schema|ollama_schema|serve_options|request_log|http_error_handler|sampling)_test' --output-on-failure
# 100% tests passed, 0 tests failed out of 10
```

New `ninfer_ollama_schema_test` covers request parsing, rejection codes, preload detection and
`:latest` model matching, non-streaming/streaming frame shapes, timing fields, and inventory
bodies; `ninfer_http_error_handler_test` gains the `/api/*` error-body cases.

End-to-end serving contract (OpenAI Chat/Responses, Anthropic, Ollama inventory + preload +
non-stream + NDJSON stream, multimodal), against a resident `qwen3_8_27b.ninfer` artifact:

```
./build/apps/ninfer-serve /models/qwen3_8_27b.ninfer --host 127.0.0.1 --port 18080 --vision
python3 -m tools.smoke.serve_contract --base-url http://127.0.0.1:18080 --model qwen3.8-27b
```

```json
{
  "format": "ninfer_serve_contract_v3",
  "model": "qwen3.8-27b",
  "count_tokens": 55,
  "openai_finish_reason": "length",
  "openai_completion_tokens": 4,
  "responses_input_tokens": 59,
  "responses_output_tokens": 16,
  "image_prompt_tokens": 125,
  "anthropic_stop_reason": "max_tokens",
  "ollama_done_reason": "length",
  "ollama_prompt_eval_count": 2,
  "ollama_eval_count": 4,
  "ollama_eval_tokens_per_second": 113.5
}
```

Also exercised by hand with `--request-log-jsonl`: a `think: "high"` request over `/api/chat`
returns the Ollama error body and produces a `request_rejected` (phase `prepare`) record;
`model: "qwen3.8-27b:latest"` chats and is echoed back; an empty tool result in the history is
accepted; the model-not-found preload returns 404.

Manually verified with Open WebUI (Ollama connection) against this exact build: a two-turn
conversation (second turn hit the prefix cache and round-tripped four native tool calls plus the
tool-result turn), an image message, and Open WebUI's side requests (title/tags/follow-ups), all
with prompt/response token/s rendered from the terminal frame; 13 `ollama_chat` requests in the
request log, no rejections.

Not run: the CUDA operator, artifact, and target test suites — this change does not touch them.

No performance claim is made; the change is a serialization layer over the existing Engine path.

## AI disclosure

The implementation was generated entirely by Claude Fable 5 (`claude-fable-5`, via Claude Code),
including a multi-agent review pass over the diff whose findings were fixed before this PR. I
reviewed the complete diff and the verification results above, and did the manual Open WebUI
testing myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pBx1ApfndwnpKyWvexdEH
