### PR TITLE
perf(ops): warm L2 for the next consumer from the MoE tail (+3.7% decode)

### DIFF
--- a/include/ninfer/ops/sparse_moe.h
+++ b/include/ninfer/ops/sparse_moe.h
@@ -22,6 +22,11 @@ enum class SparseMoeEpilogue : std::uint8_t {
     AddResidual,
 };
 
+struct WeightPrefetchSpan {
+    const void* data  = nullptr;
+    std::size_t bytes = 0;
+};
+
 /**
  * Returns the transient capacity required by SparseMoe for every T in the inclusive
  * [min_tokens,max_tokens] interval. The routed QTypes are the fixed implementation profile.
@@ -59,7 +64,15 @@ enum class SparseMoeEpilogue : std::uint8_t {
  * Execution is enqueued on stream without host synchronization. Workspace is caller-owned,
  * graph-stable transient storage and carries no state beyond the call.
  */
+/**
+ * `next_prefetch` names the weight payload the next decode-step consumer will stream. The D4
+ * epilogue, whose tail runs on an otherwise idle bus, issues fire-and-forget L2 prefetches for it,
+ * clamped to the op's own cap. Purely a cache hint: no value is read through it and the emitted
+ * tokens are unaffected. An empty span disables the hint, which is what every non-decode route
+ * passes.
+ */
 void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilogue epilogue,
-                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream);
+                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream,
+                WeightPrefetchSpan next_prefetch = {});
 
 } // namespace ninfer::ops

--- a/src/ops/sparse_moe/decode/sparse_moe_decode.h
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode.h
@@ -53,6 +53,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
                                          cudaStream_t stream,
                                          const int* adaptive_route_jobs = nullptr);
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
-                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream);
+                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                              const void* prefetch_data = nullptr, std::size_t prefetch_bytes = 0);
 
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -378,7 +378,8 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
     const float* __restrict__ shared_scale, const float* __restrict__ act,
     const std::uint8_t* __restrict__ routed_codes, const std::uint8_t* __restrict__ routed_high,
     const std::uint8_t* __restrict__ routed_scales, const std::uint8_t* __restrict__ shared_codes,
-    const std::uint8_t* __restrict__ shared_scales, __nv_bfloat16* __restrict__ destination) {
+    const std::uint8_t* __restrict__ shared_scales, __nv_bfloat16* __restrict__ destination,
+    const char* __restrict__ prefetch_data, unsigned long long prefetch_bytes) {
     __shared__ float paths[kTopK + 1][Rows];
     pdl::wait_for_dependencies();
     const int warp     = static_cast<int>(threadIdx.x) >> 5;
@@ -411,6 +412,17 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
 #pragma unroll
         for (int path = 0; path < kTopK + 1; ++path) { value += paths[path][lane]; }
         destination[row_base + lane] = __float2bfloat16_rn(value);
+    }
+    if (prefetch_data != nullptr) {
+        // Fire-and-forget L2 warmup of the next consumer's weight payload. D4 CTAs
+        // retire in waves across the tail of the MoE window while the bus is
+        // largely idle; one 128B line per thread covers the whole span in a single
+        // sweep. A pure cache hint: no value and no addition order is touched.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < prefetch_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(prefetch_data + offset));
+        }
     }
 }
 
