### PR TITLE
fix(runtime): raise MTP CUDA-graph allowance above groupwise-int capture cost

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -646,7 +646,7 @@ std::unique_ptr<SequencePlanImpl> build_sequence_candidate(const SequencePlannin
                     const std::uint64_t final_visible = std::min<std::uint64_t>(
                         impl->capacity,
                         static_cast<std::uint64_t>(profile.max) + 2ULL * impl->draft_window);
-                    return (final_visible <= 4096 ? 12ULL : 82ULL) * kMiB;
+                    return (final_visible <= 4096 ? 12ULL : 256ULL) * kMiB;
                 },
                 "MTP graph allowance");
             impl->graph_allowance_bytes = checked_mul(per_batch_allowance, impl->max_concurrency,


### PR DESCRIPTION
**Problem**

`ninfer-serve` aborts startup for the Qwen3.8-27B groupwise-int artifact (`qwen3_8_27b`, Q4/Q5/Q6,
`A16Only` linear policy) when CUDA graphs are enabled:

```
[error] ninfer-serve: CUDA Graph preparation consumed 203296768 bytes,
exceeding the planned allowance of 85983232 bytes
```

Reproduced with `--spec mtp --draft-tokens 3 --lm-head-draft --max-concurrency 1 --kv-dtype int8
--kv-capacity auto --max-context 200000` (image built at `b2b96bae`; RTX 5090 / sm_120a, CUDA
13.1.2, container). The identical command passes on the NVFP4 artifact (`qwen3.8-27b-nvfp4`); only
the `weights_profile` differs.

**Analysis**

`build_sequence_candidate()` (`src/targets/qwen3_6/impl/runtime/layouts_impl.h:641-653`) plans the MTP
allowance as a flat `(final_visible <= 4096 ? 12 : 82) MiB` per topology class. `prepare_graphs()`
(`program_impl.h:1384-1392`) measures the free-VRAM delta of the whole family instantiation — driver
module state from qualifying all kernel definitions plus per-leaf capture workspaces — and throws when
it exceeds the plan. `text_policy()` (`qwen3_6_27b/impl/variant.cpp:49`) routes NVFP4 to `AllowA4`
(narrow kernel family) but Q4/Q5/Q6 to `A16Only`, which instantiates the full 16-bit kernel family
plus dequant/per-group-scale kernels and larger GDN/post-mixer workspaces — hence ~194 MiB measured
vs the 82 MiB static plan, which appears to have been sized against an NVFP4 reference. Context length
is not a mitigation: `mtp_graph_profiles` is identical for any capacity ≥ 32768.

**Fix**

Raise the MTP `> 4096` class allowance from 82 to 256 MiB (covers the measured 194 MiB with headroom).
The allowance is only a reservation subtracted from the KV auto-sizing budget, so artifacts that
capture less pay only a slightly larger planned reservation (≈174 MiB ≈ 4–5k KV tokens at
concurrency 1 — negligible); no behavior change for NVFP4. A `weights_profile`-aware allowance would
be a cleaner long-term fix; this constant keeps the existing heuristic shape.

**Verification performed (local)**

- NVFP4 profile: boots with graphs before and after the change (capture already under the old plan).
- groupwise-int profile with the raised allowance: startup passes `prepare_graphs()` with no
  "exceeding the planned allowance" error (the stock binary throws here at 203,296,768 bytes),
  `/health` ok, and the KV ledger line shows the patched plan in effect
  (`graphs=0.00 MiB/256.00 MiB` — the planned column is the 256 MiB constant; capture happens
  during warm-up, after that line is printed).
- End-to-end decode on the same artifact/box: ~133 tok/s with graphs ON vs ~128 tok/s with
  `--no-cuda-graph` (MTP ~2.7 tok/round, 57% acceptance) — the change restores the graph path
  without altering numerical behavior.

**Exact verification commands**

- Build: repo `Dockerfile` invocation on `a05746aa` + this patch —
  `cmake -S . -B /build -G Ninja <repo flags> && cmake --build /build --parallel --target ninfer ninfer-serve`
  (278/278 objects; no new warnings on the changed header).
- Serve: the repro command quoted above (identical flags for stock and patched image), RTX 5090 /
  sm_120a, CUDA 13.1.2, container; startup evidence in the serve log (`KV capacity auto resolved=…`).

**Checks not run, and why**

- No unit test added: the allowance is a private planning constant; the affected observable
  behavior (startup with CUDA graphs for the groupwise-int artifact) is the real-artifact,
  real-GPU startup above. `tests/` contains no allowance/planning unit test to extend, and the
  suite builds behind `-DBUILD_TESTING=ON`, which the serve image does not enable.
- No numerical oracle: the change alters only the VRAM reservation subtracted from KV
  auto-sizing; kernels, graph topology, and token output are unchanged by construction.

**AI-assisted contribution disclosure**

The bug analysis, patch, and verification were produced with an AI coding agent — exact model
and version: Qwen3.8-27B, served by the local NInfer deployment (artifacts `qwen3_8_27b` and
`qwen3_8_27b_nvfp4`, RTX 5090) and driven through VS Code (Zoo Code); the human contributor
(i74iv3) reviewed the complete diff and owns the verification above.

**Workaround used meanwhile**

`--no-cuda-graph` (MTP runs with eager decode).