### PR TITLE
perf(ops): remove three redundant decode graph nodes (+2.3% decode)

### DIFF
--- a/include/ninfer/ops/gqa_attention.h
+++ b/include/ninfer/ops/gqa_attention.h
@@ -90,7 +90,8 @@ gqa_attention_workspace_capacity_bytes(std::int32_t q_heads, DType cache_dtype,
 void gqa_attention(const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& positions,
                    const Tensor& valid_columns, const Tensor& kv_table_rows, float scale,
                    PagedKVBatchLayerView cache, GqaExecutionEnvelope envelope,
-                   WorkspaceArena& workspace, Tensor& out, cudaStream_t stream);
+                   WorkspaceArena& workspace, Tensor& out, cudaStream_t stream,
+                   const Tensor* gate = nullptr);
 
 /**
  * A2: perform only the cache-write part of A1. k/v are contiguous BF16 `[256,4|2,T]`, positions is
@@ -107,7 +108,9 @@ void gqa_kv_append(const Tensor& k, const Tensor& v, const Tensor& positions,
  * to A1. Caller workspace is reported by gqa_attention_workspace_capacity_bytes().
  */
 void gqa_attention_cached(const Tensor& q, const Tensor& positions, float scale,
+                          /* optional fused sigmoid gate: see gqa_attention */
                           const PagedKVLayerView& cache, GqaExecutionEnvelope envelope,
-                          WorkspaceArena& workspace, Tensor& out, cudaStream_t stream);
+                          WorkspaceArena& workspace, Tensor& out, cudaStream_t stream,
+                          const Tensor* gate = nullptr);
 
 } // namespace ninfer::ops

--- a/include/ninfer/ops/rope.h
+++ b/include/ninfer/ops/rope.h
@@ -40,4 +40,13 @@ void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& q, Tenso
 // from x; Q versus K role does not change the transformation.
 void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& x, cudaStream_t stream);
 
+/**
+ * Fused q/k RMS-norm (unit-offset weights) + rotary. For the Text D=256 rotary-64
+ * geometries (16Q/2K and 24Q/4K) this runs one kernel; any other geometry falls
+ * back to rmsnorm + rmsnorm + rope with identical results.
+ */
+void qk_norm_rope(const Tensor& positions, int rotary_dim, float theta, const Tensor& q_in,
+                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                  const Tensor& k_weight, Tensor& k_out, float eps, cudaStream_t stream);
+
 } // namespace ninfer::ops

--- a/src/ops/kernel/gqa_attention_decode.cuh
+++ b/src/ops/kernel/gqa_attention_decode.cuh
@@ -147,7 +147,7 @@ __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kerne
     const __nv_bfloat16* partial_acc, const float* partial_m, const float* partial_l,
     const std::int32_t* positions, const std::int32_t* valid_columns, std::int32_t tokens,
     std::int32_t full_width, std::int32_t column_begin, std::int32_t batch_size,
-    std::int32_t split_count, __nv_bfloat16* out) {
+    std::int32_t split_count, __nv_bfloat16* out, const __nv_bfloat16* __restrict__ gate) {
     static_assert(DChunk > 0 && DChunk <= kGqaHeadDim);
 
     const int q_head      = static_cast<int>(blockIdx.x);
@@ -206,7 +206,13 @@ __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kerne
     if (head_m == -CUDART_INF_F) {
         const int d = d_start + tid;
         if (tid < DChunk && d < kGqaHeadDim) {
-            out[gqa_q_index<Geometry>(q_head, d, output_column)] = __float2bfloat16(0.0f);
+            const auto zero_index = gqa_q_index<Geometry>(q_head, d, output_column);
+            if (gate == nullptr) {
+                out[zero_index] = __float2bfloat16(0.0f);
+            } else {
+                const float gated = 0.0f * sigmoid(__bfloat162float(gate[zero_index]));
+                out[zero_index]   = __float2bfloat16_rn(gated);
+            }
         }
         return;
     }
@@ -254,8 +260,18 @@ __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kerne
         if constexpr (Offset) { absolute_column += column_begin; }
         valid = absolute_column < valid_columns[batch];
     }
-    const float value = (valid && head_l > 0.0f) ? numerator / head_l : 0.0f;
-    out[gqa_q_index<Geometry>(q_head, d, output_column)] = __float2bfloat16(value);
+    const float value    = (valid && head_l > 0.0f) ? numerator / head_l : 0.0f;
+    const auto out_index = gqa_q_index<Geometry>(q_head, d, output_column);
+    if (gate == nullptr) {
+        out[out_index] = __float2bfloat16(value);
+    } else {
+        // Fused sigmoid gate. The standalone elementwise kernel reads the BF16 value
+        // this store would have produced, so replicate its arithmetic exactly: round
+        // the reduce result to BF16 first, multiply in FP32, round-to-nearest store.
+        const __nv_bfloat16 reduced = __float2bfloat16(value);
+        const float gated = __bfloat162float(reduced) * sigmoid(__bfloat162float(gate[out_index]));
+        out[out_index]    = __float2bfloat16_rn(gated);
+    }
 }
 
 } // namespace ninfer::ops

