### PR TITLE
fix(serve): name the exception that terminates the process

### DIFF
--- a/apps/serve/main.cpp
+++ b/apps/serve/main.cpp
@@ -8,10 +8,13 @@
 #include <chrono>
 #include <csignal>
 #include <cstddef>
+#include <cstdlib>
 #include <exception>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <typeinfo>
 #include <utility>
 
 namespace {
@@ -21,6 +24,27 @@ std::atomic<ninfer::serve::HttpServer*> g_server{nullptr};
 void handle_signal(int) {
     ninfer::serve::HttpServer* server = g_server.load();
     if (server != nullptr) { server->stop(); }
+}
+
+// An exception that escapes a request boundary ends the process through
+// std::terminate, and the default handler's message is the only record of which
+// exception it was. That message is worth writing through the server's own log:
+// under a container this process is pid 1, the kernel discards the SIGABRT that
+// abort() raises against itself, glibc falls through to its abort instruction,
+// and all the kernel reports is a bare protection fault inside libc.
+[[noreturn]] void log_terminate() {
+    std::string detail = "terminate called with no active exception";
+    if (std::current_exception() != nullptr) {
+        try {
+            std::rethrow_exception(std::current_exception());
+        } catch (const std::exception& error) {
+            detail = std::string("terminate called after throwing ") + typeid(error).name() + ": " +
+                     error.what();
+        } catch (...) { detail = "terminate called after throwing a non-std exception"; }
+    }
+    ninfer::serve::write_console_log(ninfer::serve::ConsoleLogLevel::Error, detail);
+    std::cerr.flush();
+    std::abort();
 }
 
 std::string format_bytes(std::size_t bytes) {
@@ -39,6 +63,7 @@ std::string format_bytes(std::size_t bytes) {
 } // namespace
 
 int main(int argc, char** argv) {
+    std::set_terminate(log_terminate);
     try {
         const ninfer::serve::ServeOptions options = ninfer::serve::parse_serve_options(argc, argv);
         if (options.help_requested) {


### PR DESCRIPTION
## Summary

When `ninfer-serve` dies from an uncaught exception, the only thing the server's own log records is that it stopped. What was thrown is written by the default `std::terminate` handler to stderr, which goes to the container log — and that log is discarded with the container on the next redeploy. This installs a terminate handler that writes the exception's type and `what()` through the server's own logger first, then chains to the previous handler.

25 lines in `apps/serve/main.cpp`. No behaviour change on any successful path.

## Why this is worth merging

This is a diagnosability fix for a failure mode that is actively misleading in containers.

`ninfer-serve` died twice on a 5090 host with nothing in `ninfer.log` but this kernel line:

```
traps: ninfer-serve[...] general protection fault ip:...9a2 error:0 in libc.so.6
```

That offset is the `hlt` at the end of glibc's `abort()`, which is only reached after `raise(SIGABRT)` *returns*. It returns because the server is pid 1 in its container: the kernel drops a default-disposition signal that a namespace init sends to itself, so `abort()` falls through to its trailing abort instruction and the kernel reports the result as a protection fault inside libc.

So the log says "general protection fault in libc" for what is an ordinary C++ `terminate`. Anyone reading it — including me, for a while — starts hunting memory corruption in the CUDA path. The actual exception message is the one piece of information that resolves it immediately, and today it is written only to a place that does not survive a redeploy.

Anyone running the server under Docker with `--init` absent, or as pid 1 at all, will hit the same misreading.

## Scope

- Only adds a handler; does not catch anything, does not change exit codes, does not alter shutdown.
- Chains to the previously installed handler, so the default message still reaches stderr as before.
