### PR TITLE
feat(serve): accept codex Responses-API client hints

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -216,7 +216,7 @@ wire response contains typed `output` Items.
 | `chat_template_kwargs.preserve_thinking` | optional boolean controlling whether closed-turn reasoning remains in reconstructed prompts |
 | `preserve_thinking` | top-level alias for the same option; conflicting values are rejected |
 | `text.format` | omitted or `{"type":"text"}` only |
-| `tools` | function definitions are used; known non-function tool types (`web_search`, `tool_search`, `custom`, `namespace`, `file_search`) are validated and ignored; see below |
+| `tools` | flat function definitions and `namespace` groups of function definitions are used; `web_search` and `tool_search` are validated and ignored; other tool types are rejected; see below |
 | `tool_choice` | `auto` or `none` |
 | `parallel_tool_calls` | optional boolean; `true` or `false` both accepted. Parallel tool calls are the server’s only mode; `false` is validated and ignored, the response always reports `true` |
 | `truncation` | omitted or `disabled`; overlong input fails instead of silently dropping Items |
@@ -233,10 +233,11 @@ wire response contains typed `output` Items.
 Unknown top-level fields fail with `unknown_parameter`. Recognized but unsupported features fail
 with a field-specific 400 error instead of being silently ignored. Harmless client hints
 (`prompt_cache_key`, `prompt_cache_options`, `prompt_cache_retention`, `include`,
-`client_metadata`, `parallel_tool_calls=false`, `reasoning.summary`, and non-function tool types)
-are validated for shape and then ignored: they tune client-side caching, carry client metadata,
-request a parallel-tool-call mode or reasoning-summary streaming that cannot be enforced, or
-declare client-side capabilities this server does not execute (matching vLLM behavior).
+`client_metadata`, `parallel_tool_calls=false`, `reasoning.summary`, and the `web_search` and
+`tool_search` tool types) are validated for shape and then ignored: they tune client-side caching,
+carry client metadata, request a parallel-tool-call mode or reasoning-summary streaming that
+cannot be enforced, or declare client-side capabilities this server does not execute. Ignoring
+them never changes generated output.
 
 ### Input Item contract
 
@@ -288,10 +289,35 @@ NInfer renders these definitions in the Qwen prompt and parses model output into
 `function_call` output Items. Each output has a protocol Item `id` (`fc_...`) and a distinct
 `call_id` (`call_...`). The client executes the function and sends a `function_call_output` Item in
 a later request. NInfer does not execute functions or enforce JSON Schema through constrained
-decoding, so `strict:true`, `tool_choice:required`, named tool choice, hosted tools, and MCP tools
-are rejected. Known non-function tool types (`web_search`, `tool_search`, `custom`, `namespace`,
-`file_search`) declare client-side capabilities this server does not execute: they are validated
-for shape and ignored, and the model is not primed to call them.
+decoding, so `strict:true`, `tool_choice:required`, and named tool choice are rejected.
+
+Function definitions may also be grouped under a `namespace` tool, which is how the OpenAI Codex CLI
+declares every MCP server:
+
+```json
+{
+  "type": "namespace",
+  "name": "mcp__clock",
+  "description": "Tools for working with clock.",
+  "tools": [
+    {"type": "function", "name": "now", "parameters": {"type": "object", "properties": {}}}
+  ]
+}
+```
+
+The Qwen prompt format has no tool namespaces, so each nested function is primed under the flat
+name `<namespace>__<name>` (`mcp__clock__now` above), following the same convention as vLLM. The
+flat name must still match `[A-Za-z0-9_-]{1,64}` and must not collide with another tool. When the
+model calls a namespaced function, the emitted `function_call` Item carries the wire-level split
+(`"name":"now"`, `"namespace":"mcp__clock"`) so the client can route it; plain function calls carry
+no `namespace`. Inbound `function_call` history Items may carry `namespace` and are replayed to the
+model under the same flat name. The response `tools` array echoes namespace tools as declared.
+
+`web_search` and `tool_search` declare client-side capabilities this server does not execute: they
+are validated for shape and ignored, and the model is not primed to call them. Every other tool
+type (`custom`, `file_search`, `mcp`, `code_interpreter`, and so on) is rejected with
+`tool_type_not_supported`, whether top-level or nested in a namespace, because it would need
+server-side execution or constrained decoding.
 
 ### Response object and usage
 
