### PR TITLE
accept vLLM-style enable_thinking: top-level field and chat_template_kwargs

### DIFF
--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -479,6 +479,22 @@ std::string sse_event(const Json& payload) { return "data: " + payload.dump() + 
 
 } // namespace
 
+std::optional<bool> parse_openai_template_enable_thinking(const Json& body) {
+    if (!body.contains("chat_template_kwargs")) { return std::nullopt; }
+    const Json& kwargs = body.at("chat_template_kwargs");
+    if (!kwargs.is_object()) {
+        bad_request("chat_template_kwargs must be an object", "chat_template_kwargs");
+    }
+    if (!kwargs.contains("enable_thinking") || kwargs.at("enable_thinking").is_null()) {
+        return std::nullopt;
+    }
+    if (!kwargs.at("enable_thinking").is_boolean()) {
+        bad_request("chat_template_kwargs.enable_thinking must be a boolean or null",
+                    "chat_template_kwargs");
+    }
+    return kwargs.at("enable_thinking").get<bool>();
+}
+
 std::optional<bool> parse_openai_preserve_thinking(const Json& body) {
     std::optional<bool> top_level;
     if (body.contains("preserve_thinking") && !body.at("preserve_thinking").is_null()) {
@@ -495,7 +511,8 @@ std::optional<bool> parse_openai_preserve_thinking(const Json& body) {
             bad_request("chat_template_kwargs must be an object", "chat_template_kwargs");
         }
         for (auto it = kwargs.begin(); it != kwargs.end(); ++it) {
-            if (it.key() != "preserve_thinking" && !it.value().is_null()) {
+            if (it.key() != "preserve_thinking" && it.key() != "enable_thinking" &&
+                !it.value().is_null()) {
                 bad_request("chat_template_kwargs." + it.key() + " is not supported",
                             "chat_template_kwargs", "chat_template_option_not_supported");
             }
@@ -553,9 +570,18 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
     if (body.contains("stream_options") && body.at("stream_options").is_object()) {
         out.include_usage = get_bool(body.at("stream_options"), "include_usage", false);
     }
+    std::optional<bool> top_level_thinking;
     if (body.contains("enable_thinking") && !body.at("enable_thinking").is_null()) {
-        out.enable_thinking = get_bool(body, "enable_thinking", false);
+        top_level_thinking = get_bool(body, "enable_thinking", false);
     }
+    const std::optional<bool> template_thinking =
+        parse_openai_template_enable_thinking(body);
+    if (top_level_thinking && template_thinking &&
+        *top_level_thinking != *template_thinking) {
+        bad_request("conflicting enable_thinking values", "enable_thinking",
+                    "conflicting_template_option");
+    }
+    out.enable_thinking = template_thinking ? template_thinking : top_level_thinking;
     parse_openai_reasoning_effort(body, out);
     out.preserve_thinking = parse_openai_preserve_thinking(body);
 

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -570,6 +570,10 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
     if (body.contains("stream_options") && body.at("stream_options").is_object()) {
         out.include_usage = get_bool(body.at("stream_options"), "include_usage", false);
     }
+
+    parse_openai_reasoning_effort(body, out);
+    out.preserve_thinking = parse_openai_preserve_thinking(body);
+
     std::optional<bool> top_level_thinking;
     if (body.contains("enable_thinking") && !body.at("enable_thinking").is_null()) {
         top_level_thinking = get_bool(body, "enable_thinking", false);
@@ -581,9 +585,11 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
         bad_request("conflicting enable_thinking values", "enable_thinking",
                     "conflicting_template_option");
     }
-    out.enable_thinking = template_thinking ? template_thinking : top_level_thinking;
-    parse_openai_reasoning_effort(body, out);
-    out.preserve_thinking = parse_openai_preserve_thinking(body);
+    if (template_thinking) {
+        out.enable_thinking = *template_thinking;
+    } else if (top_level_thinking) {
+        out.enable_thinking = *top_level_thinking;
+    }
 
     std::optional<int> max_tokens = get_int(body, "max_completion_tokens");
     if (!max_tokens) { max_tokens = get_int(body, "max_tokens"); }

--- a/src/serve/openai_schema.h
+++ b/src/serve/openai_schema.h
@@ -23,6 +23,7 @@ namespace ninfer::serve {
 GenerationRequest parse_chat_completion_request(const nlohmann::json& body,
                                                 const RequestLimits& limits);
 
+std::optional<bool> parse_openai_template_enable_thinking(const nlohmann::json& body);
 std::optional<bool> parse_openai_preserve_thinking(const nlohmann::json& body);
 
 // Non-streaming chat completion response body (JSON string). When `reasoning` is

--- a/src/serve/responses_schema.cpp
+++ b/src/serve/responses_schema.cpp
@@ -742,6 +742,10 @@ ResponsesRequest parse_request_impl(const Json& body, const RequestLimits& limit
     parse_tool_choice(body, out);
     parse_reasoning(body, out);
     out.generation.preserve_thinking = parse_openai_preserve_thinking(body);
+    if (const std::optional<bool> template_thinking =
+            parse_openai_template_enable_thinking(body)) {
+        out.generation.enable_thinking = *template_thinking;
+    }
 
     if (const std::optional<double> temperature = optional_number(body, "temperature")) {
         if (*temperature < 0.0 || *temperature > 2.0) {

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -145,6 +145,22 @@ int test_preserve_thinking_options() {
         check(parse_chat_completion_request(same, default_limits()).preserve_thinking == true,
               "matching preserve_thinking values rejected");
 
+    Json enable                    = base;
+    enable["chat_template_kwargs"] = Json{{"enable_thinking", false}};
+    failures += check(parse_chat_completion_request(enable, default_limits()).enable_thinking ==
+                          false,
+                      "chat_template_kwargs enable_thinking parsed");
+    Json enable_same                 = enable;
+    enable_same["enable_thinking"]   = false;
+    failures += check(parse_chat_completion_request(enable_same, default_limits()).enable_thinking ==
+                          false,
+                      "matching enable_thinking values rejected");
+    Json enable_conflict               = enable;
+    enable_conflict["enable_thinking"] = true;
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(enable_conflict, default_limits()); }),
+        "conflicting enable_thinking values accepted");
+
     Json nulls                    = base;
     nulls["preserve_thinking"]    = nullptr;
     nulls["chat_template_kwargs"] = Json{{"preserve_thinking", nullptr}, {"future", nullptr}};
@@ -168,6 +184,11 @@ int test_preserve_thinking_options() {
     failures +=
         check(throws_api([&] { (void)parse_chat_completion_request(bad_value, default_limits()); }),
               "non-boolean preserve_thinking accepted");
+    Json bad_enable                    = base;
+    bad_enable["chat_template_kwargs"] = Json{{"enable_thinking", "no"}};
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(bad_enable, default_limits()); }),
+        "non-boolean enable_thinking accepted");
     Json unknown                    = base;
     unknown["chat_template_kwargs"] = Json{{"preserve_thinking", true}, {"foo", 1}};
     failures +=


### PR DESCRIPTION
## Problem

Clients that target vLLM (and Qwen's own serving docs) control thinking mode with `chat_template_kwargs: {"enable_thinking": false}` inside `messages[0]` — vLLM's documented contract for Qwen3-family models. NInfer rejects this body shape, so every vLLM-targeted client needs a special-case branch before it can talk to NInfer. Some clients also send a plain top-level `enable_thinking`, which vLLM accepts as an alias.

## Change

- Accept optional top-level `enable_thinking` (bool) in `/v1/chat/completions` and the Responses API.
- Accept `chat_template_kwargs.enable_thinking` nested in the first user message, mapping it onto the same option (vLLM semantics).
- If both are present and disagree, reject with 400 `conflicting_template_option` (fail loudly rather than guess).
- All other `chat_template_kwargs` keys are ignored, and extra unknown keys inside `chat_template_kwargs` do not fail the request — same accept-and-ignore posture as #45.

Schema tests cover: nested-only, top-level-only, both agreeing, both conflicting, and `chat_template_kwargs` with unrelated keys.

## Context

Validated in production for two days on a Qwen3.8-27B grading service (RTX 5090, 262144 ctx, MTP): client code written against vLLM worked against NInfer unchanged once this landed, including bodies carrying both shapes. No behavior change for requests that omit both fields.