@@ -528,7 +540,8 @@ void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
 
 template <class Codec>
 void launch_d4_dependent_codec(const SparseMoeWeights& weights, Tensor& destination,
-                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                               const void* prefetch_data, std::size_t prefetch_bytes) {
     const auto* ids           = static_cast<const int*>(workspace.ids.data);
     const auto* alpha         = static_cast<const float*>(workspace.alpha.data);
     const auto* shared_scale  = static_cast<const float*>(workspace.shared_scale.data);
@@ -542,20 +555,26 @@ void launch_d4_dependent_codec(const SparseMoeWeights& weights, Tensor& destinat
     CUDA_CHECK(pdl::launch_dependent({dim3(kHidden), dim3(9 * 32), 0, stream},
                                      sparse_moe_d4_nine_warp_kernel<Codec, 1>, ids, alpha,
                                      shared_scale, act, routed_codes, routed_high, routed_scales,
-                                     shared_codes, shared_scales, output));
+                                     shared_codes, shared_scales, output,
+                                     static_cast<const char*>(prefetch_data),
+                                     static_cast<unsigned long long>(prefetch_bytes)));
 }
 
 void launch_d4_dependent(const SparseMoeWeights& weights, Tensor& destination,
-                         const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                         const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                         const void* prefetch_data, std::size_t prefetch_bytes) {
     switch (weights.routed_down.qtype) {
     case QType::Q5G64_F16S:
-        launch_d4_dependent_codec<Q5Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<Q5Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     case QType::Q6G64_F16S:
-        launch_d4_dependent_codec<Q6Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<Q6Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     case QType::W8G32_F16S:
-        launch_d4_dependent_codec<W8Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<W8Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     default:
         throw std::invalid_argument("sparse_moe: unsupported D4 codec");
@@ -718,10 +737,11 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 }
 
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
-                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                              const void* prefetch_data, std::size_t prefetch_bytes) {
     launch_d1(x, weights.router_shared_gate, workspace, stream);
     launch_d2_d3(x, weights, workspace, stream);
-    launch_d4_dependent(weights, destination, workspace, stream);
+    launch_d4_dependent(weights, destination, workspace, stream, prefetch_data, prefetch_bytes);
 }
 
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -69,7 +69,9 @@ __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __
 
 __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
-                                     float* __restrict__ scores) {
+                                     float* __restrict__ scores,
+                                     const char* __restrict__ shared_down_payload,
+                                     unsigned long long shared_down_bytes) {
     __shared__ float partial[kD1Warps];
     const int row   = static_cast<int>(blockIdx.x);
     const int warp  = static_cast<int>(threadIdx.x) >> 5;
@@ -81,6 +83,17 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
         float value = lane < kD1Warps ? partial[lane] : 0.0f;
         value       = warp_reduce_sum<kD1Warps>(value);
         if (lane == 0) { scores[row] = value; }
+    }
+    if (shared_down_payload != nullptr) {
+        // Warm L2 for the shared-expert down payload while the bus idles behind the
+        // router: D4's shared warp streams these bytes last and otherwise sets the
+        // block's critical path. One 128B line per thread covers the payload in a
+        // single sweep. A pure cache hint.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < shared_down_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(shared_down_payload + offset));
+        }
     }
 }
 
@@ -492,12 +505,14 @@ __global__ void sparse_moe_d4_token_kernel(
     }
 }
 
-void launch_d1(const Tensor& x, const Weight& router_shared_gate,
+void launch_d1(const Tensor& x, const SparseMoeWeights& weights,
                const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
     sparse_moe_d1_kernel<<<kRouterRows, kD1Warps * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data),
-        static_cast<const __nv_bfloat16*>(router_shared_gate.qdata),
-        static_cast<float*>(workspace.scratch.data));
+        static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
+        static_cast<float*>(workspace.scratch.data),
+        static_cast<const char*>(weights.shared_down.qdata),
+        static_cast<unsigned long long>(weights.shared_down.payload_bytes));
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -739,7 +754,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
                               const void* prefetch_data, std::size_t prefetch_bytes) {
-    launch_d1(x, weights.router_shared_gate, workspace, stream);
+    launch_d1(x, weights, workspace, stream);
     launch_d2_d3(x, weights, workspace, stream);
     launch_d4_dependent(weights, destination, workspace, stream, prefetch_data, prefetch_bytes);
 }

--- a/src/ops/wrapper/sparse_moe.cpp
+++ b/src/ops/wrapper/sparse_moe.cpp
@@ -189,8 +189,18 @@ std::size_t sparse_moe_workspace_capacity_bytes(QType routed_gate_up, QType rout
     return required;
 }
 
+namespace {
+// Cap keeps the warmed span well inside L2 next to the layer's own streams.
+constexpr std::size_t kNextWeightPrefetchLimit = std::size_t{8} << 20;
+} // namespace
+
 void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilogue epilogue,