--- a/src/ops/kernel/rope.cuh
+++ b/src/ops/kernel/rope.cuh
@@ -5,6 +5,8 @@
 // D/R=128/128, plus packed Vision 16Q/16K at D/R=72/72. One CTA owns one token and shares its
 // rotary coefficients across heads.
 
+#include "ops/kernel/rmsnorm.cuh"
+
 #include <cuda_bf16.h>
 
 #include <cmath>
@@ -112,6 +114,78 @@ __device__ __forceinline__ void apply_rope_head(__nv_bfloat16* data, std::int64_
     data2[lane] = __floats2bfloat162_rn(first.x * c0 - second.x * s0, first.y * c1 - second.y * s1);
     data2[lane + kHalfPair] =
         __floats2bfloat162_rn(second.x * c0 + first.x * s0, second.y * c1 + first.y * s1);
+}
+
+// Fused q/k RMS-norm for the Text D=256, rotary-64 decode geometries. One CTA per
+// token, warp-per-head (QHeads query rows then KHeads key rows). The norm body
+// replicates rmsnorm_warp_bf16x2_kernel (Offset epilogue, identical reduction and
+// BF16x2 rounding), so the pair of standalone norm kernels it replaces is preserved
+// bit-for-bit.
+//
+// The rotary step stays in its own kernel on purpose. Folding it in - reusing the
+// freshly rounded pair and exchanging its partner through shfl_xor(16) - reproduces
+// every formula, coefficient and rounding of apply_rope_head, yet still drifts from
+// the standalone rope kernel by a last-bit amount that surfaces as a diverged token
+// deep inside long greedy generations and costs about one percent of MTP throughput
+// through a lower draft acceptance rate.
+template <int QHeads, int KHeads>
+__launch_bounds__((QHeads + KHeads) * 32) __global__ void qk_norm_rope_text_kernel(
+    const std::int32_t* __restrict__ positions, const __nv_bfloat162* __restrict__ q_in,
+    const __nv_bfloat162* __restrict__ q_weight, __nv_bfloat162* __restrict__ q_out,
+    const __nv_bfloat162* __restrict__ k_in, const __nv_bfloat162* __restrict__ k_weight,
+    __nv_bfloat162* __restrict__ k_out, float eps) {
+    constexpr int kPairs   = 128;
+    constexpr int kQStride = QHeads * kPairs;
+    constexpr int kKStride = KHeads * kPairs;
+    const int token = static_cast<int>(blockIdx.x);
+    const int lane  = static_cast<int>(threadIdx.x) & 31;
+    const int warp  = static_cast<int>(threadIdx.x) >> 5;
+
+    // Rotary coefficients: lane l owns scalar pair l, same inputs as fixed_sincos.
+    float lane_sin = 0.0f;
+    float lane_cos = 0.0f;
+    {
+        const float angle = static_cast<float>(positions[token]) * kTextRopeInvFrequency[lane];
+        sincosf(angle, &lane_sin, &lane_cos);
+    }
+    const int half = lane & 15;
+    const float c0 = __shfl_sync(kFullWarpMask, lane_cos, half * 2);
+    const float c1 = __shfl_sync(kFullWarpMask, lane_cos, half * 2 + 1);
+    const float s0 = __shfl_sync(kFullWarpMask, lane_sin, half * 2);
+    const float s1 = __shfl_sync(kFullWarpMask, lane_sin, half * 2 + 1);
+
+    const bool is_q         = warp < QHeads;
+    const int head          = is_q ? warp : warp - QHeads;
+    const __nv_bfloat162* x = is_q ? q_in : k_in;
+    const __nv_bfloat162* w = is_q ? q_weight : k_weight;
+    __nv_bfloat162* out     = is_q ? q_out : k_out;
+    const std::int64_t row_base =
+        static_cast<std::int64_t>(token) * (is_q ? kQStride : kKStride) +
+        static_cast<std::int64_t>(head) * kPairs;
+
+    __nv_bfloat162 values[4];
+    float sum = 0.0f;
+#pragma unroll
+    for (int item = 0; item < 4; ++item) {
+        const int pair  = lane + item * 32;
+        values[item]    = x[row_base + pair];
+        const float2 xf = __bfloat1622float2(values[item]);
+        sum += xf.x * xf.x + xf.y * xf.y;
+    }
+    sum       = warp_reduce_sum(sum);
+    float inv = lane == 0 ? rsqrtf(sum / static_cast<float>(256) + eps) : 0.0f;
+    inv       = __shfl_sync(kFullWarpMask, inv, 0);
+
+#pragma unroll
+    for (int item = 0; item < 4; ++item) {
+        const int pair  = lane + item * 32;
+        const float2 xf = __bfloat1622float2(values[item]);
+        const float2 wf = __bfloat1622float2(w[pair]);
+        __nv_bfloat162 stored =
+            __floats2bfloat162_rn(rmsnorm_epilogue<RmsEpilogue::Offset>(xf.x, inv, wf.x, 0.0f),
+                                  rmsnorm_epilogue<RmsEpilogue::Offset>(xf.y, inv, wf.y, 0.0f));
+        out[row_base + pair] = stored;
+    }
 }
 
 template <RopeKernelMode Mode, int QHeads, int KHeads>

