### PR TITLE
fix(serve): type tool-call parameters by their declared schema

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -634,8 +634,19 @@ context-capacity finishes map to `length`/ `max_tokens`; ordinary model or strin
 `stop`/ `end_turn`.
 
 Function tools are rendered into the model prompt and generated calls are parsed into protocol
-responses. NInfer does not execute tools and does not enforce client JSON Schema through constrained
-decoding.
+responses. NInfer does not execute tools and does not validate tool arguments against the full
+client JSON Schema through constrained decoding; that remains the client's responsibility. When
+parsing a generated call, NInfer does consult the top-level parameter `"type"` declared in each
+tool's schema to decide whether a parameter value that is valid JSON may be deserialized into the
+corresponding JSON type (number, boolean, array, object, null): only parameters whose declared
+type(s) are all valid non-string JSON Schema types are deserialized. Parameters typed as `"string"`
+(or declared via a type array that includes `"string"`), parameters with an unknown or misspelled
+`"type"`, and parameters absent from the schema preserve the model's raw text so the string
+contract reaches the client intact. Full JSON Schema validation (constraints, required sets,
+formats, nested keywords) is not performed server-side and remains the client's job.
+Duplicate tool names within a single request are rejected with a 400 on all three
+protocol surfaces (OpenAI Chat Completions, OpenAI Responses, Anthropic Messages),
+keeping the per-tool parameter type map unambiguous.
 
 Prompt-token usage includes chat-template and expanded media tokens. Generated-token usage comes
 from accepted output token IDs, including a stop token whose decoded text may be withheld.