-                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream) {
+                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream,
+                WeightPrefetchSpan next_prefetch_request) {
+    const WeightPrefetchSpan next_prefetch{
+        next_prefetch_request.data,
+        next_prefetch_request.bytes < kNextWeightPrefetchLimit ? next_prefetch_request.bytes
+                                                               : kNextWeightPrefetchLimit};
     if (epilogue != SparseMoeEpilogue::AddResidual) {
         throw std::invalid_argument("sparse_moe: unsupported epilogue");
     }
@@ -258,7 +268,8 @@ void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilo
     for (std::int32_t token = 0; token < tokens; ++token) {
         const Tensor x_column     = x.slice(1, token, 1);
         Tensor destination_column = destination.slice(1, token, 1);
-        detail::sparse_moe_decode_launch(x_column, weights, destination_column, views, stream);
+        detail::sparse_moe_decode_launch(x_column, weights, destination_column, views, stream,
+                                         next_prefetch.data, next_prefetch.bytes);
     }
 }
 

--- a/src/targets/qwen3_6/impl/runtime/text_context.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context.h
@@ -11,6 +11,7 @@
 #include "core/weight.h"
 #include "ninfer/ops/sampling.h"
 #include "ninfer/ops/gqa_attention.h"
+#include "ninfer/ops/sparse_moe.h"
 #include <ninfer/targets/qwen3_6/decoder_state.h>
 #include <ninfer/targets/qwen3_6/prepared_prompt.h>
 #include <ninfer/targets/qwen3_6/round_state.h>
@@ -240,7 +241,9 @@ private:
     [[nodiscard]] const MtpW& mtp_weights() const;
     void attn_mix(const FullLayerW& weights, Tensor& x, int index, Phase phase);
     void gdn_mix(const GdnLayerW& weights, Tensor& x, int index, Phase phase);
-    void mlp_tail(const Tensor* post_norm, const MlpW& weights, Tensor& x, Phase phase);
+    void mlp_tail(const Tensor* post_norm, const MlpW& weights, Tensor& x, Phase phase,
+                  ops::WeightPrefetchSpan next_prefetch);
+    [[nodiscard]] ops::WeightPrefetchSpan next_projection_prefetch(int layer) const;
     void run_layers(Tensor& x, Phase phase);
     template <class Tap>
     void run_layers(Tensor& x, Phase phase, Tap& tap);

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -25,6 +25,7 @@
 #include "ninfer/ops/residual_add.h"
 #include "ninfer/ops/rmsnorm.h"
 #include "ninfer/ops/rope.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "ninfer/ops/scatter.h"
 #include "ninfer/ops/scalar.h"
 #include "ninfer/ops/sigmoid_mul.h"
@@ -955,13 +956,27 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
     Variant::gdn_output_projection(on.view({kCfg.value_dim, T}), *w.out_proj, x, ph, work_, s);
 }
 
