### PR TITLE
Fix/tool message content parts

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -73,6 +73,8 @@ The endpoint supports:
 
 - `system`, `developer`, `user`, `assistant`, and `tool` history;
 - string content and ordered text, `image_url`, and `video_url` parts;
+- tool messages with string content or an array of `text` content parts (the OpenAI
+  contract allows no other part type for tool messages);
 - `max_completion_tokens` and the legacy `max_tokens` spelling;
 - `temperature`, `top_p`, `top_k`, presence/frequency penalties, and a nonnegative `seed`;
 - one stop string or an array of stop strings;

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -137,60 +137,6 @@ ninfer::product::media_acquire::Source parse_media_url(const Json& part, const c
     return source;
 }
 
-void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
-                         std::vector<std::string> allowed_types = {}) {
-    if (content.is_string()) {
-        turn.content.push_back(ContentPart{ContentKind::Text, content.get<std::string>(), "text"});
-        return;
-    }
-    if (!content.is_array()) {
-        bad_request("message " + std::to_string(index) + " content must be a string or array",
-                    "messages");
-    }
-    std::string allowed_list;
-    for (const std::string& allowed : allowed_types) {
-        if (!allowed_list.empty()) { allowed_list += ", "; }
-        allowed_list += "'" + allowed + "'";
-    }
-    for (const Json& part : content) {
-        if (!part.is_object() || !part.contains("type") || !part.at("type").is_string()) {
-            bad_request("message " + std::to_string(index) +
-                            " content parts must be objects with a string 'type'",
-                        "messages");
-        }
-        const std::string type = part.at("type").get<std::string>();
-        if (!allowed_types.empty() &&
-            std::find(allowed_types.begin(), allowed_types.end(), type) == allowed_types.end()) {
-            bad_request("message " + std::to_string(index) + " content parts must have type " +
-                            allowed_list,
-                        "messages");
-        }
-        ContentPart out;
-        out.type_raw = type;
-        if (type == "text") {
-            if (!part.contains("text") || !part.at("text").is_string()) {
-                bad_request("text content part must contain a string 'text'", "messages");
-            }
-            out.kind = ContentKind::Text;
-            out.text = part.at("text").get<std::string>();
-        } else if (type == "image_url") {
-            out.kind   = ContentKind::Image;
-            out.source = parse_media_url(part, "image_url");
-        } else if (type == "video_url") {
-            out.kind   = ContentKind::Video;
-            out.source = parse_media_url(part, "video_url");
-        } else if (type == "input_audio") {
-            out.kind = ContentKind::InputAudio;
-        } else {
-            out.kind = ContentKind::Unsupported;
-        }
-        turn.content.push_back(std::move(out));
-    }
-    if (turn.content.empty()) {
-        bad_request("message " + std::to_string(index) + " content must not be empty", "messages");
-    }
-}
-
 std::vector<ToolCall> parse_assistant_tool_calls(const Json& item, std::size_t index) {
     std::vector<ToolCall> calls;
     if (!item.contains("tool_calls") || item.at("tool_calls").is_null()) { return calls; }
@@ -491,6 +437,60 @@ Json tool_calls_json(const std::vector<ToolCall>& tool_calls, bool include_index
 std::string sse_event(const Json& payload) { return "data: " + payload.dump() + "\n\n"; }
 
 } // namespace
+
+void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
+                         std::vector<std::string> allowed_types) {
+    if (content.is_string()) {
+        turn.content.push_back(ContentPart{ContentKind::Text, content.get<std::string>(), "text"});
+        return;
+    }
+    if (!content.is_array()) {
+        bad_request("message " + std::to_string(index) + " content must be a string or array",
+                    "messages");
+    }
+    std::string allowed_list;
+    for (const std::string& allowed : allowed_types) {
+        if (!allowed_list.empty()) { allowed_list += ", "; }
+        allowed_list += "'" + allowed + "'";
+    }
+    for (const Json& part : content) {
+        if (!part.is_object() || !part.contains("type") || !part.at("type").is_string()) {
+            bad_request("message " + std::to_string(index) +
+                            " content parts must be objects with a string 'type'",
+                        "messages");
+        }
+        const std::string type = part.at("type").get<std::string>();
+        if (!allowed_types.empty() &&
+            std::find(allowed_types.begin(), allowed_types.end(), type) == allowed_types.end()) {
+            bad_request("message " + std::to_string(index) + " content parts must have type " +
+                            allowed_list,
+                        "messages");
+        }
+        ContentPart out;
+        out.type_raw = type;
+        if (type == "text") {
+            if (!part.contains("text") || !part.at("text").is_string()) {
+                bad_request("text content part must contain a string 'text'", "messages");
+            }
+            out.kind = ContentKind::Text;
+            out.text = part.at("text").get<std::string>();
+        } else if (type == "image_url") {
+            out.kind   = ContentKind::Image;
+            out.source = parse_media_url(part, "image_url");
+        } else if (type == "video_url") {
+            out.kind   = ContentKind::Video;
+            out.source = parse_media_url(part, "video_url");
+        } else if (type == "input_audio") {
+            out.kind = ContentKind::InputAudio;
+        } else {
+            out.kind = ContentKind::Unsupported;
+        }
+        turn.content.push_back(std::move(out));
+    }
+    if (turn.content.empty()) {
+        bad_request("message " + std::to_string(index) + " content must not be empty", "messages");
+    }
+}
 
 std::optional<bool> parse_openai_preserve_thinking(const Json& body) {
     std::optional<bool> top_level;

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -1,5 +1,6 @@
 #include "serve/openai_schema.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <chrono>
@@ -137,7 +138,7 @@ ninfer::product::media_acquire::Source parse_media_url(const Json& part, const c
 }
 
 void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
-                         bool text_only = false) {
+                         std::vector<std::string> allowed_types = {}) {
     if (content.is_string()) {
         turn.content.push_back(ContentPart{ContentKind::Text, content.get<std::string>(), "text"});
         return;
@@ -146,6 +147,11 @@ void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
         bad_request("message " + std::to_string(index) + " content must be a string or array",
                     "messages");
     }
+    std::string allowed_list;
+    for (const std::string& allowed : allowed_types) {
+        if (!allowed_list.empty()) { allowed_list += ", "; }
+        allowed_list += "'" + allowed + "'";
+    }
     for (const Json& part : content) {
         if (!part.is_object() || !part.contains("type") || !part.at("type").is_string()) {
             bad_request("message " + std::to_string(index) +
@@ -153,6 +159,12 @@ void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
                         "messages");
         }
         const std::string type = part.at("type").get<std::string>();
+        if (!allowed_types.empty() &&
+            std::find(allowed_types.begin(), allowed_types.end(), type) == allowed_types.end()) {
+            bad_request("message " + std::to_string(index) + " content parts must have type " +
+                            allowed_list,
+                        "messages");
+        }
         ContentPart out;
         out.type_raw = type;
         if (type == "text") {
@@ -161,10 +173,6 @@ void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
             }
             out.kind = ContentKind::Text;
             out.text = part.at("text").get<std::string>();
-        } else if (text_only) {
-            bad_request("message " + std::to_string(index) +
-                            " content parts must have type 'text'",
-                        "messages");
         } else if (type == "image_url") {
             out.kind   = ContentKind::Image;
             out.source = parse_media_url(part, "image_url");
@@ -260,7 +268,7 @@ void parse_messages(const Json& body, GenerationRequest& out) {
             }
             turn.tool_call_id = item.at("tool_call_id").get<std::string>();
             // Per the OpenAI contract, only text parts are valid in tool messages.
-            parse_content_parts(item.at("content"), turn, i, /*text_only=*/true);
+            parse_content_parts(item.at("content"), turn, i, {"text"});
             out.messages.push_back(std::move(turn));
             continue;
         }

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -136,7 +136,8 @@ ninfer::product::media_acquire::Source parse_media_url(const Json& part, const c
     return source;
 }
 
-void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index) {
+void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index,
+                         bool text_only = false) {
     if (content.is_string()) {
         turn.content.push_back(ContentPart{ContentKind::Text, content.get<std::string>(), "text"});
         return;
@@ -160,6 +161,10 @@ void parse_content_parts(const Json& content, ChatTurn& turn, std::size_t index)
             }
             out.kind = ContentKind::Text;
             out.text = part.at("text").get<std::string>();
+        } else if (text_only) {
+            bad_request("message " + std::to_string(index) +
+                            " content parts must have type 'text'",
+                        "messages");
         } else if (type == "image_url") {
             out.kind   = ContentKind::Image;
             out.source = parse_media_url(part, "image_url");
@@ -250,12 +255,12 @@ void parse_messages(const Json& body, GenerationRequest& out) {
                 item.at("tool_call_id").get<std::string>().empty()) {
                 bad_request("tool messages must contain a string tool_call_id", "messages");
             }
-            if (!item.contains("content") || !item.at("content").is_string()) {
-                bad_request("tool messages must contain string content", "messages");
+            if (!item.contains("content") || item.at("content").is_null()) {
+                bad_request("tool messages must contain content", "messages");
             }
             turn.tool_call_id = item.at("tool_call_id").get<std::string>();
-            turn.content.push_back(
-                ContentPart{ContentKind::Text, item.at("content").get<std::string>(), "text"});
+            // Per the OpenAI contract, only text parts are valid in tool messages.
+            parse_content_parts(item.at("content"), turn, i, /*text_only=*/true);
             out.messages.push_back(std::move(turn));
             continue;
         }

--- a/src/serve/openai_schema.h
+++ b/src/serve/openai_schema.h
@@ -23,6 +23,11 @@ namespace ninfer::serve {
 GenerationRequest parse_chat_completion_request(const nlohmann::json& body,
                                                 const RequestLimits& limits);
 
+// Parse a message's `content` field (string or content-part array) into `turn.content`.
+// A non-empty `allowed_types` rejects parts whose `type` is not listed.
+void parse_content_parts(const nlohmann::json& content, ChatTurn& turn, std::size_t index,
+                         std::vector<std::string> allowed_types = {});
+
 std::optional<bool> parse_openai_preserve_thinking(const nlohmann::json& body);
 
 // Non-streaming chat completion response body (JSON string). When `reasoning` is

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -477,6 +477,85 @@ int test_parse_tool_history_messages() {
     return failures;
 }
 
+int test_parse_tool_message_content_parts() {
+    int failures = 0;
+    Json tool_msg;
+    tool_msg["role"]         = "tool";
+    tool_msg["tool_call_id"] = "call_1";
+    tool_msg["content"]      = Json::array({Json{{"type", "text"}, {"text", R"({"temp":20})"}}});
+    Json body;
+    body["model"]    = "m";
+    body["messages"] = Json::array(
+        {Json{{"role", "user"}, {"content", "weather?"}},
+         Json{{"role", "assistant"},
+              {"content", nullptr},
+              {"tool_calls",
+               Json::array({Json{{"id", "call_1"},
+                                 {"type", "function"},
+                                 {"function",
+                                  Json{{"name", "get_weather"}, {"arguments", R"({"city":"Paris"})"}}}}})}},
+         tool_msg});
+    const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+    failures += check(req.messages.size() == 3, "array tool content accepted");
+    failures += check(req.messages[2].role == ninfer::ChatRole::Tool, "tool role parsed");
+    failures += check(req.messages[2].tool_call_id == "call_1", "tool_call_id parsed");
+    failures += check(req.messages[2].content.size() == 1, "one tool content part");
+    failures += check(req.messages[2].content[0].kind == ContentKind::Text, "tool part kind");
+    failures += check(req.messages[2].content[0].text == R"({"temp":20})", "tool part text");
+
+    Json multi_tool;
+    multi_tool["role"]         = "tool";
+    multi_tool["tool_call_id"] = "call_1";
+    multi_tool["content"]      = Json::array({Json{{"type", "text"}, {"text", "a"}},
+                                              Json{{"type", "text"}, {"text", "b"}}});
+    Json multi;
+    multi["model"]    = "m";
+    multi["messages"] = Json::array({multi_tool});
+    const GenerationRequest multi_req = parse_chat_completion_request(multi, default_limits());
+    failures += check(multi_req.messages[0].content.size() == 2, "two tool text parts kept");
+
+    const Json str = {
+        {"model", "m"},
+        {"messages",
+         Json::array({Json{{"role", "tool"}, {"tool_call_id", "call_1"}, {"content", "plain"}}})}};
+    const GenerationRequest str_req = parse_chat_completion_request(str, default_limits());
+    failures += check(str_req.messages[0].content.size() == 1, "string tool content accepted");
+    failures += check(str_req.messages[0].content[0].text == "plain", "string tool content text");
+
+    Json empty_array = multi;
+    empty_array["messages"][0]["content"] = Json::array();
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(empty_array, default_limits()); }),
+        "empty tool content array rejected");
+    Json null_content = str;
+    null_content["messages"][0]["content"] = nullptr;
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(null_content, default_limits()); }),
+        "null tool content rejected");
+
+    for (const char* bad_type : {"image_url", "video_url", "input_audio", "file"}) {
+        Json bad_tool = multi_tool;
+        bad_tool["content"] =
+            Json::array({Json{{"type", bad_type},
+                              {"image_url", Json{{"url", "https://example.test/x.png"}}}}});
+        Json bad_body;
+        bad_body["model"]    = "m";
+        bad_body["messages"] = Json::array({bad_tool});
+        failures +=
+            check(throws_api([&] { (void)parse_chat_completion_request(bad_body, default_limits()); }),
+                  std::string("non-text tool content part '") + bad_type + "' rejected");
+    }
+    Json text_missing = multi_tool;
+    text_missing["content"] = Json::array({Json{{"type", "text"}}});
+    Json missing_body;
+    missing_body["model"]    = "m";
+    missing_body["messages"] = Json::array({text_missing});
+    failures += check(
+        throws_api([&] { (void)parse_chat_completion_request(missing_body, default_limits()); }),
+        "tool text part without 'text' field rejected");
+    return failures;
+}
+
 int test_parse_stop_and_max_tokens() {
     int failures          = 0;
     Json body             = {{"model", "m"},
@@ -717,6 +796,7 @@ int main() {
     failures += test_reject_unsupported();
     failures += test_parse_function_tools_and_choices();
     failures += test_parse_tool_history_messages();
+    failures += test_parse_tool_message_content_parts();
     failures += test_parse_stop_and_max_tokens();
     failures += test_parse_sampling_carried();
     failures += test_response_serialization();

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -46,6 +46,15 @@ std::string api_code(const std::function<void()>& f) {
     return {};
 }
 
+std::string api_message(const std::function<void()>& f) {
+    try {
+        f();
+    } catch (const ApiException& error) { return error.error().message; } catch (...) {
+        return "wrong_exception";
+    }
+    return {};
+}
+
 RequestLimits default_limits() {
     RequestLimits limits;
     limits.default_max_tokens = 512;
@@ -556,6 +565,79 @@ int test_parse_tool_message_content_parts() {
     return failures;
 }
 
+int test_parse_content_parts_allowed_types() {
+    int failures = 0;
+    ChatTurn all;
+    parse_content_parts(
+        Json::array(
+            {Json{{"type", "text"}, {"text", "a"}},
+             Json{{"type", "image_url"}, {"image_url", Json{{"url", "data:image/png;base64,AA=="}}}},
+             Json{{"type", "video_url"},
+                  {"video_url", Json{{"url", "https://example.test/clip.mp4"}}}},
+             Json{{"type", "input_audio"}}}),
+        all, 0);
+    failures += check(all.content.size() == 4, "default allowlist parses all normal parts");
+    failures += check(all.content[0].kind == ContentKind::Text, "default text kind");
+    failures += check(all.content[1].kind == ContentKind::Image, "default image kind");
+    failures += check(all.content[2].kind == ContentKind::Video, "default video kind");
+    failures += check(all.content[3].kind == ContentKind::InputAudio, "default input_audio kind");
+
+    ChatTurn str;
+    parse_content_parts(Json("plain"), str, 0, {"text"});
+    failures += check(str.content.size() == 1 && str.content[0].kind == ContentKind::Text &&
+                          str.content[0].text == "plain",
+                      "string content is a single text part");
+
+    ChatTurn text_only;
+    parse_content_parts(Json::array({Json{{"type", "text"}, {"text", "a"}}}), text_only, 0, {"text"});
+    failures +=
+        check(text_only.content.size() == 1 && text_only.content[0].kind == ContentKind::Text,
+              "text allowed by {\"text\"}");
+    failures += check(
+        api_message([&] {
+            ChatTurn t;
+            parse_content_parts(Json::array({Json{{"type", "image_url"},
+                                                {"image_url", Json{{"url", "data:image/png;base64,AA=="}}}}}),
+                                t, 0, {"text"});
+        }) == "message 0 content parts must have type 'text'",
+        "non-text rejected with the allowed type listed");
+
+    ChatTurn multi;
+    parse_content_parts(
+        Json::array(
+            {Json{{"type", "text"}, {"text", "a"}},
+             Json{{"type", "image_url"}, {"image_url", Json{{"url", "data:image/png;base64,AA=="}}}}}),
+        multi, 0, {"text", "image_url"});
+    failures += check(multi.content.size() == 2, "multi-type allowlist parses both listed types");
+    failures += check(multi.content[0].kind == ContentKind::Text, "multi-type text kind");
+    failures += check(multi.content[1].kind == ContentKind::Image, "multi-type image kind");
+    failures += check(
+        api_message([&] {
+            ChatTurn t;
+            parse_content_parts(
+                Json::array({Json{{"type", "video_url"},
+                                  {"video_url", Json{{"url", "https://example.test/clip.mp4"}}}}}),
+                t, 0, {"text", "image_url"});
+        }) == "message 0 content parts must have type 'text', 'image_url'",
+        "multi-type rejection lists the allowed types in caller order");
+
+    ChatTurn rejected;
+    failures += check(
+        throws_api([&] {
+            parse_content_parts(
+                Json::array({Json{{"type", "image_url"},
+                                  {"image_url", Json{{"url", "https://not-a-real-host.test/x"}}}}}),
+                rejected, 0, {"text"});
+        }),
+        "disallowed media part rejected at the schema boundary");
+    failures += check(rejected.content.empty(), "disallowed part is not appended or acquired");
+
+    ChatTurn empty;
+    failures += check(throws_api([&] { parse_content_parts(Json::array(), empty, 0, {"text"}); }),
+                      "empty content array rejected");
+    return failures;
+}
+
 int test_parse_stop_and_max_tokens() {
     int failures          = 0;
     Json body             = {{"model", "m"},
@@ -797,6 +879,7 @@ int main() {
     failures += test_parse_function_tools_and_choices();
     failures += test_parse_tool_history_messages();
     failures += test_parse_tool_message_content_parts();
+    failures += test_parse_content_parts_allowed_types();
     failures += test_parse_stop_and_max_tokens();
     failures += test_parse_sampling_carried();
     failures += test_response_serialization();


### PR DESCRIPTION
Problem

`POST /v1/chat/completions` rejects tool messages whose `content` is a content-part array
(`[{ "type": "text", "text": ... }]`) with `400 "tool messages must contain string content"`.
OpenAI-compatible agent clients emit that shape by default (Qwen Code serializes tool results
as parts), so every tool call in an agentic loop fails. The OpenAI spec defines tool `content`
as oneOf string | content-part array (`minItems: 1`), only `type: "text"` parts valid; other
roles already accept both forms via `parse_content_parts()`, but the tool branch
(`openai_schema.cpp`) hard-required the string.

## Change

Route tool content through the existing `parse_content_parts()` helper with a new optional
`allowed_types` allowlist (wire type names, default empty = accept all, behavior unchanged):

- `parse_content_parts(content, turn, index, allowed_types = {})` — when non-empty, a guard in
  the part loop rejects any part whose `type` is not in the list with a precise 400.
- Tool branch: after its existing `tool_call_id`/`content` checks, calls
  `parse_content_parts(item.at("content"), turn, i, {"text"})`.
- All other call sites omit the argument — user/assistant/system behavior unchanged.
- `parse_content_parts()` is exported in `openai_schema.h` (moved out of the anonymous
  namespace, same as `parse_openai_preserve_thinking`) so the allowlist is unit-testable.

Non-text parts (media, audio, unknown) are rejected at the schema boundary with a precise 400
instead of being media-acquired and failing later with `modality_not_supported`.

## Affected behavior

| Input | Before | After |
|---|---|---|
| `content` = string | accepted | accepted (unchanged) |
| `content` = `[{"type":"text","text":...}]` | **400** | accepted, parsed to text parts |
| multiple text parts | **400** | accepted, kept separate (matches other roles) |
| non-text part (e.g. `image_url`) | **400** | 400 `"content parts must have type 'text'"` |
| `content` = `[]` | 400 | 400 `"content must not be empty"` |
| `content` = null/missing | 400 | 400 `"tool messages must contain content"` |

Downstream translation, prompt construction, sampling, and non-tool roles are unaffected.
`docs/serving.md` documents the tool-message content contract in the same change.

## Verification

Base `a05746aa`, tip `f197be4b` (RTX 5090, `sm_120a`, CUDA 13.1).

- `ninfer_openai_schema_test` passed — new `test_parse_tool_message_content_parts` (array
  accepted, multiple text parts kept separate, bare string still accepted, empty array/null
  rejected, `image_url`/`video_url`/`input_audio`/unknown rejected at the schema boundary) and
  new `test_parse_content_parts_allowed_types` (default allowlist accepts all normal part
  types; multi-type allowlist accepts listed types and rejects the rest, listing allowed types
  in caller order; guard runs before any media acquisition; empty array still rejected).
- Serve-protocol suite: **4/4 passed** (openai/anthropic/responses schema, tool-call parser) —
  no cross-protocol regression in the shared `ninfer_serve` layer.
- Full CTest (89 tests): 79 passed, 10 failed, 5 skipped; all 10 failures are environmental
  (9 × GPU OOM from a live serve process, 1 × hardcoded model paths) and none link
  `ninfer_serve`. All 11 serve/protocol contract tests pass.
- `git diff --check` clean.
- End-to-end (live server, `qwen3.8:27B` nvfp4): the reproduction payload (tool result as
  text-part array) returns **HTTP 200** with a valid completion; the identical payload on the
  unpatched server returns 400.

## AI-assisted implementation disclosure

Implementation and tests drafted in an AI-assisted session (Qwen Code agent; model
`qwen3.8:27B`) and reviewed by the contributor.

#56 