@@ -398,9 +424,9 @@ curl http://127.0.0.1:8080/v1/responses/input_tokens \
 ```
 
 Unsupported Create fields include Conversations, prompt templates, context management, hosted
-moderation, prompt-cache controls, safety/user identifiers, Structured Outputs/JSON mode,
-background execution, compaction, files/audio, and OpenAI-hosted/MCP/custom tools that would be
-executed server-side. These are compatibility boundaries, not silently accepted placeholders.
+moderation, safety/user identifiers, Structured Outputs/JSON mode, background execution,
+compaction, files/audio, and OpenAI-hosted/MCP/custom tools that would be executed server-side.
+These are compatibility boundaries, not silently accepted placeholders.
 
 ## Anthropic Messages
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -212,21 +212,31 @@ wire response contains typed `output` Items.
 | `top_p` | finite number in `[0,1]` |
 | `metadata` | at most 16 string pairs; keys at most 64 characters and values at most 512 |
 | `reasoning.effort` | `none` disables thinking; `low`, `medium`, or `xhigh` selects an effort exposed by the loaded chat template; `minimal`, `high`, and `max` return `reasoning_effort_not_supported` for the registered templates |
+| `reasoning.summary` | optional string (e.g. `auto`) or `null`, accepted and ignored (client hint for streaming reasoning summaries, not implemented) |
 | `chat_template_kwargs.preserve_thinking` | optional boolean controlling whether closed-turn reasoning remains in reconstructed prompts |
 | `preserve_thinking` | top-level alias for the same option; conflicting values are rejected |
 | `text.format` | omitted or `{"type":"text"}` only |
-| `tools` | flat Responses function definitions; see below |
+| `tools` | function definitions are used; known non-function tool types (`web_search`, `tool_search`, `custom`, `namespace`, `file_search`) are validated and ignored; see below |
 | `tool_choice` | `auto` or `none` |
-| `parallel_tool_calls` | omitted or `true` |
+| `parallel_tool_calls` | optional boolean; `true` or `false` both accepted. Parallel tool calls are the server’s only mode; `false` is validated and ignored, the response always reports `true` |
 | `truncation` | omitted or `disabled`; overlong input fails instead of silently dropping Items |
 | `top_logprobs` | omitted or `0` |
 | `service_tier` | omitted, `auto`, or `default`; the response reports `default` |
 | `background` | omitted or `false` |
-| `include` | omitted or an empty array |
+| `include` | accepted array of strings, e.g. `["reasoning.encrypted_content"]`; requested-extra response fields are ignored |
+| `prompt_cache_key` | optional string, accepted and ignored (client-side prompt-cache routing hint) |
+| `prompt_cache_options` | optional object, accepted and ignored (client-side prompt-cache hint) |
+| `prompt_cache_retention` | optional string, accepted and ignored (client-side prompt-cache hint) |
+| `client_metadata` | optional object, accepted and ignored (client-supplied metadata, e.g. Codex trace context) |
 | `stream_options` | omitted or `{"include_obfuscation":false}` |
 
 Unknown top-level fields fail with `unknown_parameter`. Recognized but unsupported features fail
-with a field-specific 400 error instead of being silently ignored.
+with a field-specific 400 error instead of being silently ignored. Harmless client hints
+(`prompt_cache_key`, `prompt_cache_options`, `prompt_cache_retention`, `include`,
+`client_metadata`, `parallel_tool_calls=false`, `reasoning.summary`, and non-function tool types)
+are validated for shape and then ignored: they tune client-side caching, carry client metadata,
+request a parallel-tool-call mode or reasoning-summary streaming that cannot be enforced, or
+declare client-side capabilities this server does not execute (matching vLLM behavior).
 
 ### Input Item contract
 
@@ -278,8 +288,10 @@ NInfer renders these definitions in the Qwen prompt and parses model output into
 `function_call` output Items. Each output has a protocol Item `id` (`fc_...`) and a distinct
 `call_id` (`call_...`). The client executes the function and sends a `function_call_output` Item in
 a later request. NInfer does not execute functions or enforce JSON Schema through constrained
-decoding, so `strict:true`, `tool_choice:required`, named tool choice, hosted tools, MCP tools, and
-custom free-form tools are rejected.
+decoding, so `strict:true`, `tool_choice:required`, named tool choice, hosted tools, and MCP tools
+are rejected. Known non-function tool types (`web_search`, `tool_search`, `custom`, `namespace`,
+`file_search`) declare client-side capabilities this server does not execute: they are validated
+for shape and ignored, and the model is not primed to call them.
 
 ### Response object and usage
 
@@ -387,8 +399,8 @@ curl http://127.0.0.1:8080/v1/responses/input_tokens \
 
 Unsupported Create fields include Conversations, prompt templates, context management, hosted
 moderation, prompt-cache controls, safety/user identifiers, Structured Outputs/JSON mode,
-non-empty `include`, background execution, compaction, files/audio, and OpenAI-hosted/MCP/custom
-tools. These are compatibility boundaries, not silently accepted placeholders.
+background execution, compaction, files/audio, and OpenAI-hosted/MCP/custom tools that would be
+executed server-side. These are compatibility boundaries, not silently accepted placeholders.
 
 ## Anthropic Messages
 

--- a/src/serve/responses_schema.cpp
+++ b/src/serve/responses_schema.cpp
@@ -453,8 +453,20 @@ void parse_tools(const Json& body, ResponsesRequest& out) {
         if (!item.is_object() || !item.contains("type") || !item.at("type").is_string()) {
             bad_request("tools entries must be objects with a string type", "tools");
         }
-        if (item.at("type").get<std::string>() != "function") {
-            bad_request("only function tools are supported", "tools", "tool_type_not_supported");
+        const std::string tool_type = item.at("type").get<std::string>();
+        if (tool_type != "function") {
+            // Non-function tools (web search, tool search, freeform custom
+            // tools, tool namespaces, file search) declare client-side
+            // capabilities this server does not execute. They are validated
+            // for shape (a string type) and ignored (vLLM/OpenAI parity); the
+            // model is not primed to call them.
+            if (tool_type != "web_search" && tool_type != "tool_search" &&
+                tool_type != "custom" && tool_type != "namespace" &&
+                tool_type != "file_search") {
+                bad_request("unsupported tool type: " + tool_type, "tools",
+                            "tool_type_not_supported");
+            }
+            continue;
         }
         ToolDefinition tool;
         tool.name = require_function_name(item, "tools");
@@ -532,7 +544,16 @@ void parse_reasoning(const Json& body, ResponsesRequest& out) {
     const Json& reasoning = body.at("reasoning");
     if (!reasoning.is_object()) { bad_request("reasoning must be an object", "reasoning"); }
     for (auto it = reasoning.begin(); it != reasoning.end(); ++it) {
-        if (it.key() != "effort" && !it.value().is_null()) {
+        if (it.key() == "effort") { continue; }
+        if (it.key() == "summary") {
+            // Client asks to stream reasoning summaries; not implemented, so
+            // the value ("auto", "none", ...) is validated and ignored.
+            if (!it.value().is_null() && !it.value().is_string()) {
+                bad_request("reasoning.summary must be a string", "reasoning");
+            }
+            continue;
+        }
+        if (!it.value().is_null()) {
             bad_request("reasoning." + it.key() + " is not supported", "reasoning",
                         "reasoning_option_not_supported");
         }
@@ -573,6 +594,7 @@ void reject_unknown_top_level(const Json& body) {
     static const std::unordered_set<std::string> allowed = {
         "background",
         "chat_template_kwargs",
+        "client_metadata",
         "context_management",
         "conversation",
         "include",
@@ -614,8 +636,7 @@ void reject_unknown_top_level(const Json& body) {
 
 void reject_server_managed_features(const Json& body) {
     for (const char* key : {"context_management", "conversation", "max_tool_calls", "moderation",
-                            "prompt", "prompt_cache_key", "prompt_cache_options",
-                            "prompt_cache_retention", "safety_identifier", "user"}) {
+                            "prompt", "safety_identifier", "user"}) {
         if (body.contains(key) && !body.at(key).is_null()) {
             bad_request(std::string(key) + " is not supported", key, "parameter_not_supported");
         }
@@ -631,19 +652,19 @@ void reject_server_managed_features(const Json& body) {
     }
     if (body.contains("include") && !body.at("include").is_null()) {
         if (!body.at("include").is_array()) { bad_request("include must be an array", "include"); }
-        if (!body.at("include").empty()) {
-            bad_request("additional response fields are not supported", "include",
-                        "include_not_supported");
+        for (const Json& value : body.at("include")) {
+            if (!value.is_string()) { bad_request("include entries must be strings", "include"); }
         }
+        // Requested-extra response fields (e.g. "reasoning.encrypted_content") are
+        // accepted and ignored: they do not change generated output.
     }
     if (body.contains("parallel_tool_calls") && !body.at("parallel_tool_calls").is_null()) {
         if (!body.at("parallel_tool_calls").is_boolean()) {
             bad_request("parallel_tool_calls must be a boolean", "parallel_tool_calls");
         }
-        if (!body.at("parallel_tool_calls").get<bool>()) {
-            bad_request("parallel_tool_calls=false cannot be enforced", "parallel_tool_calls",
-                        "parallel_tool_calls_not_supported");
-        }
+        // Parallel tool calls are the server's only mode; a request to disable
+        // them cannot be enforced and is accepted and ignored (vLLM parity).
+        // The response still reports parallel_tool_calls=true.
     }
     if (body.contains("top_logprobs") && !body.at("top_logprobs").is_null()) {
         const std::optional<int> value = optional_int(body, "top_logprobs");
@@ -706,10 +727,34 @@ void reject_server_managed_features(const Json& body) {
     }
 }
 
+// Accepted-and-ignored client hints (mirroring vLLM and other OpenAI-compatible
+// servers). These fields tune client-side prompt caching or carry client
+// metadata and never change generated output, so they are validated for shape
+// and dropped instead of failing the request.
+void validate_ignored_client_hints(const Json& body) {
+    if (body.contains("prompt_cache_key") && !body.at("prompt_cache_key").is_null() &&
+        !body.at("prompt_cache_key").is_string()) {
+        bad_request("prompt_cache_key must be a string", "prompt_cache_key");
+    }
+    if (body.contains("prompt_cache_retention") && !body.at("prompt_cache_retention").is_null() &&
+        !body.at("prompt_cache_retention").is_string()) {
+        bad_request("prompt_cache_retention must be a string", "prompt_cache_retention");
+    }
+    if (body.contains("prompt_cache_options") && !body.at("prompt_cache_options").is_null() &&
+        !body.at("prompt_cache_options").is_object()) {
+        bad_request("prompt_cache_options must be an object", "prompt_cache_options");
+    }
+    if (body.contains("client_metadata") && !body.at("client_metadata").is_null() &&
+        !body.at("client_metadata").is_object()) {
+        bad_request("client_metadata must be an object", "client_metadata");
+    }
+}
+
 ResponsesRequest parse_request_impl(const Json& body, const RequestLimits& limits) {
     require_object(body);
     reject_unknown_top_level(body);
     reject_server_managed_features(body);
+    validate_ignored_client_hints(body);
 
     ResponsesRequest out;
     if (!body.contains("model") || !body.at("model").is_string() ||

--- a/src/serve/responses_schema.cpp
+++ b/src/serve/responses_schema.cpp
@@ -80,6 +80,19 @@ bool valid_function_name(const std::string& name) {
     return true;
 }
 
+constexpr std::string_view kNamespaceToolSeparator = "__";
+
+// Namespaced function tools reach the model under the flat name
+// "<namespace>__<name>" (the same convention vLLM uses), because the Qwen
+// prompt format has no notion of tool namespaces. The flat name is validated
+// against the same character/length rules as a plain function name.
+std::string flat_namespace_tool_name(const std::string& ns, const std::string& name) {
+    std::string flat;
+    flat.reserve(ns.size() + kNamespaceToolSeparator.size() + name.size());
+    flat.append(ns).append(kNamespaceToolSeparator).append(name);
+    return flat;
+}
+
 std::string require_function_name(const Json& object, const char* param) {
     if (!object.contains("name") || !object.at("name").is_string()) {
         bad_request("function name must be a string", param);
@@ -301,8 +314,22 @@ ToolCall parse_function_call_item(const Json& item, Json& canonical) {
         item.at("call_id").get<std::string>().empty()) {
         bad_request("function_call must contain a non-empty call_id", "input");
     }
-    call.id   = item.at("call_id").get<std::string>();
-    call.name = require_function_name(item, "input");
+    call.id                     = item.at("call_id").get<std::string>();
+    const std::string wire_name = require_function_name(item, "input");
+    std::optional<std::string> ns;
+    if (item.contains("namespace") && !item.at("namespace").is_null()) {
+        if (!item.at("namespace").is_string() ||
+            !valid_function_name(item.at("namespace").get<std::string>())) {
+            bad_request("function_call namespace must match [A-Za-z0-9_-]{1,64}", "input");
+        }
+        ns = item.at("namespace").get<std::string>();
+    }
+    // History replays under the same flat name the model was primed with.
+    call.name = ns ? flat_namespace_tool_name(*ns, wire_name) : wire_name;
+    if (ns && !valid_function_name(call.name)) {
+        bad_request("function_call namespace and name must flatten to [A-Za-z0-9_-]{1,64}",
+                    "input");
+    }
     if (!item.contains("arguments") || !item.at("arguments").is_string()) {
         bad_request("function_call arguments must be a JSON string", "input");
     }
@@ -319,8 +346,9 @@ ToolCall parse_function_call_item(const Json& item, Json& canonical) {
                  {"type", "function_call"},
                  {"status", "completed"},
                  {"call_id", call.id},
-                 {"name", call.name},
+                 {"name", wire_name},
                  {"arguments", call.arguments_json}};
+    if (ns) { canonical["namespace"] = *ns; }
     return call;
 }
 
@@ -445,6 +473,91 @@ void parse_input(const Json& input, ResponsesRequest& out) {
     }
 }
 
+void parse_function_tool(const Json& item, const std::string* ns,
+                         std::unordered_set<std::string>& names, ResponsesRequest& out) {
+    ToolDefinition tool;
+    const std::string wire_name = require_function_name(item, "tools");
+    tool.name                   = ns ? flat_namespace_tool_name(*ns, wire_name) : wire_name;
+    if (ns && !valid_function_name(tool.name)) {
+        bad_request("namespaced function name " + *ns + "." + wire_name +
+                        " must flatten to [A-Za-z0-9_-]{1,64}",
+                    "tools");
+    }
+    if (!names.insert(tool.name).second) {
+        bad_request("duplicate function tool name: " + tool.name, "tools");
+    }
+    if (item.contains("description") && !item.at("description").is_null()) {
+        if (!item.at("description").is_string()) {
+            bad_request("function description must be a string", "tools");
+        }
+        tool.description = item.at("description").get<std::string>();
+    }
+    Json parameters = Json{{"type", "object"}, {"properties", Json::object()}};
+    if (item.contains("parameters") && !item.at("parameters").is_null()) {
+        if (!item.at("parameters").is_object()) {
+            bad_request("function parameters must be a JSON object", "tools");
+        }
+        parameters = item.at("parameters");
+    }
+    if (item.contains("strict") && !item.at("strict").is_null()) {
+        if (!item.at("strict").is_boolean()) {
+            bad_request("function strict must be a boolean", "tools");
+        }
+        if (item.at("strict").get<bool>()) {
+            bad_request("strict function schema enforcement is not supported", "tools",
+                        "strict_tools_not_supported");
+        }
+    }
+    tool.strict          = false;
+    tool.parameters_json = parameters.dump();
+    Json nested          = {
+        {"type", "function"},
+        {"function", Json{{"name", tool.name}, {"parameters", parameters}, {"strict", false}}}};
+    if (!tool.description.empty()) { nested["function"]["description"] = tool.description; }
+    tool.definition_json = nested.dump();
+    if (ns) {
+        out.namespaced_tool_names.emplace(tool.name, std::make_pair(*ns, wire_name));
+    } else {
+        Json canonical = {{"type", "function"},
+                          {"name", tool.name},
+                          {"parameters", parameters},
+                          {"strict", false}};
+        if (!tool.description.empty()) { canonical["description"] = tool.description; }
+        out.tools.push_back(std::move(canonical));
+    }
+    out.generation.tools.push_back(std::move(tool));
+}
+
+void parse_namespace_tool(const Json& item, std::unordered_set<std::string>& names,
+                          ResponsesRequest& out) {
+    if (!item.contains("name") || !item.at("name").is_string() ||
+        !valid_function_name(item.at("name").get<std::string>())) {
+        bad_request("namespace name must match [A-Za-z0-9_-]{1,64}", "tools");
+    }
+    const std::string ns = item.at("name").get<std::string>();
+    if (item.contains("description") && !item.at("description").is_null() &&
+        !item.at("description").is_string()) {
+        bad_request("namespace description must be a string", "tools");
+    }
+    if (!item.contains("tools") || !item.at("tools").is_array()) {
+        bad_request("namespace tools must be an array", "tools");
+    }
+    for (const Json& nested : item.at("tools")) {
+        if (!nested.is_object() || !nested.contains("type") || !nested.at("type").is_string()) {
+            bad_request("namespace tools entries must be objects with a string type", "tools");
+        }
+        const std::string nested_type = nested.at("type").get<std::string>();
+        if (nested_type != "function") {
+            bad_request("unsupported tool type in namespace " + ns + ": " + nested_type, "tools",
+                        "tool_type_not_supported");
+        }
+        parse_function_tool(nested, &ns, names, out);
+    }
+    // The namespace object is echoed as received: clients match the response
+    // tools list against what they declared.
+    out.tools.push_back(item);
+}
+
 void parse_tools(const Json& body, ResponsesRequest& out) {
     if (!body.contains("tools") || body.at("tools").is_null()) { return; }
     if (!body.at("tools").is_array()) { bad_request("tools must be an array", "tools"); }
@@ -454,61 +567,21 @@ void parse_tools(const Json& body, ResponsesRequest& out) {
             bad_request("tools entries must be objects with a string type", "tools");
         }
         const std::string tool_type = item.at("type").get<std::string>();
-        if (tool_type != "function") {
-            // Non-function tools (web search, tool search, freeform custom
-            // tools, tool namespaces, file search) declare client-side
-            // capabilities this server does not execute. They are validated
-            // for shape (a string type) and ignored (vLLM/OpenAI parity); the
-            // model is not primed to call them.
-            if (tool_type != "web_search" && tool_type != "tool_search" &&
-                tool_type != "custom" && tool_type != "namespace" &&
-                tool_type != "file_search") {
-                bad_request("unsupported tool type: " + tool_type, "tools",
-                            "tool_type_not_supported");
-            }
+        if (tool_type == "function") {
+            parse_function_tool(item, nullptr, names, out);
+        } else if (tool_type == "namespace") {
+            parse_namespace_tool(item, names, out);
+        } else if (tool_type == "web_search" || tool_type == "tool_search") {
+            // These declare client-side capabilities this server does not
+            // execute; they are validated for shape (a string type) and
+            // ignored, and the model is not primed to call them.
             continue;
+        } else {
+            // Hosted tools (file_search, mcp, code_interpreter, ...) and
+            // grammar-constrained custom tools would require server-side
+            // execution or constrained decoding.
+            bad_request("unsupported tool type: " + tool_type, "tools", "tool_type_not_supported");
         }
-        ToolDefinition tool;
-        tool.name = require_function_name(item, "tools");
-        if (!names.insert(tool.name).second) {
-            bad_request("duplicate function tool name: " + tool.name, "tools");
-        }
-        if (item.contains("description") && !item.at("description").is_null()) {
-            if (!item.at("description").is_string()) {
-                bad_request("function description must be a string", "tools");
-            }
-            tool.description = item.at("description").get<std::string>();
-        }
-        Json parameters = Json{{"type", "object"}, {"properties", Json::object()}};
-        if (item.contains("parameters") && !item.at("parameters").is_null()) {
-            if (!item.at("parameters").is_object()) {
-                bad_request("function parameters must be a JSON object", "tools");
-            }
-            parameters = item.at("parameters");
-        }
-        if (item.contains("strict") && !item.at("strict").is_null()) {
-            if (!item.at("strict").is_boolean()) {
-                bad_request("function strict must be a boolean", "tools");
-            }
-            if (item.at("strict").get<bool>()) {
-                bad_request("strict function schema enforcement is not supported", "tools",
-                            "strict_tools_not_supported");
-            }
-        }
-        tool.strict          = false;
-        tool.parameters_json = parameters.dump();
-        Json canonical       = {{"type", "function"},
-                                {"name", tool.name},
-                                {"parameters", parameters},
-                                {"strict", false}};
-        if (!tool.description.empty()) { canonical["description"] = tool.description; }
-        Json nested = {
-            {"type", "function"},
-            {"function", Json{{"name", tool.name}, {"parameters", parameters}, {"strict", false}}}};
-        if (!tool.description.empty()) { nested["function"]["description"] = tool.description; }
-        tool.definition_json = nested.dump();
-        out.generation.tools.push_back(std::move(tool));
-        out.tools.push_back(std::move(canonical));
     }
 }
 
@@ -845,6 +918,30 @@ std::string response_status(ninfer::FinishReason reason) {
     return "failed";
 }
 
+// Split a model-facing (flat) tool call name back into the wire-level
+// {name, namespace} the client declared. Plain function tools resolve to
+// themselves with no namespace.
+struct WireToolCallName {
+    std::string name;
+    std::optional<std::string> ns;
+};
+
+WireToolCallName wire_tool_call_name(const ResponsesRequest& request, const std::string& flat) {
+    const auto it = request.namespaced_tool_names.find(flat);
+    if (it == request.namespaced_tool_names.end()) { return {flat, std::nullopt}; }
+    return {it->second.second, it->second.first};
+}
+
+// Fields shared by every function_call output Item representation.
+Json function_call_item(const ResponsesRequest& request, const std::string& item_id,
+                        const char* status, const ToolCall& call, const std::string& arguments) {
+    const WireToolCallName wire = wire_tool_call_name(request, call.name);
+    Json item = {{"id", item_id},      {"type", "function_call"}, {"status", status},
+                 {"call_id", call.id}, {"name", wire.name},       {"arguments", arguments}};
+    if (wire.ns) { item["namespace"] = *wire.ns; }
+    return item;
+}
+
 struct ItemIds {
     std::string reasoning;
     std::string message;
@@ -922,12 +1019,8 @@ BuiltResponse build_response(const std::string& id, std::int64_t created_at,
             ids.function_calls[index] = new_response_item_id("fc");
         }
         const ToolCall& call = outcome.tool_calls[index];
-        built.output_items.push_back(Json{{"id", ids.function_calls[index]},
-                                          {"type", "function_call"},
-                                          {"status", "completed"},
-                                          {"call_id", call.id},
-                                          {"name", call.name},
-                                          {"arguments", call.arguments_json}});
+        built.output_items.push_back(function_call_item(request, ids.function_calls[index],
+                                                        "completed", call, call.arguments_json));
     }
 
     ChatTurn history;
@@ -1266,9 +1359,8 @@ ResponsesStreamFinish ResponsesEventStream::finish(const GenerationOutcome& outc
         const std::string item_id = new_response_item_id("fc");
         impl_->ids.function_calls.push_back(item_id);
         const int output_index = impl_->next_output_index++;
-        const Json added_item  = {{"id", item_id},           {"type", "function_call"},
-                                  {"status", "in_progress"}, {"call_id", call.id},
-                                  {"name", call.name},       {"arguments", ""}};
+        const Json added_item =
+            function_call_item(impl_->request, item_id, "in_progress", call, "");
         finished.events_before_terminal.push_back(
             sse(impl_->event("response.output_item.added",
                              Json{{"output_index", output_index}, {"item", added_item}})));
@@ -1278,14 +1370,14 @@ ResponsesStreamFinish ResponsesEventStream::finish(const GenerationOutcome& outc
                                                                {"output_index", output_index},
                                                                {"delta", call.arguments_json}})));
         }
-        finished.events_before_terminal.push_back(sse(impl_->event(
-            "response.function_call_arguments.done", Json{{"item_id", item_id},
-                                                          {"output_index", output_index},
-                                                          {"name", call.name},
-                                                          {"arguments", call.arguments_json}})));
-        const Json done_item = {{"id", item_id},         {"type", "function_call"},
-                                {"status", "completed"}, {"call_id", call.id},
-                                {"name", call.name},     {"arguments", call.arguments_json}};
+        finished.events_before_terminal.push_back(
+            sse(impl_->event("response.function_call_arguments.done",
+                             Json{{"item_id", item_id},
+                                  {"output_index", output_index},
+                                  {"name", wire_tool_call_name(impl_->request, call.name).name},
+                                  {"arguments", call.arguments_json}})));
+        const Json done_item =
+            function_call_item(impl_->request, item_id, "completed", call, call.arguments_json);
         finished.events_before_terminal.push_back(
             sse(impl_->event("response.output_item.done",
                              Json{{"output_index", output_index}, {"item", done_item}})));

--- a/src/serve/responses_schema.h
+++ b/src/serve/responses_schema.h
@@ -49,7 +49,10 @@ struct BuiltResponse {
 };
 
 // Parse POST /v1/responses. Only NInfer Responses Core capabilities are
-// accepted; recognized but unsupported OpenAI fields fail explicitly.
+// accepted; recognized but unsupported OpenAI fields fail explicitly. Harmless
+// client hints (prompt_cache_key/prompt_cache_options/prompt_cache_retention,
+// include, client_metadata, parallel_tool_calls=false, reasoning.summary, and
+// non-function tool types) are validated for shape and ignored.
 ResponsesRequest parse_responses_request(const nlohmann::json& body, const RequestLimits& limits);
 
 // Parse POST /v1/responses/input_tokens. The current OpenAI endpoint accepts

--- a/src/serve/responses_schema.h
+++ b/src/serve/responses_schema.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace ninfer::serve {
@@ -34,6 +36,11 @@ struct ResponsesRequest {
     nlohmann::json tool_choice = "auto";
     bool store                 = true;
     bool stream                = false;
+
+    // Namespaced function tools are flattened to "<namespace>__<name>" for the
+    // model. This maps each flat name back to {namespace, name} so emitted
+    // function_call Items carry the wire-level split the client dispatches on.
+    std::unordered_map<std::string, std::pair<std::string, std::string>> namespaced_tool_names;
 };
 
 struct ResponsesRuntimeValues {
@@ -52,7 +59,9 @@ struct BuiltResponse {
 // accepted; recognized but unsupported OpenAI fields fail explicitly. Harmless
 // client hints (prompt_cache_key/prompt_cache_options/prompt_cache_retention,
 // include, client_metadata, parallel_tool_calls=false, reasoning.summary, and
-// non-function tool types) are validated for shape and ignored.
+// the client-side web_search/tool_search tool types) are validated for shape
+// and ignored. Function tools nested in a namespace tool are flattened for the
+// model and split back on output.
 ResponsesRequest parse_responses_request(const nlohmann::json& body, const RequestLimits& limits);
 
 // Parse POST /v1/responses/input_tokens. The current OpenAI endpoint accepts

--- a/tests/test_responses_schema.cpp
+++ b/tests/test_responses_schema.cpp
@@ -408,20 +408,23 @@ int test_ignored_client_hints() {
     failures += check(throws_api([&] { (void)parse_responses_request(bad_ptc, limits()); }),
                       "parallel_tool_calls must be a boolean");
 
-    // Codex ships a built-in web_search tool; every known non-function tool
-    // type is accepted and ignored, unknown types are rejected.
-    for (const char* type :
-         {"web_search", "tool_search", "custom", "namespace", "file_search"}) {
+    // Codex ships a built-in web_search tool; client-side capability types are
+    // accepted and ignored. Hosted tools, grammar-constrained custom tools, and
+    // unknown types are rejected explicitly.
+    for (const char* type : {"web_search", "tool_search"}) {
         Json with_ignored = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
         with_ignored["tools"] = Json::array({Json{{"type", type}, {"name", "x"}}});
-        failures += check(!throws_api([&] { (void)parse_responses_request(with_ignored, limits()); }),
-                          std::string("non-function tool accepted and ignored: ") + type);
+        const ResponsesRequest ignored = parse_responses_request(with_ignored, limits());
+        failures += check(ignored.tools.empty() && ignored.generation.tools.empty(),
+                          std::string("client-side tool accepted and ignored: ") + type);
     }
-    Json unknown_tool = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
-    unknown_tool["tools"] = Json::array({Json{{"type", "made_up"}}});
-    failures += check(api_code([&] { (void)parse_responses_request(unknown_tool, limits()); }) ==
-                          "tool_type_not_supported",
-                      "unknown tool type rejected");
+    for (const char* type : {"custom", "file_search", "mcp", "code_interpreter", "made_up"}) {
+        Json rejected     = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+        rejected["tools"] = Json::array({Json{{"type", type}, {"name", "x"}}});
+        failures += check(api_code([&] { (void)parse_responses_request(rejected, limits()); }) ==
+                              "tool_type_not_supported",
+                          std::string("unsupported tool type rejected: ") + type);
+    }
 
     // reasoning.summary is a client hint for streaming reasoning summaries;
     // string values are accepted and ignored, non-string shapes rejected.
@@ -434,6 +437,174 @@ int test_ignored_client_hints() {
     bad_summary["reasoning"] = Json{{"effort", "low"}, {"summary", 42}};
     failures += check(throws_api([&] { (void)parse_responses_request(bad_summary, limits()); }),
                       "reasoning.summary must be a string");
+    return failures;
+}
+
+int test_namespace_tools() {
+    // Codex declares every MCP server as a namespace tool whose nested
+    // functions are the callable surface. They are flattened for the model as
+    // "<namespace>__<name>" and split back on output so the client can route
+    // the call by (namespace, name).
+    const Json request_json = {
+        {"model", "qwen3.6-27b"},
+        {"input", "what time is it"},
+        {"max_output_tokens", 32},
+        {"tools",
+         Json::array({Json{{"type", "web_search"}, {"external_web_access", false}},
+                      Json{{"type", "namespace"},
+                           {"name", "mcp__clock"},
+                           {"description", "Tools for working with clock."},
+                           {"tools",
+                            Json::array({Json{{"type", "function"},
+                                              {"name", "now"},
+                                              {"description", "Return the current time in UTC."},
+                                              {"strict", false},
+                                              {"parameters", Json{{"type", "object"},
+                                                                  {"properties", Json::object()}}}},
+                                         Json{{"type", "function"}, {"name", "sleep"}}})}},
+                      Json{{"type", "namespace"},
+                           {"name", "mcp__fs"},
+                           {"description", "Filesystem"},
+                           {"tools", Json::array({Json{{"type", "function"}, {"name", "now"}}})}},
+                      Json{{"type", "function"},
+                           {"name", "shell"},
+                           {"parameters", Json{{"type", "object"}}}}})},
+    };
+    int failures                   = 0;
+    const ResponsesRequest request = parse_responses_request(request_json, limits());
+
+    // Prompt-facing definitions: flat names, same nested name in two
+    // namespaces stays distinct, plain function untouched.
+    std::vector<std::string> primed;
+    for (const ToolDefinition& tool : request.generation.tools) { primed.push_back(tool.name); }
+    failures += check(primed == std::vector<std::string>{"mcp__clock__now", "mcp__clock__sleep",
+                                                         "mcp__fs__now", "shell"},
+                      "namespaced functions are flattened for the model");
+    const Json nested = Json::parse(request.generation.tools[0].definition_json);
+    failures +=
+        check(nested.at("function").at("name") == "mcp__clock__now" &&
+                  nested.at("function").at("description") == "Return the current time in UTC.",
+              "flat definition keeps nested description");
+
+    // Echoed tools: namespace objects verbatim, web_search dropped.
+    failures += check(request.tools.size() == 3 && request.tools[0].at("type") == "namespace" &&
+                          request.tools[0].at("name") == "mcp__clock" &&
+                          request.tools[0].at("tools").size() == 2 &&
+                          request.tools[2].at("type") == "function",
+                      "namespace tools are echoed as declared");
+
+    // Output: the emitted function_call carries the wire-level split.
+    GenerationOutcome outcome;
+    outcome.prompt_tokens     = 8;
+    outcome.completion_tokens = 4;
+    outcome.finish_reason     = ninfer::FinishReason::StopToken;
+    outcome.tool_calls.push_back(ToolCall{"call_1", "mcp__clock__now", "{}"});
+    outcome.tool_calls.push_back(ToolCall{"call_2", "shell", R"({"cmd":"ls"})"});
+    const BuiltResponse built = make_response_object("resp_ns", 1, request, {}, outcome);
+    const Json& first         = built.body.at("output").at(0);
+    const Json& second        = built.body.at("output").at(1);
+    failures += check(first.at("type") == "function_call" && first.at("name") == "now" &&
+                          first.at("namespace") == "mcp__clock" && first.at("call_id") == "call_1",
+                      "namespaced tool call is split into name and namespace");
+    failures += check(second.at("name") == "shell" && !second.contains("namespace"),
+                      "plain function call carries no namespace");
+    failures +=
+        check(built.output_history.size() == 1 && built.output_history[0].tool_calls.size() == 2 &&
+                  built.output_history[0].tool_calls[0].name == "mcp__clock__now",
+              "stored history keeps the flat model-facing name");
+
+    // Streaming emits the same split on every function_call event.
+    ResponsesRequest stream_request = request;
+    stream_request.stream           = true;
+    ResponsesEventStream encoder("resp_ns_stream", 1, stream_request, {});
+    (void)encoder.start();
+    const ResponsesStreamFinish finish = encoder.finish(outcome);
+    int split_events                   = 0;
+    for (const std::string& event : finish.events_before_terminal) {
+        const Json payload     = parse_event(event);
+        const std::string type = payload.at("type").get<std::string>();
+        if (type == "response.output_item.added" || type == "response.output_item.done") {
+            const Json& item = payload.at("item");
+            if (item.at("type") == "function_call" && item.at("call_id") == "call_1") {
+                split_events += (item.at("name") == "now" && item.at("namespace") == "mcp__clock");
+            }
+        }
+        if (type == "response.function_call_arguments.done" &&
+            payload.at("item_id") == finish.response.body.at("output").at(0).at("id")) {
+            split_events += (payload.at("name") == "now");
+        }
+    }
+    failures += check(split_events == 3, "SSE function_call events carry name and namespace");
+
+    // Inbound history: a namespaced function_call replays under the flat name
+    // and round-trips its namespace in the canonical Item.
+    Json history = {
+        {"model", "qwen3.6-27b"},
+        {"max_output_tokens", 32},
+        {"tools", request_json.at("tools")},
+        {"input",
+         Json::array(
+             {Json{{"role", "user"},
+                   {"content", Json::array({Json{{"type", "input_text"}, {"text", "time?"}}})}},
+              Json{{"type", "function_call"},
+                   {"call_id", "call_1"},
+                   {"namespace", "mcp__clock"},
+                   {"name", "now"},
+                   {"arguments", "{}"}},
+              Json{
+                  {"type", "function_call_output"}, {"call_id", "call_1"}, {"output", "12:00Z"}}})},
+    };
+    const ResponsesRequest replay = parse_responses_request(history, limits());
+    failures +=
+        check(replay.input_turns.size() == 3 && replay.input_turns[1].tool_calls.size() == 1 &&
+                  replay.input_turns[1].tool_calls[0].name == "mcp__clock__now",
+              "inbound namespaced function_call replays under the flat name");
+    failures += check(replay.input_items.size() == 3 && replay.input_items[1].at("name") == "now" &&
+                          replay.input_items[1].at("namespace") == "mcp__clock",
+                      "canonical function_call Item keeps the namespace");
+
+    // Malformed and unsupported namespace shapes.
+    Json base     = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    Json bad_name = base;
+    bad_name["tools"] =
+        Json::array({Json{{"type", "namespace"}, {"name", "a b"}, {"tools", Json::array()}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_name, limits()); }),
+                      "namespace name is validated");
+    Json bad_tools     = base;
+    bad_tools["tools"] = Json::array({Json{{"type", "namespace"}, {"name", "ns"}, {"tools", "x"}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_tools, limits()); }),
+                      "namespace tools must be an array");
+    Json nested_custom = base;
+    nested_custom["tools"] =
+        Json::array({Json{{"type", "namespace"},
+                          {"name", "ns"},
+                          {"tools", Json::array({Json{{"type", "custom"}, {"name", "raw"}}})}}});
+    failures += check(api_code([&] { (void)parse_responses_request(nested_custom, limits()); }) ==
+                          "tool_type_not_supported",
+                      "custom tools nested in a namespace are rejected");
+    Json collision = base;
+    collision["tools"] =
+        Json::array({Json{{"type", "function"}, {"name", "ns__f"}},
+                     Json{{"type", "namespace"},
+                          {"name", "ns"},
+                          {"tools", Json::array({Json{{"type", "function"}, {"name", "f"}}})}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(collision, limits()); }),
+                      "flat name colliding with a plain function is rejected");
+    Json too_long     = base;
+    too_long["tools"] = Json::array({Json{
+        {"type", "namespace"},
+        {"name", std::string(40, 'a')},
+        {"tools", Json::array({Json{{"type", "function"}, {"name", std::string(30, 'b')}}})}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(too_long, limits()); }),
+                      "flat name longer than 64 characters is rejected");
+    Json bad_history_ns     = base;
+    bad_history_ns["input"] = Json::array({Json{{"type", "function_call"},
+                                                {"call_id", "c"},
+                                                {"namespace", 5},
+                                                {"name", "f"},
+                                                {"arguments", "{}"}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_history_ns, limits()); }),
+                      "function_call namespace must be a string");
     return failures;
 }
 
@@ -652,6 +823,7 @@ int main() {
     failures += test_reasoning_effort();
     failures += test_typed_items_and_tools();
     failures += test_ignored_client_hints();
+    failures += test_namespace_tools();
     failures += test_explicit_rejections();
     failures += test_response_object();
     failures += test_sse_sequence();

--- a/tests/test_responses_schema.cpp
+++ b/tests/test_responses_schema.cpp
@@ -308,6 +308,135 @@ int test_typed_items_and_tools() {
     return failures;
 }
 
+int test_ignored_client_hints() {
+    // Codex-shaped request: every client hint present at once must parse and
+    // leave generation inputs unchanged.
+    const Json codex = {
+        {"model", "qwen3.6-27b"},
+        {"input", "hello"},
+        {"max_output_tokens", 32},
+        {"instructions", "Be brief."},
+        {"tool_choice", "auto"},
+        {"parallel_tool_calls", false},
+        {"reasoning", Json{{"effort", "medium"}, {"summary", "auto"}}},
+        {"store", false},
+        {"include", Json::array({"reasoning.encrypted_content"})},
+        {"prompt_cache_key", "session/thread:1"},
+        {"prompt_cache_retention", "1h"},
+        {"prompt_cache_options", Json{{"prompt_cache_breakpoint", "auto"}}},
+        {"client_metadata",
+         Json{{"x-codex-session-id", "s1"}, {"x-codex-thread-id", "t1"}}},
+        {"tools",
+         Json::array({Json{{"type", "function"},
+                           {"name", "shell"},
+                           {"parameters", Json{{"type", "object"}}},
+                           {"strict", false}},
+                      Json{{"type", "web_search"}, {"external_web_access", false}}})},
+    };
+    int failures = 0;
+    const ResponsesRequest request = parse_responses_request(codex, limits());
+    failures += check(request.instructions.has_value() && *request.instructions == "Be brief.",
+                      "hints do not drop instructions");
+    failures += check(request.input_turns.size() == 1 &&
+                          request.input_turns[0].role == ninfer::ChatRole::User,
+                      "hints do not change input");
+    failures += check(request.tools.size() == 1, "hints do not drop tools");
+    failures += check(request.generation.tools.size() == 1 &&
+                          request.generation.tools[0].name == "shell",
+                      "non-function tools are not primed");
+    failures += check(!request.store, "store preserved");
+    failures += check(request.generation.max_tokens == 32, "generation options preserved");
+
+    // Each hint is accepted on its own and ignored.
+    for (const char* key : {"prompt_cache_key", "prompt_cache_retention"}) {
+        Json single = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+        single[key] = "value";
+        failures += check(!throws_api([&] { (void)parse_responses_request(single, limits()); }),
+                          std::string("accepted: ") + key);
+    }
+    for (const char* key : {"prompt_cache_options", "client_metadata"}) {
+        Json single = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+        single[key] = Json{{"k", "v"}};
+        failures += check(!throws_api([&] { (void)parse_responses_request(single, limits()); }),
+                          std::string("accepted: ") + key);
+    }
+    Json include_ok         = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    include_ok["include"]   = Json::array({"reasoning.encrypted_content", "response.usage"});
+    const ResponsesRequest include_parsed = parse_responses_request(include_ok, limits());
+    failures += check(include_parsed.input_turns.size() == 1, "include entries accepted and ignored");
+
+    // Malformed hint shapes are still rejected explicitly.
+    Json bad_key = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_key["prompt_cache_key"] = 42;
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_key, limits()); }),
+                      "prompt_cache_key must be a string");
+
+    Json bad_retention                = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_retention["prompt_cache_retention"] = 42;
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_retention, limits()); }),
+                      "prompt_cache_retention must be a string");
+
+    Json bad_options                = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_options["prompt_cache_options"] = "x";
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_options, limits()); }),
+                      "prompt_cache_options must be an object");
+
+    Json bad_metadata                = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_metadata["client_metadata"]  = "x";
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_metadata, limits()); }),
+                      "client_metadata must be an object");
+
+    Json bad_include = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_include["include"] = "x";
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_include, limits()); }),
+                      "include must be an array");
+
+    Json bad_include_entry              = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_include_entry["include"]        = Json::array({"ok", 42});
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_include_entry, limits()); }),
+                      "include entries must be strings");
+
+    // parallel_tool_calls=false (sent by Codex via litellm) is accepted and
+    // ignored; non-boolean shapes are still rejected.
+    Json ptc_false = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    ptc_false["parallel_tool_calls"] = false;
+    failures += check(!throws_api([&] { (void)parse_responses_request(ptc_false, limits()); }),
+                      "parallel_tool_calls=false accepted and ignored");
+
+    Json bad_ptc = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_ptc["parallel_tool_calls"] = "x";
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_ptc, limits()); }),
+                      "parallel_tool_calls must be a boolean");
+
+    // Codex ships a built-in web_search tool; every known non-function tool
+    // type is accepted and ignored, unknown types are rejected.
+    for (const char* type :
+         {"web_search", "tool_search", "custom", "namespace", "file_search"}) {
+        Json with_ignored = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+        with_ignored["tools"] = Json::array({Json{{"type", type}, {"name", "x"}}});
+        failures += check(!throws_api([&] { (void)parse_responses_request(with_ignored, limits()); }),
+                          std::string("non-function tool accepted and ignored: ") + type);
+    }
+    Json unknown_tool = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    unknown_tool["tools"] = Json::array({Json{{"type", "made_up"}}});
+    failures += check(api_code([&] { (void)parse_responses_request(unknown_tool, limits()); }) ==
+                          "tool_type_not_supported",
+                      "unknown tool type rejected");
+
+    // reasoning.summary is a client hint for streaming reasoning summaries;
+    // string values are accepted and ignored, non-string shapes rejected.
+    Json summary_ok = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    summary_ok["reasoning"] = Json{{"effort", "low"}, {"summary", "auto"}};
+    const ResponsesRequest summary_parsed = parse_responses_request(summary_ok, limits());
+    failures += check(summary_parsed.generation.reasoning_effort_param == "reasoning.effort",
+                      "reasoning.summary accepted and ignored");
+    Json bad_summary = {{"model", "qwen3.6-27b"}, {"input", "hello"}};
+    bad_summary["reasoning"] = Json{{"effort", "low"}, {"summary", 42}};
+    failures += check(throws_api([&] { (void)parse_responses_request(bad_summary, limits()); }),
+                      "reasoning.summary must be a string");
+    return failures;
+}
+
 int test_explicit_rejections() {
     const Json base = {{"model", "qwen3.6-27b"}, {"input", "hello"}, {"max_output_tokens", 32}};
     int failures    = 0;
@@ -522,6 +651,7 @@ int main() {
     failures += test_preserve_thinking_options_and_inheritance();
     failures += test_reasoning_effort();
     failures += test_typed_items_and_tools();
+    failures += test_ignored_client_hints();
     failures += test_explicit_rejections();
     failures += test_response_object();
     failures += test_sse_sequence();


### PR DESCRIPTION
## Summary

The OpenAI Codex CLI talks to `POST /v1/responses` and sends a number of fields that the Responses schema previously rejected with 400. This makes direct codex -> ninfer work end to end, including MCP tools (verified live against the qwen3.8-27b target with codex 0.147.0 and a real MCP server).

Two kinds of change:

1. Harmless client hints are validated for shape and then ignored; they never change generated output.
2. `namespace` tools — how Codex declares every MCP server — are translated so the model is actually primed with the nested functions and the client can route the resulting calls.

## Client hints accepted and ignored

- `prompt_cache_key`, `prompt_cache_options`, `prompt_cache_retention` (client-side prompt-cache routing hints; Codex sends `prompt_cache_key`)
- `client_metadata` (client-supplied metadata, e.g. Codex trace context)
- `include` — any array of strings (Codex sends `["reasoning.encrypted_content"]`)
- `parallel_tool_calls: false` (parallel tool calls are the server's only mode; the response still reports `parallel_tool_calls: true`)
- `reasoning.summary` — string or null (streaming reasoning summaries are not implemented)
- `web_search` and `tool_search` tool types — client-side capabilities the server does not execute; the model is not primed to call them (Codex sends `web_search` by default)

Malformed shapes for all of the above still fail with a field-specific 400.

## Namespace tools

Codex wraps each MCP server's tools in `{"type":"namespace","name":"mcp__<server>","tools":[{"type":"function",...}]}` and dispatches the model's calls on `(namespace, name)`. Since the Qwen prompt format has no tool namespaces, NInfer now:

- primes each nested function under the flat name `<namespace>__<name>` (same convention as vLLM's Responses implementation), validated against the usual `[A-Za-z0-9_-]{1,64}` rule; collisions are a 400
- emits `function_call` output Items with the wire-level split (`"name":"now"`, `"namespace":"mcp__clock"`) in both the terminal response and every SSE `function_call` event; plain function calls carry no `namespace`
- accepts `namespace` on inbound `function_call` history Items and replays them under the flat name
- echoes namespace tools as declared in the response `tools` array

`custom` (grammar-constrained freeform), `file_search`, `mcp`, and every other tool type are rejected with `tool_type_not_supported`, top-level or nested, because they would need server-side execution or constrained decoding.

## Behavior unchanged

- Flat function tools, tool choices, strict-tool rejection, and all previously supported fields behave exactly as before.
- `/v1/models` is intentionally left OpenAI-standard. Codex parses its own catalog shape, logs a non-fatal decode error, and falls back to its bundled model metadata — observed working live.

## Tests

- `tests/test_responses_schema.cpp`: codex-shaped request (all hints present) parses; each hint accepted alone; malformed shapes rejected; `web_search` / `tool_search` ignored; `custom` / `file_search` / `mcp` / unknown types rejected. New `test_namespace_tools`: flattening (including the same nested name in two namespaces), prompt definition, echo, name/namespace split in the terminal object and in every SSE `function_call` event, inbound history replay and canonical round-trip, and malformed/oversized/colliding names.
- All 8 protocol test binaries pass; `git diff --check` clean.
- Live: `codex exec -p ninfer` with an MCP server configured — Codex sent the server's tools as a namespace, the model called `list_nodes` through it, and Codex routed and executed the MCP call.