-void TextContext::mlp_tail(const Tensor* post_norm, const MlpW& m, Tensor& x, Phase ph) {
+ops::WeightPrefetchSpan TextContext::next_projection_prefetch(int layer) const {
+    // Names the next layer's projection payload so the current post-mixer can warm L2 for it
+    // while its own tail runs. The last layer names nothing.
+    const int next = layer + 1;
+    if (next >= kCfg.n_layers) { return {}; }
+    if (ModelConfig::is_full(next)) {
+        return Variant::projection_prefetch_span(
+            *full_.at(static_cast<std::size_t>(ModelConfig::full_idx(next))).projection);
+    }
+    return Variant::projection_prefetch_span(
+        *gdn_.at(static_cast<std::size_t>(ModelConfig::gdn_idx(next))).projection);
+}
+
+void TextContext::mlp_tail(const Tensor* post_norm, const MlpW& m, Tensor& x, Phase ph,
+                           ops::WeightPrefetchSpan next_prefetch) {
     cudaStream_t s = ctx_.stream;
     const int T    = x.ne[1];
     Tensor h       = workspace_recipe::post_mixer_hidden<TextConfig>(work_, T);
     ops::rmsnorm(x, *post_norm, kCfg.rms_eps, true, h, s);
 
-    Variant::post_mixer(h, *m.payload, x, ph, work_, s);
+    Variant::post_mixer(h, *m.payload, x, ph, work_, s, next_prefetch);
 }
 
 template <class Tap>
@@ -986,7 +1001,7 @@ void TextContext::run_layers(Tensor& x, Phase ph, Tap& tap) {
                     prefill ? nvtx::Name::PrefillPostMixer : nvtx::Name::VerifyPostMixer,
                     nvtx::Category::PostMixer, static_cast<std::uint64_t>(layer));
                 auto mlp_scope = work_.scope();
-                mlp_tail(full.post_attn_norm, full.mlp, x, ph);
+                mlp_tail(full.post_attn_norm, full.mlp, x, ph, next_projection_prefetch(layer));
                 if constexpr (Tap::enabled) { tap.capture_layer(layer, x, ctx_.stream); }
             }
         } else {
@@ -1007,7 +1022,7 @@ void TextContext::run_layers(Tensor& x, Phase ph, Tap& tap) {
                     prefill ? nvtx::Name::PrefillPostMixer : nvtx::Name::VerifyPostMixer,
                     nvtx::Category::PostMixer, static_cast<std::uint64_t>(layer));
                 auto mlp_scope = work_.scope();
-                mlp_tail(gdn.post_attn_norm, gdn.mlp, x, ph);
+                mlp_tail(gdn.post_attn_norm, gdn.mlp, x, ph, next_projection_prefetch(layer));
                 if constexpr (Tap::enabled) { tap.capture_layer(layer, x, ctx_.stream); }
             }
         }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -292,7 +292,8 @@ void Variant::gdn_norm_control_projection(const Tensor& residual, const Tensor& 
 }
 
 void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
-                         qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
+                         qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream,
+                         ops::WeightPrefetchSpan) {
     auto scope        = workspace.scope();
     Tensor activation = workspace.alloc(DType::BF16, {TextConfig::intermediate, hidden.ne[1]});
     ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up), workspace,

--- a/src/targets/qwen3_6_27b/impl/variant.h
+++ b/src/targets/qwen3_6_27b/impl/variant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "targets/qwen3_6_27b/impl/config.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "targets/qwen3_6_27b/impl/load/bindings.h"
 #include <ninfer/targets/qwen3_6/runtime.h>
 
@@ -27,6 +28,16 @@ struct Variant {
     using MtpPostMixerWeights            = detail::DensePostMixerPayload;
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
+
+    // The dense post-mixer path does not consume weight-prefetch registrations yet.
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const FullAttentionProjectionWeights&) {
+        return {};
+    }
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const GdnProjectionWeights&) {
+        return {};
+    }
 
     static constexpr float attention_scale                     = kAttentionScale;
     static constexpr float gdn_scale                           = kGdnScale;
@@ -79,7 +90,7 @@ struct Variant {
                                             WorkspaceArena& workspace, cudaStream_t stream);
     static void post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                            qwen3_6::TextPhase phase, WorkspaceArena& workspace,