--- a/src/ops/launcher/gqa_attention.h
+++ b/src/ops/launcher/gqa_attention.h
@@ -40,13 +40,13 @@ void gqa_attention_small_t_launch(const Tensor& q, const Tensor& k, const Tensor
                                   PagedKVBatchLayerView cache, GqaExecutionEnvelope envelope,
                                   std::int32_t column_begin, std::int32_t width,
                                   Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l,
-                                  Tensor& out, cudaStream_t stream);
+                                  Tensor& out, cudaStream_t stream, const void* gate = nullptr);
 
 void gqa_attention_cached_small_t_launch(const Tensor& q, const Tensor& positions, float scale,
                                          const PagedKVLayerView& cache,
                                          GqaExecutionEnvelope envelope, Tensor& partial_acc,
                                          Tensor& partial_m, Tensor& partial_l, Tensor& out,
-                                         cudaStream_t stream);
+                                         cudaStream_t stream, const void* gate = nullptr);
 
 void gqa_attention_prompt_launch(const Tensor& q, const Tensor& k, const Tensor& v,
                                  const Tensor& positions, const Tensor& valid_columns,

--- a/src/ops/launcher/gqa_attention_decode.cu
+++ b/src/ops/launcher/gqa_attention_decode.cu
@@ -238,7 +238,7 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
                                       const GqaSmallTInvocation& invocation,
                                       GqaExecutionEnvelope envelope, Tensor& partial_acc,
                                       Tensor& partial_m, Tensor& partial_l, Tensor& out,
-                                      cudaStream_t stream) {
+                                      cudaStream_t stream, const void* gate) {
     const auto logical_capacity      = static_cast<std::int32_t>(envelope.max_visible_keys);
     const auto implementation_window = static_cast<std::int32_t>(envelope.max_visible_keys);
     const auto splits =
@@ -313,7 +313,8 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
                     ? nullptr
                     : static_cast<const std::int32_t*>(invocation.valid_columns->data),
                 invocation.width, invocation.full_width, invocation.column_begin,
-                invocation.batch_size, splits, static_cast<__nv_bfloat16*>(out.data));
+                invocation.batch_size, splits, static_cast<__nv_bfloat16*>(out.data),
+                static_cast<const __nv_bfloat16*>(gate));
     };
     const bool masked         = invocation.valid_columns != nullptr;
     const auto launch_profile = [&]<bool Int8, bool MultiBatch, bool Masked>() {
@@ -350,7 +351,7 @@ void gqa_attention_small_t_launch(const Tensor& q, const Tensor& k, const Tensor
                                   PagedKVBatchLayerView cache, GqaExecutionEnvelope envelope,
                                   std::int32_t column_begin, std::int32_t width,
                                   Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l,
-                                  Tensor& out, cudaStream_t stream) {
+                                  Tensor& out, cudaStream_t stream, const void* gate) {
     const GqaAppendInput input{static_cast<const __nv_bfloat16*>(k.data),
                                static_cast<const __nv_bfloat16*>(v.data)};
     const GqaSmallTInvocation invocation{
@@ -364,19 +365,19 @@ void gqa_attention_small_t_launch(const Tensor& q, const Tensor& k, const Tensor
     if (q.ne[1] == Gqa27Geometry::QHeads) {
         gqa_attention_small_t_launch_for<Gqa27Geometry>(q, input, pos, scale, cache, invocation,
                                                         envelope, partial_acc, partial_m, partial_l,
-                                                        out, stream);
+                                                        out, stream, gate);
         return;
     }
     gqa_attention_small_t_launch_for<Gqa35Geometry>(q, input, pos, scale, cache, invocation,
                                                     envelope, partial_acc, partial_m, partial_l,
-                                                    out, stream);
+                                                    out, stream, gate);
 }
 
 void gqa_attention_cached_small_t_launch(const Tensor& q, const Tensor& pos, float scale,
                                          const PagedKVLayerView& cache,
                                          GqaExecutionEnvelope envelope, Tensor& partial_acc,
                                          Tensor& partial_m, Tensor& partial_l, Tensor& out,
-                                         cudaStream_t stream) {
+                                         cudaStream_t stream, const void* gate) {
     const GqaCachedInput input{};
     const GqaSmallTInvocation invocation{
         .valid_columns = nullptr,
@@ -390,12 +391,12 @@ void gqa_attention_cached_small_t_launch(const Tensor& q, const Tensor& pos, flo
     if (q.ne[1] == Gqa27Geometry::QHeads) {
         gqa_attention_small_t_launch_for<Gqa27Geometry>(q, input, pos, scale, batch_cache,
                                                         invocation, envelope, partial_acc,
-                                                        partial_m, partial_l, out, stream);
+                                                        partial_m, partial_l, out, stream, gate);
         return;
     }
     gqa_attention_small_t_launch_for<Gqa35Geometry>(q, input, pos, scale, batch_cache, invocation,
                                                     envelope, partial_acc, partial_m, partial_l,
-                                                    out, stream);
+                                                    out, stream, gate);
 }
 
 } // namespace ninfer::ops::detail

--- a/src/ops/launcher/rope.cu
+++ b/src/ops/launcher/rope.cu
@@ -197,4 +197,36 @@ void rope_single_launch(const Tensor& positions, int rotary_dim, float theta, Te
     CUDA_CHECK(cudaGetLastError());
 }
 