--- a/src/serve/anthropic_schema.cpp
+++ b/src/serve/anthropic_schema.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <random>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 namespace ninfer::serve {
@@ -141,6 +142,7 @@ void parse_tools(const Json& body, GenerationRequest& out) {
     const Json& tools = body.at("tools");
     if (!tools.is_array()) { bad_request("tools must be an array", "tools"); }
     out.tools.reserve(tools.size());
+    std::unordered_set<std::string> names;
     for (const Json& item : tools) {
         if (!item.is_object()) { bad_request("tools entries must be objects", "tools"); }
         // Anthropic server/built-in tools carry a `type` and no `input_schema`; we
@@ -155,6 +157,9 @@ void parse_tools(const Json& body, GenerationRequest& out) {
         }
         ToolDefinition tool;
         tool.name     = require_function_name(item, "tools");
+        if (!names.insert(tool.name).second) {
+            bad_request("duplicate tool name: " + tool.name, "tools");
+        }
         Json function = Json{{"name", tool.name}};
         if (item.contains("description") && !item.at("description").is_null()) {
             if (!item.at("description").is_string()) {

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -276,6 +276,7 @@ PreparedRequest GenerationService::prepare(const GenerationRequest& request,
     prepared.include_usage                 = request.include_usage;
     prepared.tool_capable                  = request.uses_tools() || request.has_tool_history();
     prepared.tool_name_max_length          = request.tool_name_max_length;
+    prepared.param_types                   = build_tool_param_type_map(request.tools);
     const ResolvedPromptSemantics semantics =
         resolve_prompt_semantics(request, options_, prompt_capabilities_);
     prepared.enable_thinking                   = semantics.enable_thinking;
@@ -401,8 +402,8 @@ GenerationOutcome GenerationService::run(PreparedRequest& prepared, const Stream
 
     bool is_tool_call_response = false;
     if (prepared.tool_capable) {
-        ParsedToolCallOutput parsed =
-            parse_qwen_tool_call_output(outcome.text, prepared.tool_name_max_length);
+        ParsedToolCallOutput parsed = parse_qwen_tool_call_output(
+            outcome.text, prepared.tool_name_max_length, prepared.param_types);
         outcome.text          = std::move(parsed.content);
         is_tool_call_response = parsed.is_tool_call_response;
         if (is_tool_call_response) { outcome.tool_calls = std::move(parsed.tool_calls); }

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -7,6 +7,7 @@
 #include "ninfer/engine.h"
 #include "serve/request.h"
 #include "serve/serve_options.h"
+#include "serve/tool_call_parser.h"
 
 #include <chrono>
 #include <cstddef>
@@ -74,6 +75,7 @@ struct PreparedRequest {
     bool include_usage                     = false;
     bool tool_capable                      = false;
     std::size_t tool_name_max_length       = 64;
+    ToolParamTypeMap param_types;
     bool enable_thinking                   = true;
     bool preserve_thinking                 = false;
     bool preserve_thinking_semantic_change = false;

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <random>
 #include <string>
+#include <unordered_set>
 
 namespace ninfer::serve {
 namespace {
@@ -298,6 +299,7 @@ void parse_tools(const Json& body, GenerationRequest& out) {
     const Json& tools = body.at("tools");
     if (!tools.is_array()) { bad_request("tools must be an array", "tools"); }
     out.tools.reserve(tools.size());
+    std::unordered_set<std::string> names;
     for (std::size_t i = 0; i < tools.size(); ++i) {
         const Json& item = tools.at(i);
         if (!item.is_object()) { bad_request("tools entries must be objects", "tools"); }
@@ -314,6 +316,9 @@ void parse_tools(const Json& body, GenerationRequest& out) {
         Json& fn        = normalized["function"];
         ToolDefinition tool;
         tool.name = require_function_name(fn, "tools");
+        if (!names.insert(tool.name).second) {
+            bad_request("duplicate function tool name: " + tool.name, "tools");
+        }
         if (fn.contains("description") && !fn.at("description").is_null()) {
             if (!fn.at("description").is_string()) {
                 bad_request("function description must be a string", "tools");

--- a/src/serve/tool_call_parser.cpp
+++ b/src/serve/tool_call_parser.cpp
@@ -6,9 +6,14 @@
 #include <array>
 #include <cctype>
 #include <cstdio>
+#include <optional>
 #include <random>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace ninfer::serve {
 namespace {
@@ -64,7 +69,120 @@ std::string new_tool_call_id() {
     return std::string(buf.data());
 }
 
-bool parse_parameter(std::string_view inner, std::size_t& pos, Json& args) {
+const std::unordered_map<std::string, std::vector<std::string>>* tool_param_types(
+    const ToolParamTypeMap& map, const std::string& tool_name) {
+    const auto it = map.find(tool_name);
+    return it == map.end() ? nullptr : &it->second;
+}
+
+// The full set of declared non-string types recorded for (tool_name, param),
+// or nullptr when the parameter has no non-string schema permission.
+const std::vector<std::string>* param_declared_types(const ToolParamTypeMap& map,
+                                                     const std::string& tool_name,
+                                                     const std::string& param) {
+    const auto* params = tool_param_types(map, tool_name);
+    if (params == nullptr) { return nullptr; }
+    const auto it = params->find(param);
+    return it == params->end() ? nullptr : &it->second;
+}
+
+// vLLM's qwen3coder coercion for boolean-declared parameters: the model may
+// emit Python-style scalars (True/False, 1/0) that are not valid JSON.
+// `value` is the lowercased raw text; "true"/"1" -> true, "false"/"0" ->
+// false; anything else is not a boolean and stays raw text.
+std::optional<bool> coerce_boolean(std::string_view value) {
+    if (value == "true" || value == "1") { return true; }
+    if (value == "false" || value == "0") { return false; }
+    return std::nullopt;
+}
+
+} // namespace
+
+namespace {
+
+// Valid JSON Schema "type" values that are not string. A parameter is only
+// allowed to deserialize when every type it declares is in this set.
+const std::unordered_set<std::string>& non_string_schema_types() {
+    static const std::unordered_set<std::string> types = {"integer", "number", "boolean",
+                                                          "array", "object", "null"};
+    return types;
+}
+
+// Classify a parameter's schema "type" (a string or an array of strings) into
+// the set of declared types. Returns false if "type" is absent or not a
+// string/array; in that case classification is uncertain and the caller
+// preserves raw text. Returns true and fills `declared` otherwise.
+bool classify_param_type(const Json& spec, std::vector<std::string>& declared) {
+    const auto type_it = spec.find("type");
+    if (type_it == spec.end()) { return false; }
+    if (type_it->is_string()) {
+        declared.push_back(type_it->get<std::string>());
+        return true;
+    }
+    if (type_it->is_array()) {
+        for (const Json& t : *type_it) {
+            if (!t.is_string()) { return false; }
+            declared.push_back(t.get<std::string>());
+        }
+        // An empty type array (e.g. "type":[]) is uncertain, not a positive
+        // declaration of a non-string type; returning false here preserves
+        // raw text and prevents all_non_string_types from succeeding vacuously
+        // on an empty set (which would record the parameter with no declared
+        // types).
+        if (declared.empty()) { return false; }
+        return true;
+    }
+    return false;
+}
+
+// Whether every declared type is a valid non-string JSON Schema type. If any
+// declared type is "string" or unknown/invalid, the schema permits (or may
+// permit) a string value, so the parser must preserve raw text.
+bool all_non_string_types(const std::vector<std::string>& declared) {
+    const auto& valid = non_string_schema_types();
+    for (const std::string& type : declared) {
+        if (valid.find(type) == valid.end()) { return false; }
+    }
+    return true;
+}
+
+} // namespace
+
+ToolParamTypeMap build_tool_param_type_map(const std::vector<ToolDefinition>& tools) {
+    ToolParamTypeMap map;
+    for (const ToolDefinition& tool : tools) {
+        // Replace any prior entry for this tool name first, before any early
+        // exit, so a redefinition with an empty/malformed/no-properties schema
+        // cannot leak stale non-string permissions from a previous definition.
+        map[tool.name] = {};
+        if (tool.parameters_json.empty()) { continue; }
+        const Json schema = Json::parse(tool.parameters_json, nullptr, false);
+        if (!schema.is_object()) { continue; }
+        const auto props_it = schema.find("properties");
+        if (props_it == schema.end() || !props_it->is_object()) { continue; }
+        // The entry for tool.name was already reset to empty at the top of
+        // the loop; populate it only from this definition's properties.
+        auto& inner = map[tool.name];
+        for (const auto& [name, spec] : props_it->items()) {
+            if (!spec.is_object()) { continue; }
+            std::vector<std::string> declared;
+            if (!classify_param_type(spec, declared)) { continue; }
+            // Record only when every declared type is a valid non-string type;
+            // string-allowed, unknown/invalid, and absent-type params are left
+            // out so the parser preserves raw text for them. Store the full
+            // declared set (not just the first element) so the parser can
+            // reason about nullable types (e.g. ["boolean","null"])
+            // independently of the type-array order.
+            if (all_non_string_types(declared)) { inner[name] = declared; }
+        }
+    }
+    return map;
+}
+
+namespace {
+
+bool parse_parameter(std::string_view inner, std::size_t& pos, Json& args,
+                     const std::string& tool_name, const ToolParamTypeMap& param_types) {
     constexpr std::string_view kParamOpen  = "<parameter=";
     constexpr std::string_view kParamClose = "</parameter>";
     if (!starts_with_at(inner, pos, kParamOpen)) { return false; }
@@ -76,13 +194,47 @@ bool parse_parameter(std::string_view inner, std::size_t& pos, Json& args) {
     const std::size_t value_end = inner.find(kParamClose, pos);
     if (value_end == std::string_view::npos) { return false; }
     const std::string raw_value = trim_ascii(inner.substr(pos, value_end - pos));
-    Json parsed                 = Json::parse(raw_value, nullptr, false);
-    args[key]                   = parsed.is_discarded() ? Json(raw_value) : parsed;
+    const std::vector<std::string>* declared = param_declared_types(param_types, tool_name, key);
+    const bool is_boolean =
+        declared != nullptr &&
+        std::find(declared->begin(), declared->end(), "boolean") != declared->end();
+    if (is_boolean) {
+        // Boolean-declared params: the model may emit Python-style scalars
+        // (True/False, 1/0) that are not valid JSON, so coerce the raw text
+        // instead of adopting a parsed value. The literal null is JSON null:
+        // a valid value for a nullable boolean, and the faithful reading of
+        // the token otherwise (matching the fallthrough for other nullable
+        // types). Any other value stays raw text for the client to validate.
+        // Both comparisons are case-insensitive, matching the model's
+        // Python-style emissions (True/TRUE, Null/NULL).
+        std::string lower;
+        lower.reserve(raw_value.size());
+        for (const char c : raw_value) {
+            lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+        }
+        if (std::optional<bool> coerced = coerce_boolean(lower)) {
+            args[key] = *coerced;
+        } else if (lower == "null") {
+            args[key] = nullptr;
+        } else {
+            args[key] = Json(raw_value);
+        }
+        pos = value_end + kParamClose.size();
+        return true;
+    }
+    // Only adopt the deserialized JSON type when the schema explicitly
+    // permits a non-string type. For string-typed, unknown, or absent
+    // params, keep the raw text so the model's value reaches the client
+    // with its type intact; the client owns the schema and validates.
+    Json parsed = Json::parse(raw_value, nullptr, false);
+    const bool can_deserialize = declared != nullptr;
+    args[key] = (parsed.is_discarded() || !can_deserialize) ? Json(raw_value) : parsed;
     pos                         = value_end + kParamClose.size();
     return true;
 }
 
-bool parse_one_tool_call(std::string_view block, std::size_t max_name_length, ToolCall& out) {
+bool parse_one_tool_call(std::string_view block, std::size_t max_name_length,
+                          const ToolParamTypeMap& param_types, ToolCall& out) {
     constexpr std::string_view kFunctionOpen  = "<function=";
     constexpr std::string_view kFunctionClose = "</function>";
     std::size_t pos                           = 0;
@@ -103,7 +255,9 @@ bool parse_one_tool_call(std::string_view block, std::size_t max_name_length, To
     for (;;) {
         skip_ws(params, param_pos);
         if (param_pos >= params.size()) { break; }
-        if (!parse_parameter(params, param_pos, args)) { return false; }
+        if (!parse_parameter(params, param_pos, args, name, param_types)) {
+            return false;
+        }
     }
 
     pos = function_end + kFunctionClose.size();
@@ -125,7 +279,8 @@ ParsedToolCallOutput fallback(const std::string& text) {
 } // namespace
 
 ParsedToolCallOutput parse_qwen_tool_call_output(const std::string& text,
-                                                 std::size_t max_tool_name_length) {
+                                                 std::size_t max_tool_name_length,
+                                                 const ToolParamTypeMap& param_types) {
     constexpr std::string_view kToolOpen  = "<tool_call>";
     constexpr std::string_view kToolClose = "</tool_call>";
 
@@ -145,7 +300,7 @@ ParsedToolCallOutput parse_qwen_tool_call_output(const std::string& text,
         if (close == std::string::npos) { return fallback(text); }
         ToolCall call;
         if (!parse_one_tool_call(std::string_view(text).substr(inner_begin, close - inner_begin),
-                                 max_tool_name_length, call)) {
+                                 max_tool_name_length, param_types, call)) {
             return fallback(text);
         }
         out.tool_calls.push_back(std::move(call));

--- a/src/serve/tool_call_parser.h
+++ b/src/serve/tool_call_parser.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace ninfer::serve {
@@ -15,8 +16,34 @@ struct ParsedToolCallOutput {
     std::vector<ToolCall> tool_calls;
 };
 
+// Per-tool parameter deserialization allow-list distilled from the request
+// ToolDefinition list. Outer key: tool name. Inner key: parameter name; the
+// inner value is the full set of declared non-string types, in schema order.
+// Only parameters whose JSON Schema "type" is a valid non-string type (or an
+// array of valid non-string types) are recorded. The parser deserializes
+// recorded parameters and, for sets containing "boolean", coerces
+// Python-style scalars (True/False, 1/0) to JSON booleans and the literal
+// null to JSON null. A parameter absent from the inner map (and a tool
+// absent from the outer map) has no schema permission to deserialize: the
+// parser preserves raw text and the client owns type interpretation.
+using ToolParamTypeMap =
+    std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::string>>>;
+
+// Distill the request ToolDefinition list into a per-tool parameter
+// deserialization allow-list. Each ToolDefinition::parameters_json is a JSON
+// Schema object; its "properties" object maps each parameter name to an
+// object whose "type" field (a string or an array of strings) declares the
+// schema type(s). A parameter is recorded only when every declared type is
+// one of the valid non-string JSON Schema types {integer, number, boolean,
+// array, object, null}; otherwise (string allowed, unknown/invalid type, or
+// absent "type") it is omitted so the parser preserves raw text. A tool
+// name seen again replaces its entry so a redefinition cannot leak stale
+// non-string permissions from a prior definition.
+ToolParamTypeMap build_tool_param_type_map(const std::vector<ToolDefinition>& tools);
+
 ParsedToolCallOutput parse_qwen_tool_call_output(const std::string& text,
-                                                 std::size_t max_tool_name_length);
+                                                 std::size_t max_tool_name_length,
+                                                 const ToolParamTypeMap& param_types);
 
 // Incrementally publishes text that is provably outside a possible Qwen
 // <tool_call> suffix. At terminal time, a valid tool response discards the

--- a/tests/test_anthropic_schema.cpp
+++ b/tests/test_anthropic_schema.cpp
@@ -417,6 +417,23 @@ int test_tools_and_choice() {
     return failures;
 }
 
+int test_duplicate_tool_name_rejected() {
+    int failures = 0;
+    const Json tool =
+        Json{{"name", "get_weather"},
+             {"input_schema", Json{{"type", "object"},
+                                   {"properties", Json{{"city", Json{{"type", "string"}}}}},
+                                   {"required", Json::array({"city"})}}}};
+    Json body = {
+        {"model", "m"},
+        {"max_tokens", 8},
+        {"tools", Json::array({tool, tool})},
+        {"messages", Json::array({Json{{"role", "user"}, {"content", "weather in Paris?"}}})}};
+    failures += check(throws_api([&] { (void)parse_messages_request(body, default_limits()); }),
+                      "duplicate tool names rejected");
+    return failures;
+}
+
 int test_tool_use_result_roundtrip() {
     int failures    = 0;
     const Json tool = Json{{"name", "get_weather"}, {"input_schema", Json{{"type", "object"}}}};
@@ -644,6 +661,31 @@ int test_response_serialization() {
     return failures;
 }
 
+// Regression: a string-typed tool argument (e.g. taskId="1") must survive the
+// Anthropic render path as a JSON string, not be coerced to a number. The
+// parser preserves the raw text into arguments_json; make_messages_response
+// forwards it verbatim into the tool_use.input object.
+int test_string_typed_argument_survives_render() {
+    int failures = 0;
+    const CompletionUsage usage{3, 1};
+    // arguments_json carries taskId as a string, exactly as the schema-aware
+    // parser emits it for a string-typed parameter with a numeric-looking value.
+    const std::vector<ToolCall> calls = {
+        ToolCall{"toolu_1", "TaskUpdate", R"({"taskId":"1"})"}};
+    const Json resp = Json::parse(
+        make_messages_response("msg_s", "claude-x", "", "", calls, "tool_use", usage));
+    const Json& content = resp.at("content");
+    failures += check(content.size() == 1 && content.at(0).at("type") == "tool_use",
+                      "render produced a single tool_use block");
+    const Json& input = content.at(0).at("input");
+    failures += check(input.at("taskId").is_string(),
+                      "string-typed taskId rendered as a JSON string, not a number");
+    failures += check(input.at("taskId") == "1", "string-typed taskId value preserved on the wire");
+    failures += check(!input.at("taskId").is_number(),
+                      "string-typed taskId is not a JSON number on the wire");
+    return failures;
+}
+
 int test_streaming_events() {
     int failures = 0;
     std::string type;
@@ -750,11 +792,13 @@ int main() {
     failures += test_missing_and_bad_fields();
     failures += test_parse_image();
     failures += test_tools_and_choice();
+    failures += test_duplicate_tool_name_rejected();
     failures += test_tool_use_result_roundtrip();
     failures += test_thinking_and_sampling();
     failures += test_reasoning_effort();
     failures += test_stop_reason_mapping();
     failures += test_response_serialization();
+    failures += test_string_typed_argument_survives_render();
     failures += test_streaming_events();
     failures += test_count_tokens_and_error();
     if (failures == 0) { std::cout << "ok\n"; }

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -437,6 +437,13 @@ int test_parse_function_tools_and_choices() {
     failures +=
         check(throws_api([&] { (void)parse_chat_completion_request(unknown, default_limits()); }),
               "unknown named tool_choice rejected");
+
+    // Duplicate function tool names are rejected (matches Responses behavior).
+    Json dup           = base;
+    dup["tools"]       = Json::array({tool, tool});
+    failures +=
+        check(throws_api([&] { (void)parse_chat_completion_request(dup, default_limits()); }),
+              "duplicate function tool names rejected");
     return failures;
 }
 

--- a/tests/test_responses_schema.cpp
+++ b/tests/test_responses_schema.cpp
@@ -349,6 +349,12 @@ int test_explicit_rejections() {
     failures += check(api_code([&] { (void)parse_responses_request(too_small, limits()); }) ==
                           "invalid_value",
                       "OpenAI minimum max_output_tokens enforced");
+
+    Json dup     = base;
+    dup["tools"] = Json::array({Json{{"type", "function"}, {"name", "f"}, {"parameters", Json::object()}, {"strict", false}},
+                                Json{{"type", "function"}, {"name", "f"}, {"parameters", Json::object()}, {"strict", false}}});
+    failures += check(throws_api([&] { (void)parse_responses_request(dup, limits()); }),
+                      "duplicate function tool names rejected");
     return failures;
 }
 

--- a/tests/test_tool_call_parser.cpp
+++ b/tests/test_tool_call_parser.cpp
@@ -1,9 +1,11 @@
 #include "serve/tool_call_parser.h"
+#include "serve/request.h"
 
 #include <nlohmann/json.hpp>
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -16,16 +18,31 @@ int fail(const std::string& message) {
 
 int check(bool condition, const std::string& message) { return condition ? 0 : fail(message); }
 
+// Build a ToolDefinition with the given name and a JSON Schema parameters
+// object string, so tests exercise the real build_tool_param_type_map path
+// rather than hand-fabricating the ToolParamTypeMap.
+ninfer::serve::ToolDefinition make_tool(const std::string& name, const std::string& schema_json) {
+    ninfer::serve::ToolDefinition tool;
+    tool.name            = name;
+    tool.parameters_json = schema_json;
+    return tool;
+}
+
 int test_single_call() {
+    // build_tool_param_type_map records only non-string types; city (string)
+    // and any unknown param are absent, so the parser preserves raw text.
+    ninfer::serve::ToolParamTypeMap map;
+    map["get_weather"]["days"] = {"integer"};
+
     const ninfer::serve::ParsedToolCallOutput parsed =
         ninfer::serve::parse_qwen_tool_call_output("Calling weather.\n"
-                                                   "<tool_call>\n"
+                                                   "   <tool_call>\n"
                                                    "<function=get_weather>\n"
                                                    "<parameter=city>\nParis\n</parameter>\n"
                                                    "<parameter=days>\n2\n</parameter>\n"
                                                    "</function>\n"
                                                    "</tool_call>",
-                                                   64);
+                                                   64, map);
 
     int failures = 0;
     failures += check(parsed.is_tool_call_response, "single call parsed as tool response");
@@ -35,11 +52,15 @@ int test_single_call() {
     failures += check(parsed.tool_calls[0].name == "get_weather", "function name parsed");
     const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
     failures += check(args.at("city") == "Paris", "string parameter parsed");
-    failures += check(args.at("days") == 2, "number parameter parsed");
+    failures += check(args.at("days") == 2, "integer-typed days deserialized to number");
     return failures;
 }
 
 int test_multiple_calls_and_json_values() {
+    // payload is object => recorded; value is string => absent.
+    ninfer::serve::ToolParamTypeMap map;
+    map["first"]["payload"]  = {"object"};
+
     const ninfer::serve::ParsedToolCallOutput parsed = ninfer::serve::parse_qwen_tool_call_output(
         "<tool_call>\n"
         "<function=first>\n"
@@ -51,7 +72,7 @@ int test_multiple_calls_and_json_values() {
         "<parameter=value>\nplain text\n</parameter>\n"
         "</function>\n"
         "</tool_call>",
-        64);
+        64, map);
 
     int failures = 0;
     failures += check(parsed.is_tool_call_response, "multiple calls parsed as tool response");
@@ -66,10 +87,57 @@ int test_multiple_calls_and_json_values() {
     return failures;
 }
 
-int test_malformed_falls_back_to_text() {
-    const std::string text = "<tool_call>\n<function=get_weather>\n";
+int test_string_param_keeps_numeric_looking_value() {
+    // priority is integer => recorded; taskId and status are string =>
+    // absent (exactly what build_tool_param_type_map produces). The tool
+    // is known, yet its string-typed params still preserve raw text.
+    ninfer::serve::ToolParamTypeMap map;
+    map["TaskUpdate"]["priority"] = {"integer"};
+
     const ninfer::serve::ParsedToolCallOutput parsed =
-        ninfer::serve::parse_qwen_tool_call_output(text, 64);
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=TaskUpdate>\n"
+            "<parameter=status>deleted</parameter>\n"
+            "<parameter=taskId>1</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "string-typed call parsed as tool response");
+    failures += check(parsed.tool_calls.size() == 1, "one parsed string-typed call");
+    failures += check(parsed.tool_calls[0].name == "TaskUpdate", "string-typed call name");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("status") == "deleted", "string status preserved");
+    failures += check(args.at("taskId").is_string(), "taskId is a string, not a number");
+    failures += check(args.at("taskId") == "1", "string-typed taskId keeps numeric-looking value");
+    return failures;
+}
+
+int test_unknown_param_defaults_to_string() {
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=adhoc>\n"
+            "<parameter=count>7</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, {});
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "unknown-schema call parsed as tool response");
+    failures += check(parsed.tool_calls.size() == 1, "one parsed unknown-schema call");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("count").is_string(), "unknown-schema count defaults to string");
+    failures += check(args.at("count") == "7", "unknown-schema count value preserved");
+    return failures;
+}
+
+int test_malformed_falls_back_to_text() {
+    const std::string text = "   <tool_call>\n<function=get_weather>\n";
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(text, 64, {});
     int failures = 0;
     failures += check(!parsed.is_tool_call_response, "malformed xml is not tool response");
     failures += check(parsed.content == text, "malformed xml preserved as text");
@@ -78,14 +146,14 @@ int test_malformed_falls_back_to_text() {
 }
 
 int test_suffix_after_tool_falls_back_to_text() {
-    const std::string text = "<tool_call>\n"
+    const std::string text = "   <tool_call>\n"
                              "<function=get_weather>\n"
                              "<parameter=city>\nParis\n</parameter>\n"
                              "</function>\n"
                              "</tool_call>\n"
                              "extra answer";
     const ninfer::serve::ParsedToolCallOutput parsed =
-        ninfer::serve::parse_qwen_tool_call_output(text, 64);
+        ninfer::serve::parse_qwen_tool_call_output(text, 64, {});
     int failures = 0;
     failures += check(!parsed.is_tool_call_response, "non-whitespace suffix falls back to text");
     failures += check(parsed.content == text, "suffix fallback preserves text");
@@ -94,16 +162,16 @@ int test_suffix_after_tool_falls_back_to_text() {
 
 int test_configured_name_limit() {
     const std::string name(128, 'a');
-    const std::string text = "<tool_call>\n<function=" + name + ">\n</function>\n</tool_call>";
+    const std::string text = "   <tool_call>\n<function=" + name + ">\n</function>\n</tool_call>";
 
     const ninfer::serve::ParsedToolCallOutput anthropic =
-        ninfer::serve::parse_qwen_tool_call_output(text, 128);
+        ninfer::serve::parse_qwen_tool_call_output(text, 128, {});
     const ninfer::serve::ParsedToolCallOutput openai =
-        ninfer::serve::parse_qwen_tool_call_output(text, 64);
+        ninfer::serve::parse_qwen_tool_call_output(text, 64, {});
     const std::string too_long_text =
-        "<tool_call>\n<function=" + std::string(129, 'a') + ">\n</function>\n</tool_call>";
+        "   <tool_call>\n<function=" + std::string(129, 'a') + ">\n</function>\n</tool_call>";
     const ninfer::serve::ParsedToolCallOutput too_long =
-        ninfer::serve::parse_qwen_tool_call_output(too_long_text, 128);
+        ninfer::serve::parse_qwen_tool_call_output(too_long_text, 128, {});
 
     int failures = 0;
     failures += check(anthropic.is_tool_call_response && anthropic.tool_calls.size() == 1 &&
@@ -151,17 +219,452 @@ int test_incremental_filter_fallback() {
     return failures;
 }
 
+// Schema-driven coverage: construct real ToolDefinition schemas and exercise
+// build_tool_param_type_map end-to-end instead of hand-fabricating the map.
+int test_schema_driven_type_map() {
+    // taskId is string; days is integer; count is nullable integer; note has a
+    // misspelled "strnig" type; flag is boolean; payload is object.
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "TaskUpdate",
+        R"({"type":"object","properties":{)"
+        R"("taskId":{"type":"string"},)"
+        R"("days":{"type":"integer"},)"
+        R"("count":{"type":["integer","null"]},)"
+        R"("note":{"type":"strnig"},)"
+        R"("flag":{"type":"boolean"},)"
+        R"("payload":{"type":"object"})"
+        R"(}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    int failures = 0;
+    failures += check(map.count("TaskUpdate") == 1, "tool recorded");
+    const auto& inner = map.at("TaskUpdate");
+    failures += check(inner.count("taskId") == 0, "string-typed taskId not recorded");
+    failures += check(inner.count("days") == 1, "integer-typed days recorded");
+    failures += check(inner.count("count") == 1, "nullable integer count recorded");
+    failures += check(inner.count("note") == 0, "misspelled strnig type not recorded");
+    failures += check(inner.count("flag") == 1, "boolean-typed flag recorded");
+    failures += check(inner.count("payload") == 1, "object-typed payload recorded");
+    return failures;
+}
+
+// (a) numeric-looking string param (taskId=1 -> "1" string).
+int test_schema_string_param_keeps_numeric_looking_value() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "TaskUpdate", R"({"type":"object","properties":{"taskId":{"type":"string"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=TaskUpdate>\n"
+            "<parameter=taskId>1</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "schema string call parsed as tool response");
+    failures += check(parsed.tool_calls.size() == 1, "one schema string call");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("taskId").is_string(), "schema taskId is a string, not a number");
+    failures += check(args.at("taskId") == "1", "schema string taskId keeps numeric-looking value");
+    return failures;
+}
+
+// (b) genuine integer (days=2 -> 2 number).
+int test_schema_integer_param_deserializes() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "get_weather", R"({"type":"object","properties":{"days":{"type":"integer"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=get_weather>\n"
+            "<parameter=days>2</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "schema integer call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("days").is_number(), "schema integer days is a number");
+    failures += check(args.at("days") == 2, "schema integer days deserialized to number 2");
+    return failures;
+}
+
+// (c) valid nullable integer (["integer","null"] count=7 -> 7 number).
+int test_schema_nullable_integer_deserializes() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "get_items", R"({"type":"object","properties":{"count":{"type":["integer","null"]}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=get_items>\n"
+            "<parameter=count>7</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "nullable integer call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("count").is_number(), "nullable count deserialized to number");
+    failures += check(args.at("count") == 7, "nullable count value 7 preserved as number");
+    return failures;
+}
+
+// ["string","null"] => string allowed => not recorded; 5 -> "5".
+int test_schema_nullable_string_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "get_opt", R"({"type":"object","properties":{"opt":{"type":["string","null"]}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=get_opt>\n"
+            "<parameter=opt>5</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "nullable string call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("opt").is_string(), "nullable string opt stays a string");
+    failures += check(args.at("opt") == "5", "nullable string opt value preserved as text");
+    return failures;
+}
+
+// ["integer","string"] => string allowed => not recorded; 9 -> "9".
+int test_schema_mixed_integer_string_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "mix", R"({"type":"object","properties":{"v":{"type":["integer","string"]}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=mix>\n"
+            "<parameter=v>9</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("v").is_string(), "mixed integer/string v stays a string");
+    failures += check(args.at("v") == "9", "mixed integer/string v value preserved as text");
+    return failures;
+}
+
+// (d) invalid type spelling ("strnig" -> raw text).
+int test_schema_invalid_type_spelling_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "bad", R"({"type":"object","properties":{"note":{"type":"strnig"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=bad>\n"
+            "<parameter=note>hi</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("note").is_string(), "invalid-type note stays a string");
+    failures += check(args.at("note") == "hi", "invalid-type note value preserved as text");
+    return failures;
+}
+
+// (d) boolean param: Python-style scalars coerce to JSON booleans
+// (vLLM qwen3coder coercion); non-boolean text stays raw.
+int test_schema_boolean_param_coerces_python_scalars() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "set_flags",
+        R"({"type":"object","properties":{)"
+        R"("a":{"type":"boolean"},"b":{"type":"boolean"},"c":{"type":"boolean"},)"
+        R"("d":{"type":"boolean"},"e":{"type":"boolean"},"f":{"type":"boolean"},)"
+        R"("g":{"type":"boolean"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "    <tool_call>\n"
+            "<function=set_flags>\n"
+            "<parameter=a>True</parameter>\n"
+            "<parameter=b>1</parameter>\n"
+            "<parameter=c>False</parameter>\n"
+            "<parameter=d>0</parameter>\n"
+            "<parameter=e>maybe</parameter>\n"
+            "<parameter=f>true</parameter>\n"
+            "<parameter=g> TRUE </parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "schema boolean call parsed as tool response");
+    failures += check(parsed.tool_calls.size() == 1, "one schema boolean call");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("a").is_boolean() && args.at("a") == true,
+                      "boolean param True coerces to true");
+    failures += check(args.at("b").is_boolean() && args.at("b") == true,
+                      "boolean param 1 coerces to true");
+    failures += check(args.at("c").is_boolean() && args.at("c") == false,
+                      "boolean param False coerces to false");
+    failures += check(args.at("d").is_boolean() && args.at("d") == false,
+                      "boolean param 0 coerces to false");
+    failures += check(args.at("e").is_string() && args.at("e") == "maybe",
+                      "non-boolean text for a boolean param stays raw");
+    failures += check(args.at("f").is_boolean() && args.at("f") == true,
+                      "JSON true for a boolean param still coerces");
+    failures += check(args.at("g").is_boolean() && args.at("g") == true,
+                      "padded all-caps TRUE coerces to true");
+    return failures;
+}
+
+// (g) nullable boolean: Python scalars coerce, the literal null is JSON
+// null, and the result does not depend on the type-array order.
+int test_schema_nullable_boolean_param() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "flags",
+        R"({"type":"object","properties":{)"
+        R"("a":{"type":["boolean","null"]},"b":{"type":["null","boolean"]},)"
+        R"("c":{"type":"boolean"},"d":{"type":["boolean","null"]},"e":{"type":["null","boolean"]},"f":{"type":["boolean","null"]}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "    <tool_call>\n"
+            "<function=flags>\n"
+            "<parameter=a>True</parameter>\n"
+            "<parameter=b>null</parameter>\n"
+            "<parameter=c>null</parameter>\n"
+            "<parameter=d>maybe</parameter>\n"
+            "<parameter=e>False</parameter>\n"
+            "<parameter=f>Null</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response, "nullable boolean call parsed as tool response");
+    failures += check(parsed.tool_calls.size() == 1, "one nullable boolean call");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("a").is_boolean() && args.at("a") == true,
+                      "nullable boolean True coerces to true");
+    failures += check(args.at("b").is_null(),
+                      "nullable boolean null is JSON null (null listed first)");
+    failures += check(args.at("c").is_null(),
+                      "plain boolean null is JSON null");
+    failures += check(args.at("d").is_string() && args.at("d") == "maybe",
+                      "non-boolean text for a nullable boolean stays raw");
+    failures += check(args.at("e").is_boolean() && args.at("e") == false,
+                      "nullable boolean False coerces to false (null listed first)");
+    failures += check(args.at("f").is_null(),
+                      "capitalized Null is JSON null (case-insensitive)");
+    return failures;
+}
+
+// (e) boolean true for a string param -> raw text "true".
+// (f) null for a string param -> raw text "null".
+int test_schema_string_param_bool_and_null_preserve_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "flaggy", R"({"type":"object","properties":{"s":{"type":"string"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=flaggy>\n"
+            "<parameter=s>true</parameter>\n"
+            "</function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=flaggy>\n"
+            "<parameter=s>null</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    failures += check(parsed.tool_calls.size() == 2, "two string-param calls parsed");
+    const Json a1 = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(a1.at("s").is_string(), "string param bool stays a string");
+    failures += check(a1.at("s") == "true", "string param bool value preserved as text");
+    const Json a2 = Json::parse(parsed.tool_calls[1].arguments_json);
+    failures += check(a2.at("s").is_string(), "string param null stays a string");
+    failures += check(a2.at("s") == "null", "string param null value preserved as text");
+    return failures;
+}
+
+// (g) object-looking text for a string param -> raw text.
+int test_schema_string_param_object_text_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "obj", R"({"type":"object","properties":{"s":{"type":"string"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "   <tool_call>\n"
+            "<function=obj>\n"
+            "<parameter=s>{\"k\":1}</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+
+    int failures = 0;
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("s").is_string(), "string param object text stays a string");
+    failures += check(args.at("s") == "{\"k\":1}", "string param object text preserved verbatim");
+    return failures;
+}
+
+// (h) empty type array ("type":[] -> raw text, no crash).
+int test_schema_empty_type_array_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "emptytype", R"({"type":"object","properties":{"n":{"type":[]}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    int failures = 0;
+    failures += check(map.at("emptytype").count("n") == 0,
+                      "empty type array leaves n unrecorded");
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "    <tool_call>\n"
+            "<function=emptytype>\n"
+            "<parameter=n>3</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+    failures += check(parsed.is_tool_call_response, "empty-array call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("n").is_string(), "empty type array n stays a string");
+    failures += check(args.at("n") == "3", "empty type array n value preserved as text");
+    return failures;
+}
+
+// (i) non-string non-array "type" (e.g. "type":5) preserves raw text.
+int test_schema_non_string_non_array_type_preserves_raw() {
+    const ninfer::serve::ToolDefinition tool = make_tool(
+        "numtype", R"({"type":"object","properties":{"n":{"type":5}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({tool});
+
+    int failures = 0;
+    failures += check(map.at("numtype").count("n") == 0,
+                      "non-string non-array type leaves n unrecorded");
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "    <tool_call>\n"
+            "<function=numtype>\n"
+            "<parameter=n>3</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+    failures += check(parsed.is_tool_call_response, "non-string-type call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("n").is_string(), "non-string-type n stays a string");
+    failures += check(args.at("n") == "3", "non-string-type n value preserved as text");
+    return failures;
+}
+
+// A second same-name definition whose object schema has no "properties"
+// must replace the first definition's recorded (integer) permissions,
+// leaving the param unrecorded (raw text) instead of leaking the first.
+int test_duplicate_tool_definition_no_properties_replaces() {
+    const ninfer::serve::ToolDefinition first = make_tool(
+        "dup2", R"({"type":"object","properties":{"count":{"type":"integer"}}})");
+    const ninfer::serve::ToolDefinition second = make_tool(
+        "dup2", R"({"type":"object"})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({first, second});
+
+    int failures = 0;
+    failures += check(map.count("dup2") == 1, "no-properties duplicate has one entry");
+    failures += check(map.at("dup2").count("count") == 0,
+                      "second no-properties definition replaced the first (count not recorded)");
+    const ninfer::serve::ParsedToolCallOutput parsed =
+        ninfer::serve::parse_qwen_tool_call_output(
+            "    <tool_call>\n"
+            "<function=dup2>\n"
+            "<parameter=count>3</parameter>\n"
+            "</function>\n"
+            "</tool_call>",
+            64, map);
+    failures += check(parsed.is_tool_call_response, "no-properties dup call parsed");
+    const Json args = Json::parse(parsed.tool_calls[0].arguments_json);
+    failures += check(args.at("count").is_string(), "no-properties dup count stays a string");
+    failures += check(args.at("count") == "3", "no-properties dup count value preserved as text");
+    return failures;
+}
+
+// A redefinition of the same tool name must replace the prior entry so a
+// second (string) definition cannot leak the first's integer permission.
+int test_duplicate_tool_definition_replaced() {
+    const ninfer::serve::ToolDefinition first = make_tool(
+        "dup", R"({"type":"object","properties":{"count":{"type":"integer"}}})");
+    const ninfer::serve::ToolDefinition second = make_tool(
+        "dup", R"({"type":"object","properties":{"count":{"type":"string"}}})");
+    const ninfer::serve::ToolParamTypeMap map =
+        ninfer::serve::build_tool_param_type_map({first, second});
+
+    int failures = 0;
+    failures += check(map.count("dup") == 1, "duplicate tool name has one entry");
+    failures += check(map.at("dup").count("count") == 0,
+                      "second (string) definition replaced the first (integer) entry");
+    return failures;
+}
+
 } // namespace
 
 int main() {
     int failures = 0;
     failures += test_single_call();
     failures += test_multiple_calls_and_json_values();
+    failures += test_string_param_keeps_numeric_looking_value();
+    failures += test_unknown_param_defaults_to_string();
     failures += test_malformed_falls_back_to_text();
     failures += test_suffix_after_tool_falls_back_to_text();
     failures += test_configured_name_limit();
     failures += test_incremental_filter_valid_tool();
     failures += test_incremental_filter_fallback();
+    failures += test_schema_driven_type_map();
+    failures += test_schema_string_param_keeps_numeric_looking_value();
+    failures += test_schema_integer_param_deserializes();
+    failures += test_schema_nullable_integer_deserializes();
+    failures += test_schema_nullable_string_preserves_raw();
+    failures += test_schema_boolean_param_coerces_python_scalars();
+    failures += test_schema_nullable_boolean_param();
+    failures += test_schema_mixed_integer_string_preserves_raw();
+    failures += test_schema_invalid_type_spelling_preserves_raw();
+    failures += test_schema_string_param_bool_and_null_preserve_raw();
+    failures += test_schema_string_param_object_text_preserves_raw();
+    failures += test_schema_empty_type_array_preserves_raw();
+    failures += test_schema_non_string_non_array_type_preserves_raw();
+    failures += test_duplicate_tool_definition_no_properties_replaces();
+    failures += test_duplicate_tool_definition_replaced();
     if (failures == 0) { std::cout << "ok\n"; }
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Problem

Two related defects in `parse_parameter` (`tool_call_parser.cpp`):

1. **Eager deserialization ignores the schema.** Any value that parses as JSON is deserialized into that JSON type, ignoring the tool schema:

```cpp
Json parsed = Json::parse(raw_value, nullptr, false);
args[key]   = parsed.is_discarded() ? Json(raw_value) : parsed;
```

A `"type":"string"` param with a numeric-looking value (`<parameter=taskId>1</parameter>`) ships as JSON number `1`, not `"1"`. Schema-validating clients reject it. Self-healing (the model retries with an un-coercible value), so it went unnoticed. Same class as [Qwen3-Coder discussion #21](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/discussions/21).

2. **No coercion for boolean-declared params.** The model emits Python-style scalars (`True`, `False`, `1`, `0`) for boolean params; these are not valid JSON, so they shipped as the raw strings `"True"` / `"1"`, which schema-validating clients reject.

## Design

Thread the schema (already populated on `ToolDefinition::parameters_json`, unused for output) to the parser.

- `ToolParamTypeMap`: `tool name -> param name -> declared type set`, built once per request in `prepare()`, carried on `PreparedRequest`. The inner value is the **full** declared type set (not just the first element), so nullable types like `["boolean","null"]` are handled independently of the type-array order.
- A param deserializes only when every declared `"type"` is a valid non-string JSON Schema type: `{integer, number, boolean, array, object, null}`. String-allowed, unknown, misspelled, or absent types preserve raw text. `"type"` may be a string or array; an empty array is uncertain.
- **Boolean-declared params** (the set contains `"boolean"`): Python-style scalars coerce to JSON booleans (`true`/`1` -> `true`, `false`/`0` -> `false`, case-insensitive, matching vLLM's qwen3coder coercion); the literal `null` is JSON `null` (a valid value for a nullable boolean); any other value stays raw text.
- `parse_parameter` inverts to allow-list membership; default is preserve.
- Duplicate tool names now rejected in `openai_schema.cpp`/`anthropic_schema.cpp` (responses already did) - prevents map shadowing.
- Top-level `"type"` only - not a JSON-Schema validator. Contract change documented in `docs/serving.md`.

## Affected behavior

- String-typed params with JSON-literal values now reach the client as strings.
- Numeric params still deserialize - common case unchanged.
- Boolean-declared params: `True`/`1` -> `true`, `False`/`0` -> `false`, `null` -> JSON `null` (nullable), other values preserved as raw text.
- Nullable types (`["boolean","null"]`, `["integer","null"]`) handled independently of type-array order.
- Absent/unknown-typed params preserved as strings (were deserialized if JSON-valid).
- Duplicate tool names now 400 on OpenAI and Anthropic endpoints.

## Verification

CPU-only, pass on the PR branch:

```
cmake --build build --target ninfer_tool_call_parser_test ninfer_serve_options_test \
  ninfer_anthropic_schema_test ninfer_openai_schema_test ninfer_responses_schema_test -j
# all 5 PASS
```

- `test_tool_call_parser.cpp`: schema-driven cases - `taskId:"1"` preserved, `days:2` deserialized, type arrays (`["string","number"]` preserved, `["integer","null"]` deserialized), empty/missing/misspelled preserved, redefinition leaks no stale permissions, duplicate names rejected, boolean coercion (`True`/`1`/`False`/`0`/`maybe`/`true`), nullable boolean (both type-array orders, `null` -> JSON null, capitalized `Null` -> JSON null).
- `test_anthropic_schema.cpp`: `taskId:"1"` survives `make_messages_response` to the wire as a JSON string.
- End-to-end (local Qwen 3.8 27B): Claude Code TaskUpdate/TaskGet with numeric `taskId` succeed first attempt (was: two rejections, then self-healing).

## AI disclosure

Implementation AI-assisted (Qwen 3.8 27B, local NInfer); the diff was code-reviewed and the contributor reviewed the full diff and ran the verification above.