-                           cudaStream_t stream);
+                           cudaStream_t stream, ops::WeightPrefetchSpan next_prefetch = {});
     static void mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,
                                Tensor& residual, WorkspaceArena& workspace, cudaStream_t stream);
     [[nodiscard]] static std::size_t

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
@@ -64,13 +64,14 @@ bool dflash_target_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_
 }
 
 void run_sparse_moe(const Tensor& hidden, const ops::SparseMoeWeights& weights, Tensor& residual,
-                    WorkspaceArena& workspace, cudaStream_t stream) {
+                    WorkspaceArena& workspace, cudaStream_t stream,
+                    ops::WeightPrefetchSpan next_prefetch) {
     auto scope               = workspace.scope();
     const DeviceSpan storage = workspace.alloc_bytes(ops::sparse_moe_workspace_capacity_bytes(
         weights.routed_gate_up.qtype, weights.routed_down.qtype, hidden.ne[1], hidden.ne[1]));
     WorkspaceArena leaf_workspace(storage);
     ops::sparse_moe(hidden, weights, ops::SparseMoeEpilogue::AddResidual, residual, leaf_workspace,
-                    stream);
+                    stream, next_prefetch);
 }
 
 void validate_token_interval(std::int32_t first, std::int32_t last) {
@@ -213,13 +214,14 @@ void Variant::gdn_norm_control_projection(const Tensor& residual, const Tensor& 
 }
 
 void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
-                         qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
-    run_sparse_moe(hidden, weights.op, residual, workspace, stream);
+                         qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream,
+                         ops::WeightPrefetchSpan next_prefetch) {
+    run_sparse_moe(hidden, weights.op, residual, workspace, stream, next_prefetch);
 }
 
 void Variant::mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,
                              Tensor& residual, WorkspaceArena& workspace, cudaStream_t stream) {
-    run_sparse_moe(hidden, weights.op, residual, workspace, stream);
+    run_sparse_moe(hidden, weights.op, residual, workspace, stream, {});
 }
 
 std::size_t Variant::mtp_attention_projection_workspace_capacity_bytes(std::int32_t first,

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "targets/qwen3_6_35b_a3b/impl/config.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "targets/qwen3_6_35b_a3b/impl/load/bindings.h"
 #include <ninfer/targets/qwen3_6/runtime.h>
 
@@ -25,6 +26,17 @@ struct Variant {
     using MtpPostMixerWeights            = detail::SparseMoePayload;
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
+
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const FullAttentionProjectionWeights& weights) {
+        return {weights.query_key_gate_value.qdata,
+                static_cast<std::size_t>(weights.query_key_gate_value.payload_bytes)};
+    }
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const GdnProjectionWeights& weights) {
+        return {weights.query_key_value_z.qdata,
+                static_cast<std::size_t>(weights.query_key_value_z.payload_bytes)};
+    }
 
     static constexpr float attention_scale                     = kAttentionScale;
     static constexpr float gdn_scale                           = kGdnScale;
@@ -85,7 +97,7 @@ struct Variant {
                                             WorkspaceArena& workspace, cudaStream_t stream);
     static void post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                            qwen3_6::TextPhase phase, WorkspaceArena& workspace,
-                           cudaStream_t stream);
+                           cudaStream_t stream, ops::WeightPrefetchSpan next_prefetch = {});
     static void mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,
                                Tensor& residual, WorkspaceArena& workspace, cudaStream_t stream);
 


### PR DESCRIPTION
Implements the proposal in #68. Opened so the mechanism can be judged against real
code and real numbers; happy to reshape or drop it if the contract is not one you want.

## Problem

Profiling one decode step of Qwen3.6-35B-A3B at T=1 (nsys, `--cuda-graph-trace=node`, RTX 5090)
shows the MoE chain of every layer leaves the memory system idle at two points while the kernels
that follow start cold on weights:

- **the D1/D2 window at the head of the chain.** D3 cannot do real work until routing resolves, so
  the first microseconds of every MoE layer run with the bus nearly idle.
- **the D4 epilogue.** The block has finished its dot products and is waiting on the barrier.

Immediately after, two pure weight streams begin with cold first touches: the next layer's
projection GEMV, and — inside D4 itself — the shared expert's down-projection, which is the long
pole of the D4 block because its codes are one byte per value against the routed experts' packed
four bits.

## Change

Two commits, each issuing `prefetch.global.L2` for weights a later kernel will stream:

1. **`perf(ops): prefetch next projection weights from moe d4 tail`** — the D4 epilogue warms the
   next layer's projection codes. The span travels as an ordinary argument from the family
   schedule down to the op:

   ```
   struct WeightPrefetchSpan { const void* data; std::size_t bytes; };

   void sparse_moe(..., cudaStream_t stream, WeightPrefetchSpan next_prefetch = {});
   ```

   `run_layers` names the next layer's payload, `Variant::post_mixer` forwards it, and the op
   clamps it to a fixed cap. The default empty span is what every non-decode route passes, so the
   hint is inert unless a caller asks for it. Byte counts come from `Weight::payload_bytes`, so the
   hint does not know or care about the codec.