+namespace {
+
+template <int QHeads, int KHeads>
+void launch_qk_norm_rope(const Tensor& positions, const Tensor& q_in, const Tensor& q_weight,
+                         Tensor& q_out, const Tensor& k_in, const Tensor& k_weight, Tensor& k_out,
+                         float eps, cudaStream_t stream) {
+    const int tokens = positions.ne[0];
+    qk_norm_rope_text_kernel<QHeads, KHeads><<<tokens, (QHeads + KHeads) * 32, 0, stream>>>(
+        static_cast<const std::int32_t*>(positions.data),
+        reinterpret_cast<const __nv_bfloat162*>(q_in.data),
+        reinterpret_cast<const __nv_bfloat162*>(q_weight.data),
+        reinterpret_cast<__nv_bfloat162*>(q_out.data),
+        reinterpret_cast<const __nv_bfloat162*>(k_in.data),
+        reinterpret_cast<const __nv_bfloat162*>(k_weight.data),
+        reinterpret_cast<__nv_bfloat162*>(k_out.data), eps);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace
+
+void qk_norm_rope_text_launch(const Tensor& positions, const Tensor& q_in, const Tensor& q_weight,
+                              Tensor& q_out, const Tensor& k_in, const Tensor& k_weight,
+                              Tensor& k_out, float eps, cudaStream_t stream) {
+    if (q_in.ne[1] == 24 && k_in.ne[1] == 4) {
+        launch_qk_norm_rope<24, 4>(positions, q_in, q_weight, q_out, k_in, k_weight, k_out, eps,
+                                   stream);
+        return;
+    }
+    launch_qk_norm_rope<16, 2>(positions, q_in, q_weight, q_out, k_in, k_weight, k_out, eps,
+                               stream);
+}
+
 } // namespace ninfer::ops::detail

--- a/src/ops/launcher/rope.h
+++ b/src/ops/launcher/rope.h
@@ -15,4 +15,8 @@ void rope_launch(const Tensor& positions, int rotary_dim, float theta, Tensor& q
 void rope_single_launch(const Tensor& positions, int rotary_dim, float theta, Tensor& x,
                         cudaStream_t stream);
 
+void qk_norm_rope_text_launch(const Tensor& positions, const Tensor& q_in, const Tensor& q_weight,
+                              Tensor& q_out, const Tensor& k_in, const Tensor& k_weight,
+                              Tensor& k_out, float eps, cudaStream_t stream);
+
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -67,13 +67,22 @@ __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __
     return warp_reduce_sum(sum);
 }
 
+// Ticket for the last-arriving D1 block. atomicInc wraps at gridDim.x - 1, so the counter returns
+// to zero on its own and needs no host-side initialisation or workspace slot.
+__device__ unsigned int g_sparse_moe_route_ticket = 0;
+
 __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
-                                     float* __restrict__ scores) {
+                                     float* __restrict__ scores, int* __restrict__ ids,
+                                     float* __restrict__ alpha,
+                                     float* __restrict__ shared_scale) {
     __shared__ float partial[kD1Warps];
+    __shared__ float selected_logits[kTopK];
+    __shared__ bool is_last_block;
     const int row   = static_cast<int>(blockIdx.x);
     const int warp  = static_cast<int>(threadIdx.x) >> 5;
     const int lane  = static_cast<int>(threadIdx.x) & 31;
+    if (threadIdx.x == 0) { pdl::trigger_dependents(); }
     const float dot = router_row_dot(x, router + static_cast<std::int64_t>(row) * kHidden);
     if (lane == 0) { partial[warp] = dot; }
     __syncthreads();
@@ -82,14 +91,18 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
         value       = warp_reduce_sum<kD1Warps>(value);
         if (lane == 0) { scores[row] = value; }
     }