2. **`perf(ops): prefetch shared expert down weights behind moe router`** — the tail of D1 warms the
   shared-expert down codes that D4's shared warp reads a few microseconds later, using the idle
   window the routing dependency creates.

Both are pure cache hints: no value is read through them, no accumulation order changes, and the
emitted token stream is unaffected — the parity checks below are exact.

Two placement details are load-bearing and were established by measurement, not by preference:

- the hint is issued **before** the block barrier, not in the kernel tail. Issued in the tail it
  extends the grid; issued before the barrier it hides behind the slowest warp. Moving it cost
  0.7 percentage points when I measured the two placements against each other.
- the cap matters. 8 MiB per layer is the measured optimum on this hardware; 12 MiB is worse by
  0.5 points, and pushing more work into the D1 window is worse still, because that window only
  tolerates about a megabyte before it starts competing with D3's own stream.

## Why this design

The alternative that does not touch any contract is to prefetch from within the same kernel that
consumes the weights. I measured that too: issuing the hint from a hot stream — D3, which already
runs at about 81% of achievable bandwidth — **lost** 1.1 percentage points. The gain here is not
"prefetching is good"; it is specifically that these two windows are idle and the consumer is cold,
so the hint has to cross a kernel boundary to be worth anything. That is what forces the span to be
registered by the layer that knows what comes next.

The cross-layer hint is one struct and one defaulted argument. An earlier revision of this branch
registered it through a thread-local slot; the Codex review on this PR pointed out that such a slot
is shared by every `Program` on the host thread and so violates the `AGENTS.md` rule that Programs
share no mutable state. That was a fair call and the series now threads the span explicitly through
`Variant::post_mixer` into the op, with no ambient state anywhere. Kernels were untouched by that
rewrite and every number below was re-measured on it.

If you would rather see the span carried in the workspace or owned entirely by the target, I am
still happy to move it — the kernel side does not change either way.

## Verification

Hardware and toolchain: single RTX 5090 (32 GiB, 500 W cap, PCIe gen5), Ubuntu 24.04, CUDA 13.1.115,
GCC 13.3, `-DCMAKE_CUDA_ARCHITECTURES=120a`, Nsight Systems 2025.5.2.

Artifacts: `qwen3_6_35b_a3b.ninfer` (`neroued/Qwen3.6-35B-A3B-NInfer`, revision `3d960f7b`) and
`qwen3_6_27b.ninfer` (`neroued/Qwen3.6-27B-NInfer`, revision `85108f66`), both SHA-256 verified
against the published `SHA256SUMS`.

Workload for throughput: `ninfer-serve` on localhost, one sequence,
`--greedy --kv-dtype int8 --max-context 16384 --prefill-chunk 1024 --no-prefix-reuse`, three prompts
(English explanation, Russian prose, Python code) x three repetitions, 800 completion tokens each.
Decode rate comes from the server's own `request_done` records. Legs are interleaved A/B/A/B against
an unmodified `master` build in the same session; the value is the median of the nine measured
requests per leg, and both `master` legs are shown so drift is visible.

### Unit tests

```
export NINFER_QWEN3_6_35B_A3B_WEIGHTS=/path/qwen3_6_35b_a3b.ninfer
export NINFER_QWEN3_6_27B_WEIGHTS=/path/qwen3_6_27b.ninfer
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON \
  -DCMAKE_CUDA_ARCHITECTURES=120a
cmake --build build -j16
cd build && ctest --output-on-failure
```

| build | result |
|---|---|
| unmodified `master` | 100% tests passed, 0 failed out of 89 |
| this branch | 100% tests passed, 0 failed out of 89 |

`ninfer_qwen3_6_27b_load_plan_test` skips itself on both builds in this environment; everything else
runs and passes on both, including the real-model routes for 35B and 27B.