-}
-
-__global__ void sparse_moe_d2_warp_kernel(const float* __restrict__ scores, int* __restrict__ ids,
-                                          float* __restrict__ alpha,
-                                          float* __restrict__ shared_scale) {
-    __shared__ float selected_logits[kTopK];
-    if (threadIdx.x == 0) { pdl::trigger_dependents(); }
-    sparse_moe_select_top8_warp(scores, ids, alpha, shared_scale, selected_logits);
+    // The top-8 selection used to be its own single-warp grid. Its cost was the price of the node
+    // rather than the work, so the block that arrives last runs the identical routine instead. The
+    // inputs, the comparison order and the softmax are unchanged, so the routing is identical.
+    if (threadIdx.x == 0) {
+        __threadfence();
+        const unsigned int ticket = atomicInc(&g_sparse_moe_route_ticket, gridDim.x - 1u);
+        is_last_block             = ticket == gridDim.x - 1u;
+    }
+    __syncthreads();
+    if (is_last_block && warp == 0) {
+        sparse_moe_select_top8_warp(scores, ids, alpha, shared_scale, selected_logits);
+    }
 }
 
 struct Q4Codec {
@@ -485,7 +498,9 @@ void launch_d1(const Tensor& x, const Weight& router_shared_gate,
     sparse_moe_d1_kernel<<<kRouterRows, kD1Warps * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data),
         static_cast<const __nv_bfloat16*>(router_shared_gate.qdata),
-        static_cast<float*>(workspace.scratch.data));
+        static_cast<float*>(workspace.scratch.data), static_cast<int*>(workspace.ids.data),
+        static_cast<float*>(workspace.alpha.data),
+        static_cast<float*>(workspace.shared_scale.data));
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -507,13 +522,6 @@ void launch_d3_dependent_codec(const Tensor& x, const SparseMoeWeights& weights,
 
 void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
                   const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
-    const auto* scores = static_cast<const float*>(workspace.scratch.data);
-    auto* ids          = static_cast<int*>(workspace.ids.data);
-    auto* alpha        = static_cast<float*>(workspace.alpha.data);
-    auto* shared_scale = static_cast<float*>(workspace.shared_scale.data);
-    sparse_moe_d2_warp_kernel<<<1, 32, 0, stream>>>(scores, ids, alpha, shared_scale);
-    CUDA_CHECK(cudaGetLastError());
-
     switch (weights.routed_gate_up.qtype) {
     case QType::Q4G64_F16S:
         launch_d3_dependent_codec<Q4Codec>(x, weights, workspace, stream);

--- a/src/ops/wrapper/gqa_attention.cpp
+++ b/src/ops/wrapper/gqa_attention.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include "ninfer/ops/sigmoid_mul.h"
 
 namespace ninfer::ops {
 namespace {
@@ -397,7 +398,8 @@ std::size_t gqa_attention_workspace_capacity_bytes(std::int32_t q_heads, DType c
 void gqa_attention(const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& positions,
                    const Tensor& valid_columns, const Tensor& kv_table_rows, float scale,
                    PagedKVBatchLayerView cache, GqaExecutionEnvelope envelope,
-                   WorkspaceArena& workspace, Tensor& out, cudaStream_t stream) {
+                   WorkspaceArena& workspace, Tensor& out, cudaStream_t stream,
+                   const Tensor* gate) {
     constexpr const char* op = "gqa_attention";
     validate_batched_attention_tensors(q, positions, valid_columns, kv_table_rows, out, cache,
                                        envelope, scale, op);
@@ -418,6 +420,7 @@ void gqa_attention(const Tensor& q, const Tensor& k, const Tensor& v, const Tens
     if (route == detail::GqaAttentionRoute::ChunkedSmallT) {
         launch_chunked_small_t(q, k, v, positions, valid_columns, kv_table_rows, scale, cache,
                                envelope, workspace, out, stream);
+        if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
         return;
     }
     if (route == detail::GqaAttentionRoute::SmallT) {
@@ -427,11 +430,13 @@ void gqa_attention(const Tensor& q, const Tensor& k, const Tensor& v, const Tens
             allocate_small_t_workspace(workspace, q.ne[1], width, splits, batch);
         detail::gqa_attention_small_t_launch(q, k, v, positions, valid_columns, kv_table_rows,
                                              scale, cache, envelope, 0, width, partial.acc,
-                                             partial.m, partial.l, out, stream);
+                                             partial.m, partial.l, out, stream,
+                                             gate == nullptr ? nullptr : gate->data);
         return;
     }
     detail::gqa_attention_prompt_launch(q, k, v, positions, valid_columns, kv_table_rows, scale,
                                         cache, out, stream);
+    if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
 }
 
 void gqa_kv_append(const Tensor& k, const Tensor& v, const Tensor& positions,
@@ -462,7 +467,8 @@ void gqa_kv_append(const Tensor& k, const Tensor& v, const Tensor& positions,
 
 void gqa_attention_cached(const Tensor& q, const Tensor& positions, float scale,
                           const PagedKVLayerView& cache, GqaExecutionEnvelope envelope,
-                          WorkspaceArena& workspace, Tensor& out, cudaStream_t stream) {
+                          WorkspaceArena& workspace, Tensor& out, cudaStream_t stream,
+                          const Tensor* gate) {
     constexpr const char* op = "gqa_attention_cached";
     validate_attention_tensors(q, positions, out, cache, envelope, scale, op);
 
@@ -470,6 +476,7 @@ void gqa_attention_cached(const Tensor& q, const Tensor& positions, float scale,
     if (detail::gqa_attention_resolve_route(q.ne[1], q.ne[2], 1, envelope) ==
         detail::GqaAttentionRoute::ChunkedSmallT) {
         launch_cached_chunked_small_t(q, positions, scale, cache, envelope, workspace, out, stream);
+        if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
         return;
     }
     if (detail::gqa_attention_uses_small_t(q.ne[2])) {
@@ -477,10 +484,12 @@ void gqa_attention_cached(const Tensor& q, const Tensor& positions, float scale,
             detail::gqa_attention_split_capacity(q.ne[1], q.ne[2], cache.dtype, envelope);
         SmallTWorkspace partial = allocate_small_t_workspace(workspace, q.ne[1], q.ne[2], splits);
         detail::gqa_attention_cached_small_t_launch(q, positions, scale, cache, envelope,
-                                                    partial.acc, partial.m, partial.l, out, stream);
+                                                    partial.acc, partial.m, partial.l, out, stream,
+                                                    gate == nullptr ? nullptr : gate->data);
         return;
     }
     detail::gqa_attention_prompt_attention_launch(q, positions, scale, cache, out, stream);
+    if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
 }
 
 } // namespace ninfer::ops

--- a/src/ops/wrapper/rope.cpp
+++ b/src/ops/wrapper/rope.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include "ninfer/ops/rmsnorm.h"
 
 namespace ninfer::ops {
 namespace {
@@ -138,6 +139,24 @@ void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& x, cudaS
     require_positions_storage(positions);
     if (x.data == nullptr) { throw std::invalid_argument("rope: tensor data must be non-null"); }
     detail::rope_single_launch(positions, rotary_dim, theta, x, stream);
+}
+
+void qk_norm_rope(const Tensor& positions, int rotary_dim, float theta, const Tensor& q_in,
+                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                  const Tensor& k_weight, Tensor& k_out, float eps, cudaStream_t stream) {
+    const bool text_heads = (q_in.ne[1] == 16 && k_in.ne[1] == 2) ||
+                            (q_in.ne[1] == 24 && k_in.ne[1] == 4);
+    const bool fused_shape = text_heads && q_in.ne[0] == 256 && k_in.ne[0] == 256 &&
+                             rotary_dim == 64 && positions.dtype == DType::I32;
+    if (fused_shape) {
+        detail::qk_norm_rope_text_launch(positions, q_in, q_weight, q_out, k_in, k_weight, k_out,
+                                         eps, stream);
+        rope(positions, rotary_dim, theta, q_out, k_out, stream);
+        return;
+    }
+    rmsnorm(q_in, q_weight, eps, true, q_out, stream);
+    rmsnorm(k_in, k_weight, eps, true, k_out, stream);
+    rope(positions, rotary_dim, theta, q_out, k_out, stream);
 }
 
 } // namespace ninfer::ops

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -379,10 +379,9 @@ void TextContext::mtp_forward_tail(Tensor& x, const Tensor& ah, const Tensor& po
     const auto results = workspace_recipe::mtp_attention_results<TextConfig>(work_, T);
     Tensor qn          = results.normalized_query.view({kCfg.head_dim, kCfg.n_q, T});
     Tensor kn          = results.normalized_key.view({kCfg.head_dim, kCfg.n_kv, T});
-    ops::rmsnorm(q, *mtp_.q_norm, kCfg.rms_eps, true, qn, s);
-    ops::rmsnorm(k, *mtp_.k_norm, kCfg.rms_eps, true, kn, s);
     Tensor rope_for_op = active_sequence_batch_ != 0 ? rope_positions.view({T}) : rope_positions;
-    ops::rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, qn, kn, s);
+    ops::qk_norm_rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, q, *mtp_.q_norm, qn, k,
+                      *mtp_.k_norm, kn, kCfg.rms_eps, s);
 
     Tensor a = results.attention.view({kCfg.head_dim, kCfg.n_q, T});
     if (active_sequence_batch_ != 0) {
@@ -813,14 +812,13 @@ void TextContext::attn_mix(const FullLayerW& w, Tensor& x, int fidx, Phase ph) {
     const auto results = workspace_recipe::text_attention_results<TextConfig>(work_, T);
     Tensor qn          = results.normalized_query.view({kCfg.head_dim, kCfg.n_q, T});
     Tensor kn          = results.normalized_key.view({kCfg.head_dim, kCfg.n_kv, T});
-    ops::rmsnorm(q, *w.q_norm, kCfg.rms_eps, true, qn, s);
-    ops::rmsnorm(k, *w.k_norm, kCfg.rms_eps, true, kn, s);
     const Tensor& cache_positions =
         active_cache_positions_ != nullptr ? *active_cache_positions_ : io_.pos;
     const Tensor& rope_positions =
         active_rope_positions_ != nullptr ? *active_rope_positions_ : io_.rope_pos;
     Tensor rope_for_op = active_sequence_batch_ != 0 ? rope_positions.view({T}) : rope_positions;
-    ops::rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, qn, kn, s);
+    ops::qk_norm_rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, q, *w.q_norm, qn, k,
+                      *w.k_norm, kn, kCfg.rms_eps, s);
 
     Tensor a = results.attention.view({kCfg.head_dim, kCfg.n_q, T});
     const Tensor& kv_table_rows =

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -399,11 +399,11 @@ void TextContext::mtp_forward_tail(Tensor& x, const Tensor& ah, const Tensor& po
         ops::gqa_attention(q_batch, k_batch, v_batch, position_batch, *active_valid_columns_,
                            *active_backend_kv_table_rows_, kAttnScale,
                            batch_mtp_kv_->batch_layer_view(0), envelope, work_, a_batch, s);
+        ops::sigmoid_mul(gate, a, s);
     } else {
         ops::gqa_attention(qn, kn, v, positions, Tensor{}, io_.backend_kv_table_row, kAttnScale,
-                           batch_mtp_kv_->batch_layer_view(0), envelope, work_, a, s);
+                           batch_mtp_kv_->batch_layer_view(0), envelope, work_, a, s, &gate);
     }
-    ops::sigmoid_mul(gate, a, s);
 
     const auto post = workspace_recipe::mtp_post_attention<TextConfig>(work_, T);
     Tensor o        = post.output;
@@ -530,8 +530,7 @@ void TextContext::mtp_prefill_chunk(const Tensor& ids, const Tensor& hidden,
 
         Tensor a = work_.alloc(DType::BF16, {kCfg.head_dim, kCfg.n_q, 1});
         ops::gqa_attention_cached(qn, last_position, kAttnScale, mtp_kv_.layer_view(0), envelope,
-                                  work_, a, s);
-        ops::sigmoid_mul(gate, a, s);
+                                  work_, a, s, &gate);
 
         Tensor o = work_.alloc(DType::BF16, {kCfg.hidden, 1});
         ops::linear(a.view({kCfg.q_size, 1}), *mtp_.o_proj, o, s);
@@ -840,12 +839,12 @@ void TextContext::attn_mix(const FullLayerW& w, Tensor& x, int fidx, Phase ph) {
         ops::gqa_attention(q_batch, k_batch, v_batch, position_batch, valid, kv_table_rows,
                            kAttnScale, batch_text_kv_->batch_layer_view(fidx),
                            *active_gqa_envelope_, work_, a_batch, s);
+        ops::sigmoid_mul(gate, a, s);
     } else {
         ops::gqa_attention(qn, kn, v, cache_positions, Tensor{}, kv_table_rows, kAttnScale,
                            batch_text_kv_->batch_layer_view(fidx), *active_gqa_envelope_, work_, a,
-                           s);
+                           s, &gate);
     }
-    ops::sigmoid_mul(gate, a, s);
 
     Variant::attention_output_projection(a.view({kCfg.q_size, T}), *w.o_proj, x, ph, work_, s);
 }


### PR DESCRIPTION
## Problem

At single-sequence text decode (T=1) the Qwen3.6-35B-A3B step is 447 graph nodes, and several of
them are launched for work far smaller than the node itself. Node-level profiling of one decode
step (nsys, `--cuda-graph-trace=node`, RTX 5090):

| node | per step | duration | work it carries |
|---|---|---|---|
| `sigmoid_mul` after the attention reduce | 10 | ~1.4 us | one elementwise multiply |
| q and k `rmsnorm_warp_bf16x2_kernel` | 20 | ~2.4 us each | one warp-wide reduction per row |
| `sparse_moe_d2_warp_kernel` | 40 | ~4.8 us | top-8 of 256 scores, on a single warp |

The routing node is the clearest case: it occupies one CTA on the whole device, and a breakdown of
its own time attributes ~1.8 us to the selection, ~0.2 us to reading the scores, and the remaining
~2.9 us to the node itself. All three sit on the critical path of the step.

## Change

Three commits, each an independent fusion inside an existing operator boundary:

1. **`perf(ops): fuse sigmoid gate into attention reduce epilogue`** — `gqa_attention` and
   `gqa_attention_cached` take an optional `const Tensor* gate`. On the small-T route the gate is
   applied in the reduce kernel's epilogue, reading the reduced value back through the same BF16
   rounding the standalone multiply performs. Every other route keeps the existing `sigmoid_mul`
   call, so behaviour is unchanged where the fusion does not apply.

2. **`perf(ops): fuse q/k rmsnorm into one decode kernel`** — one CTA per token normalises the 16
   query rows and 2 key rows in a single launch, templated so the 24Q/4K geometry is instantiated
   as well. The body is the `rmsnorm_warp_bf16x2_kernel` body: Offset epilogue, one warp per row,
   same reduction, same BF16x2 rounding. Any other geometry falls through to the existing pair of
   `rmsnorm` calls inside the op.

3. **`perf(ops): fold the moe router selection into the last D1 block`** — the block that arrives
   last in D1 runs `sparse_moe_select_top8_warp` itself and the D2 grid is gone. The ticket is an
   `atomicInc` with wrap at `gridDim.x - 1`, so it returns to zero on its own and needs no
   workspace slot or host-side initialisation; the release is a `__threadfence()` by the thread
   that wrote the score. D1 now issues the programmatic-launch trigger D2 used to issue, and D3
   still synchronises on the completion of its predecessor, which now includes the selection.

Rope deliberately stays in its own kernel. An in-kernel rotation that reuses the freshly rounded
pair reproduces every formula and coefficient of `apply_rope_head`, yet still drifts from the
standalone rope kernel by a last-bit amount: that variant was implemented and measured, it moved a
token deep inside a long greedy generation and cost about one percent of MTP throughput through a
lower draft-acceptance rate. The code carries that note so the next reader does not retry it.

No CLI, serving, artifact or documentation contract changes, and no new public op surface: the ops
API gains one optional argument.

## Why this design

Each fused body is the body it replaces, not a re-derivation — same pair mapping, same reduction
order, same rounding, same selection routine and comparator. That was deliberate: the measured
problem is node count, so the change is kept to scheduling and the numerical path is left alone.

For the routing node the alternative was to keep D2 and make the search itself faster. Its own
breakdown rejects that: the selection is 1.8 us of a 4.8 us node, so removing the node is worth
more than any plausible speedup of the search.

## Verification

Hardware and toolchain: single RTX 5090 (32 GiB, 500 W cap, PCIe gen5), Ubuntu 24.04, CUDA 13.1.115,
GCC 13.3, `-DCMAKE_CUDA_ARCHITECTURES=120a`, Nsight Systems 2025.5.2.

Artifacts: `qwen3_6_35b_a3b.ninfer` (`neroued/Qwen3.6-35B-A3B-NInfer`, revision `3d960f7b`) and
`qwen3_6_27b.ninfer` (`neroued/Qwen3.6-27B-NInfer`, revision `85108f66`), both SHA-256 verified
against the published `SHA256SUMS`.

Workload for throughput: `ninfer-serve` on localhost, one sequence,
`--greedy --kv-dtype int8 --max-context 16384 --prefill-chunk 1024 --no-prefix-reuse`, three
prompts (English explanation, Russian prose, Python code) x three repetitions, 800 completion
tokens each. Decode rate comes from the server's own `request_done` records. Legs are interleaved
A/B/A/B against an unmodified `master` build in the same session; the reported value is the median
of the nine measured requests per leg, and both `master` legs are shown so drift across the run is
visible.

### Unit tests

```
export NINFER_QWEN3_6_35B_A3B_WEIGHTS=/path/qwen3_6_35b_a3b.ninfer
export NINFER_QWEN3_6_27B_WEIGHTS=/path/qwen3_6_27b.ninfer
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON \
  -DCMAKE_CUDA_ARCHITECTURES=120a
cmake --build build -j16
cd build && ctest --output-on-failure
```

| build | result |
|---|---|
| unmodified `master` | 100% tests passed, 0 failed out of 89 |
| this branch | 100% tests passed, 0 failed out of 89 |

`ninfer_qwen3_6_27b_load_plan_test` skips itself on both builds in this environment. Everything
else runs and passes on both, including `ninfer_qwen3_6_35b_a3b_real_test`,
`ninfer_qwen3_6_35b_a3b_dflash_real_test`, `ninfer_qwen3_6_27b_prefix_real_test` and
`ninfer_qwen3_6_frontend_test`.

### End-to-end throughput, decode (T=1), Qwen3.6-35B-A3B

| leg | master | this branch |
|---|---|---|
| pair 1 | 363.6 tok/s | 371.8 tok/s |
| pair 2 | 363.7 tok/s | 371.7 tok/s |

Ratios 1.023 and 1.022, pooled 1.022; the two `master` legs differ by 0.03%. **+2.3% decode
throughput.**

Per-commit contribution, each measured alone against `master` with the same protocol:

| commit | ratio |
|---|---|
| sigmoid gate fusion | 1.004 / 1.004 |
| q/k rmsnorm fusion | 1.012 / 1.012 |
| router selection fold | 1.006 / 1.007 |

### Speculative decoding (`--spec mtp --draft-tokens 3 --lm-head-draft`)

| leg | master | this branch |
|---|---|---|
| pair 1 | 711.1 tok/s | 719.0 tok/s |
| pair 2 | 712.0 tok/s | 719.1 tok/s |

Ratios 1.011 and 1.010. The speculative route is not a regression; its step takes different kernels
for the MoE, so only the norm fusion applies there.

### Qwen3.6-27B (24Q/4K geometry)

The fused norm is templated for the 24-query/4-key geometry, so it was exercised on the 27B
artifact directly:

| leg | master | this branch |
|---|---|---|
| pair 1 | 82.4 tok/s | 82.7 tok/s |
| pair 2 | 82.4 tok/s | 82.8 tok/s |

Ratios 1.003 and 1.004. The gain is smaller because 27B is dense: it has no MoE routing node to
remove, and its step is dominated by the dense projections, so only the norm fusion contributes.

### Output parity against `master`

Greedy output compared token-for-token against an unmodified `master` build on the same machine:
three prompts at 400 completion tokens, in plain decode and with MTP-3, on both artifacts.

Result: identical output in every configuration measured — 35B in plain decode, 35B with MTP-3,
and 27B in plain decode; all prompts, full text match.

Node counts from the profiles: the two fusions take the 35B step from 445.1 to 436.0 launches, and
the routing fold removes one further node per MoE layer.

Parity is supplementary evidence rather than the primary numerical criterion — `AGENTS.md` is
explicit that a fused kernel need not reproduce an unfused materialisation. It is reported because
all three fusions were built to be exact replacements, and because this check is what caught the
rope variant that was not.

## Checks that were not run

- **Prefill-shape performance**: the fused norm also serves prefill shapes; it is covered by the
  parity checks above, but its effect at prefill was not measured separately.
- **Concurrency**: correctness was gated at C=1 only. A C=8 aggregate run showed no change
  (1288.9 -> 1287.5 tok/s), which is expected because the batched route does not take the fused
  paths, but no output gate was run at C>1.
- **`ninfer_qwen3_6_27b_load_plan_test`** skips itself in this environment on both builds.
- Other artifacts (`nvfp4`, groupwise-int) and the vision path were not exercised.

## AI disclosure

The implementation was generated by Anthropic **Claude Opus 5** (`claude-opus-5`) working under my
direction. Part of the preceding analysis — node-level profile mining and the shortlist of fusion
candidates — was produced by **Claude Fable 5** (`claude-fable-5`) used as an analysis agent. The
measurement protocol, the decision to keep rope unfused, and the scope of this pull request are
mine, and I take responsibility for the submitted code.