### Operator-level evidence

The claim is that cold weight streams get warmer, so the kernels that consume them should shrink.
Per-family kernel time from node-traced profiles of the same CLI decode run:

| family | master | this branch | delta |
|---|---|---|---|
| `w8_k2048_decode_kernel` (layer projection) | 580.6 us | 482.2 us | **-98.4** |
| `sparse_moe_d4_nine_warp_kernel` (issues the hint) | 698.8 us | 739.2 us | **+40.4** |
| `sparse_moe_d3_nine_warp_kernel` | 467.0 us | 468.2 us | +1.2 |
| `w8_rowsplit_gemm_simt_kernel` | 318.4 us | 319.7 us | +1.3 |
| `q6_rowsplit_gemm_simt_kernel` (lm_head) | 250.3 us | 249.3 us | -1.0 |
| `sparse_moe_d2_warp_kernel` | 192.2 us | 193.0 us | +0.8 |
| step total | 3391.1 us | 3305.6 us | **-85.5** |

That is the whole mechanism in one table: the consumer of the warmed weights gets 98 us cheaper,
the kernel that pays for the hint gets 40 us more expensive, nothing else moves by more than
1.5 us. Absolute values are inflated by node tracing (~1.4 us per node); the deltas are not.

### End-to-end throughput, decode (T=1), Qwen3.6-35B-A3B

| leg | master | this branch |
|---|---|---|
| pair 1 | 363.7 tok/s | 377.2 tok/s |
| pair 2 | 363.8 tok/s | 377.2 tok/s |

Ratios 1.037 and 1.037. **+3.7% decode throughput.**

### Speculative decoding (`--spec mtp --draft-tokens 3 --lm-head-draft`)

| leg | master | this branch |
|---|---|---|
| pair 1 | 711.3 tok/s | 712.1 tok/s |
| pair 2 | 711.6 tok/s | 711.4 tok/s |

Ratios 1.001 and 1.000 — unchanged, as expected: the span is registered only on the decode route,
and the speculative step takes the small-T MoE kernels, which do not consume it.

### Qwen3.6-27B

| leg | master | this branch |
|---|---|---|
| pair 1 | 82.4 tok/s | 82.4 tok/s |
| pair 2 | 82.4 tok/s | 82.4 tok/s |

Ratios 1.000 and 1.000. 27B is dense, so the MoE route this change lives in is never taken; the
measurement is reported to show the change is inert there rather than harmful, and the 27B helpers
added by the patch are the inert stubs the dense path needs to compile.

### Output parity against `master`

Greedy output compared token-for-token against an unmodified `master` build: three prompts at 400
completion tokens, plain decode and MTP-3, on both artifacts.

Result: identical output in every configuration measured — 35B plain decode, 35B with MTP-3, and
27B plain decode; all prompts, full text match. This is expected by construction, since
`prefetch.global.L2` moves no values, and is reported as a check on that reasoning rather than as
the numerical criterion.

## Checks that were not run

- **Concurrency**: correctness gated at C=1. The batched route does not consume the span, so it is
  inert there, but no output gate was run at C>1.
- **Prefill**: the hint is restricted to the decode route; prefill is unaffected by construction and
  was covered only by the parity checks.
- **Other hardware**: the cap and the placement were tuned on one RTX 5090. Both are measured
  optima on this device and I have no evidence about others.
- **`ninfer_qwen3_6_27b_load_plan_test`** skips itself in this environment on both builds.
- Other artifacts (`nvfp4`, groupwise-int) and the vision path were not exercised.

## AI disclosure

The implementation was generated by Anthropic **Claude Opus 5** (`claude-opus-5`) working under my
direction. Part of the preceding analysis — node-level profile mining and the shortlist of
candidates, including the idle-window observation this change exploits — was produced by **Claude
Fable 5** (`claude-fable-5`) used as an analysis agent. The measurement protocol, the placement and
cap decisions, and the scope of this pull request are mine, and I take responsibility for the
submitted code.
