### PR TITLE
On-demand vision residency: stream the tower through evicted read-only text weights

### DIFF
--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -265,6 +265,8 @@ int main(int argc, char** argv) {
         engine_options.kv_cache       = cli.kv_cache;
         engine_options.speculative    = cli.speculative;
         engine_options.enable_vision  = cli.enable_vision;
+        engine_options.vision_residency         = cli.vision_residency;
+        engine_options.vision_max_merged_tokens = cli.vision_max_merged_tokens;
         engine_options.use_cuda_graph = cli.use_cuda_graph;
         engine_options.load_progress  = load_progress.callback();
 

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -153,21 +153,20 @@ Options parse_options(int argc, char** argv) {
         } else if (arg == "--vision") {
             options.enable_vision = true;
         } else if (arg == "--vision-residency") {
-            const std::string_view value = require_value("--vision-residency");
-            if (value == "resident") {
+            const std::string_view residency = value(arg);
+            if (residency == "resident") {
                 options.vision_residency = ninfer::VisionResidency::Resident;
-            } else if (value == "overlay") {
+            } else if (residency == "overlay") {
                 options.vision_residency = ninfer::VisionResidency::Overlay;
             } else {
                 throw std::invalid_argument("--vision-residency accepts resident or overlay");
             }
         } else if (arg == "--vision-max-merged") {
-            const int value =
-                parse_nonnegative_int(require_value("--vision-max-merged"), "vision-max-merged");
-            if (value < 64 || value > 32768) {
+            const std::uint32_t merged = parse_u32(value(arg), "vision-max-merged");
+            if (merged < 64 || merged > 32768) {
                 throw std::invalid_argument("--vision-max-merged must be in [64, 32768]");
             }
-            options.vision_max_merged_tokens = static_cast<std::uint32_t>(value);
+            options.vision_max_merged_tokens = merged;
         } else if (arg == "--no-cuda-graph") {
             options.use_cuda_graph = false;
         } else if (arg == "--stop-token-id") {

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -93,7 +93,7 @@ std::string usage_text(const char* argv0) {
            "--vision enables image/video input and loads the fixed Vision GPU allocations.\n"
            "--vision-residency overlay keeps the vision tower host-pinned and encodes images\n"
            "  through device memory borrowed from evicted read-only text weights, returning the\n"
-           "  tower's resident footprint to KV capacity (qwen3.8-27b family targets).\n"
+           "  tower's resident footprint to KV capacity.\n"
            "--vision-max-merged N budgets one item's merged vision tokens; oversized media\n"
            "  downscales at preprocessing to fit (default 32768).\n"
            "--kv-capacity auto leaves " +

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -94,7 +94,8 @@ std::string usage_text(const char* argv0) {
            "--vision-residency overlay keeps the vision tower host-pinned and encodes images\n"
            "  through device memory borrowed from evicted read-only text weights, returning the\n"
            "  tower's resident footprint to KV capacity (qwen3.8-27b family targets).\n"
-           "--vision-max-merged N bounds one item's merged vision tokens (default 32768).\n"
+           "--vision-max-merged N budgets one item's merged vision tokens; oversized media\n"
+           "  downscales at preprocessing to fit (default 32768).\n"
            "--kv-capacity auto leaves " +
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
            " MiB of sizing headroom.\n"

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -84,12 +84,17 @@ std::string usage_text(const char* argv0) {
            "       [--stop-token-id N]... [--stop <text>]... [--reasoning-stop <text>]...\n"
            "       [--raw-output] [--print-token-ids] [--no-thinking]\n"
            "       [--reasoning-effort low|medium|xhigh] [--vision]\n"
+           "       [--vision-residency resident|overlay] [--vision-max-merged N]\n"
            "       [--no-cuda-graph]\n"
            "\n"
            "Streams answer content to stdout and reasoning plus diagnostics to stderr.\n"
            "Structured message content accepts text, image/image_url, and video/video_url parts;\n"
            "media sources may be local paths, HTTP(S) URLs, or base64 data URIs.\n"
            "--vision enables image/video input and loads the fixed Vision GPU allocations.\n"
+           "--vision-residency overlay keeps the vision tower host-pinned and encodes images\n"
+           "  through device memory borrowed from evicted read-only text weights, returning the\n"
+           "  tower's resident footprint to KV capacity (qwen3.8-27b family targets).\n"
+           "--vision-max-merged N bounds one item's merged vision tokens (default 32768).\n"
            "--kv-capacity auto leaves " +
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
            " MiB of sizing headroom.\n"
@@ -147,6 +152,22 @@ Options parse_options(int argc, char** argv) {
             options.reasoning_effort = parse_reasoning_effort(value(arg));
         } else if (arg == "--vision") {
             options.enable_vision = true;
+        } else if (arg == "--vision-residency") {
+            const std::string_view value = require_value("--vision-residency");
+            if (value == "resident") {
+                options.vision_residency = ninfer::VisionResidency::Resident;
+            } else if (value == "overlay") {
+                options.vision_residency = ninfer::VisionResidency::Overlay;
+            } else {
+                throw std::invalid_argument("--vision-residency accepts resident or overlay");
+            }
+        } else if (arg == "--vision-max-merged") {
+            const int value =
+                parse_nonnegative_int(require_value("--vision-max-merged"), "vision-max-merged");
+            if (value < 64 || value > 32768) {
+                throw std::invalid_argument("--vision-max-merged must be in [64, 32768]");
+            }
+            options.vision_max_merged_tokens = static_cast<std::uint32_t>(value);
         } else if (arg == "--no-cuda-graph") {
             options.use_cuda_graph = false;
         } else if (arg == "--stop-token-id") {

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -26,6 +26,8 @@ struct Options {
     KvCacheStorage kv_cache = KvCacheStorage::BFloat16;
     SpeculativeOptions speculative;
     bool enable_vision  = false;
+    ninfer::VisionResidency vision_residency = ninfer::VisionResidency::Resident;
+    std::uint32_t vision_max_merged_tokens   = 32768;
     bool use_cuda_graph = true;
 
     bool raw_output      = false;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,7 @@ measured recommendation rather than a semantic limit.
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
 | `--vision-max-merged N` | largest merged vision-token count one item may carry (`[64, 32768]`); bounds the vision share of the startup workspace/transient reservations, so smaller values return memory to KV | `32768` |
-| `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM | `resident` |
+| `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM; currently supported for the qwen3.8-27b family targets | `resident` |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |
 | `--reasoning-effort low\|medium\|xhigh` | select an effort exposed by the loaded chat template | template default |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,13 @@ GPU residency is frozen when the Engine starts:
 - Vision is disabled by default, omitting its weights, Vision scratch phase, and frozen
   request-transient allocation;
 - `--vision` loads those allocations and enables image/video input.
+- `--vision-residency overlay` removes the resident Vision weight footprint: the tower lives in
+  pinned host memory and streams through a small borrowed staging window during each encode,
+  while the evicted text weights are restored byte-for-byte from pinned mirrors afterwards.
+  With `--kv-capacity auto` the freed memory becomes additional KV capacity automatically.
+  Overlay also drops the resident vision-encode workspace reservation entirely (the window
+  borrows it from the evicted tail), leaving only the `--vision-max-merged`-bounded output
+  transient resident.
 
 The complete `.ninfer` inventory is still validated. These choices are not lazy loading: a
 text-only Engine rejects media and cannot enable Vision later. DFlash and Vision are mutually
@@ -145,6 +152,8 @@ measured recommendation rather than a semantic limit.
 | `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
+| `--vision-max-merged N` | largest merged vision-token count one item may carry (`[64, 32768]`); bounds the vision share of the startup workspace/transient reservations, so smaller values return memory to KV | `32768` |
+| `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM | `resident` |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |
 | `--reasoning-effort low\|medium\|xhigh` | select an effort exposed by the loaded chat template | template default |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -152,7 +152,7 @@ measured recommendation rather than a semantic limit.
 | `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
-| `--vision-max-merged N` | largest merged vision-token count one item may carry (`[64, 32768]`); bounds the vision share of the startup workspace/transient reservations, so smaller values return memory to KV | `32768` |
+| `--vision-max-merged N` | per-item merged vision-token budget (`[64, 32768]`): oversized images/videos are downscaled at preprocessing to fit, never rejected; also bounds the vision share of the startup workspace/transient reservations, so smaller values return memory to KV | `32768` |
 | `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM; currently supported for the qwen3.8-27b family targets | `resident` |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,7 @@ measured recommendation rather than a semantic limit.
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
 | `--vision-max-merged N` | per-item merged vision-token budget (`[64, 32768]`): oversized images/videos are downscaled at preprocessing to fit, never rejected; also bounds the vision share of the startup workspace/transient reservations, so smaller values return memory to KV | `32768` |
-| `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM; currently supported for the qwen3.8-27b family targets | `resident` |
+| `--vision-residency resident\|overlay` | `overlay` keeps Vision weights in pinned host memory and encodes each image through device memory temporarily borrowed from evicted read-only text weights (lm_head, embedding, draft/MTP heads), freeing the resident Vision footprint for KV; requires `--vision` and CUDA VMM | `resident` |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |
 | `--no-thinking` | disable thinking in prompt rendering | thinking on |
 | `--reasoning-effort low\|medium\|xhigh` | select an effort exposed by the loaded chat template | template default |

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -117,7 +117,7 @@ finish-reason chunk and `[DONE]`. When `stream_options.include_usage` is true, a
 ### Multimodal request
 
 Start the server with `--vision` before sending media. Add `--vision-residency overlay` to keep
-the Vision tower out of resident device memory: images then encode inside a bounded exclusive Overlay residency currently supports the qwen3.8-27b family targets.
+the Vision tower out of resident device memory: images then encode inside a bounded exclusive
 window that borrows device memory from temporarily evicted read-only text weights and restores
 them before the next text step; the request log reports each window as
 `overlay=<ms> (evict <MiB> <ms>, restore <ms>, staged <MiB>)`. In overlay mode the encode

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -116,7 +116,15 @@ finish-reason chunk and `[DONE]`. When `stream_options.include_usage` is true, a
 
 ### Multimodal request
 
-Start the server with `--vision` before sending media:
+Start the server with `--vision` before sending media. Add `--vision-residency overlay` to keep
+the Vision tower out of resident device memory: images then encode inside a bounded exclusive
+window that borrows device memory from temporarily evicted read-only text weights and restores
+them before the next text step; the request log reports each window as
+`overlay=<ms> (evict <MiB> <ms>, restore <ms>, staged <MiB>)`. In overlay mode the encode
+workspace and item output live inside the borrowed window as well, so `--vision` adds no resident
+workspace reservation; `--vision-max-merged` bounds the remaining per-request output transient. Concurrent text requests wait for
+the window at any `--max-concurrency` and their KV/session state is untouched. Media semantics,
+routes, and outputs are identical in both residency modes:
 
 ```bash
 curl http://127.0.0.1:8080/v1/chat/completions \

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -117,7 +117,7 @@ finish-reason chunk and `[DONE]`. When `stream_options.include_usage` is true, a
 ### Multimodal request
 
 Start the server with `--vision` before sending media. Add `--vision-residency overlay` to keep
-the Vision tower out of resident device memory: images then encode inside a bounded exclusive
+the Vision tower out of resident device memory: images then encode inside a bounded exclusive Overlay residency currently supports the qwen3.8-27b family targets.
 window that borrows device memory from temporarily evicted read-only text weights and restores
 them before the next text step; the request log reports each window as
 `overlay=<ms> (evict <MiB> <ms>, restore <ms>, staged <MiB>)`. In overlay mode the encode

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -72,6 +72,15 @@ struct LoadProgress {
     std::function<void(std::string_view phase, std::uint64_t done, std::uint64_t total)> callback;
 };
 
+enum class VisionResidency : std::uint8_t {
+    // Vision weights stay resident on the device for the process lifetime.
+    Resident,
+    // Vision weights live in pinned host memory and are streamed through device
+    // memory borrowed from evicted read-only text weights for the duration of
+    // each image encode. Requires enable_vision.
+    Overlay,
+};
+
 struct EngineOptions {
     std::filesystem::path artifact_path;
     int device                         = 0;
@@ -88,6 +97,11 @@ struct EngineOptions {
     // Zero selects a bounded worker count from the detected host concurrency.
     std::uint32_t media_preprocess_threads = 0;
     bool enable_vision                     = false;
+    VisionResidency vision_residency       = VisionResidency::Resident;
+    // Largest merged vision-token count a single item may carry. Bounds the
+    // vision share of the startup workspace/transient reservations; smaller
+    // values return the difference to KV capacity.
+    std::uint32_t vision_max_merged_tokens = 32768;
     bool use_cuda_graph                    = true;
     LoadProgress load_progress;
 };
@@ -370,6 +384,13 @@ struct GenerationTimings {
     double prefill_seconds     = 0.0;
     double decode_seconds      = 0.0;
     double total_seconds       = 0.0;
+    // Overlay vision residency: duration and traffic of the encode window that
+    // borrowed device memory from evicted text weights. Zero in resident mode.
+    double overlay_window_seconds  = 0.0;
+    double overlay_evict_seconds   = 0.0;
+    double overlay_restore_seconds = 0.0;
+    std::uint64_t overlay_evicted_bytes = 0;
+    std::uint64_t overlay_staged_bytes  = 0;
 };
 
 struct SpeculativeStats {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,13 +26,14 @@ add_library(ninfer_core STATIC
   core/layout.cpp
   core/tensor.cpp
   core/decode_graph.cpp
+  core/evictable_weight_pool.cu
   runtime/engine/admission_policy.cpp
   runtime/engine/kv_capacity.cpp
   runtime/engine/public_types.cpp
   runtime/engine/request_memory.cpp)
 ninfer_internal_includes(ninfer_core)
 ninfer_cuda_archive(ninfer_core)
-target_link_libraries(ninfer_core PUBLIC CUDA::cudart CUDA::nvtx3 Threads::Threads)
+target_link_libraries(ninfer_core PUBLIC CUDA::cudart CUDA::nvtx3 Threads::Threads CUDA::cuda_driver)
 
 # Generic .ninfer framing, binding, and direct final materialization.
 add_library(ninfer_artifact STATIC

--- a/src/artifact/binder.cpp
+++ b/src/artifact/binder.cpp
@@ -79,7 +79,7 @@ PayloadSpan Binder::payload(ObjectHandle handle) const {
     return reader_.payload(descriptor(handle));
 }
 
-void Binder::materialize_on_device(ObjectHandle handle) {
+void Binder::materialize_on_device(ObjectHandle handle, std::uint32_t evict_rank) {
     const auto* tensor = std::get_if<TensorDescriptor>(&descriptor(handle));
     if (tensor == nullptr) {
         throw ArtifactError("resource cannot be materialized as a device tensor");
@@ -89,13 +89,41 @@ void Binder::materialize_on_device(ObjectHandle handle) {
                             std::string(tensor->name));
     }
     const std::uint64_t alignment = tensor_alignment(tensor->layout);
-    const std::uint64_t offset    = align_up(materialization_.device_capacity_bytes, alignment);
+    if (evict_rank != 0) {
+        // Evictable tensors receive their offsets in finish(): they are packed
+        // into the arena suffix ordered so higher ranks sit closer to the end.
+        evictable_.push_back(PendingEvictable{handle, tensor->bytes, alignment, evict_rank,
+                                              evictable_.size()});
+        planned_[handle.index] = true;
+        return;
+    }
+    const std::uint64_t offset = align_up(materialization_.device_capacity_bytes, alignment);
     if (tensor->bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
         throw ArtifactError("materialization plan size overflows u64");
     }
     materialization_.device_objects.push_back(
         DeviceMaterialization{handle, offset, tensor->bytes, alignment});
     materialization_.device_capacity_bytes = offset + tensor->bytes;
+    planned_[handle.index]                 = true;
+}
+
+void Binder::materialize_on_host_pinned(ObjectHandle handle) {
+    const auto* tensor = std::get_if<TensorDescriptor>(&descriptor(handle));
+    if (tensor == nullptr) {
+        throw ArtifactError("resource cannot be materialized as a pinned host tensor");
+    }
+    if (planned_[handle.index]) {
+        throw ArtifactError("artifact object has more than one materialization placement: " +
+                            std::string(tensor->name));
+    }
+    const std::uint64_t alignment = tensor_alignment(tensor->layout);
+    const std::uint64_t offset    = align_up(materialization_.pinned_capacity_bytes, alignment);
+    if (tensor->bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
+        throw ArtifactError("materialization plan size overflows u64");
+    }
+    materialization_.pinned_objects.push_back(
+        PinnedMaterialization{handle, offset, tensor->bytes, alignment});
+    materialization_.pinned_capacity_bytes = offset + tensor->bytes;
     planned_[handle.index]                 = true;
 }
 
@@ -121,7 +149,7 @@ void Binder::validate_only(ObjectHandle handle) {
     planned_[handle.index] = true;
 }
 
-MaterializationPlan Binder::finish() {
+MaterializationPlan Binder::finish(std::uint64_t evictable_alignment) {
     const auto it = std::find(consumed_.begin(), consumed_.end(), false);
     if (it != consumed_.end()) {
         const auto index = static_cast<std::size_t>(it - consumed_.begin());
@@ -133,6 +161,41 @@ MaterializationPlan Binder::finish() {
         const auto index = static_cast<std::size_t>(unplanned - planned_.begin());
         throw ArtifactError("artifact object has no materialization placement: " +
                             std::string(object_name(reader_.objects()[index])));
+    }
+    if (!evictable_.empty()) {
+        if (evictable_alignment == 0) {
+            throw ArtifactError("evictable tail alignment must be nonzero");
+        }
+        // Ascending rank order packs the highest rank at the arena end, which the
+        // eviction pool unmaps first. Ties keep their registration order.
+        std::stable_sort(evictable_.begin(), evictable_.end(),
+                         [](const PendingEvictable& a, const PendingEvictable& b) {
+                             return a.rank < b.rank;
+                         });
+        const std::uint64_t tail_begin =
+            align_up(materialization_.device_capacity_bytes, evictable_alignment);
+        materialization_.device_capacity_bytes = tail_begin;
+        bool first_evictable                   = true;
+        for (const PendingEvictable& pending : evictable_) {
+            // The materializer replays the arena bump allocation from these
+            // alignments, so the tail-begin alignment must live on the first
+            // evictable object rather than only in the accumulator above.
+            const std::uint64_t alignment =
+                first_evictable ? std::max(pending.alignment, evictable_alignment)
+                                : pending.alignment;
+            first_evictable            = false;
+            const std::uint64_t offset =
+                align_up(materialization_.device_capacity_bytes, alignment);
+            if (pending.bytes > std::numeric_limits<std::uint64_t>::max() - offset) {
+                throw ArtifactError("materialization plan size overflows u64");
+            }
+            materialization_.device_objects.push_back(
+                DeviceMaterialization{pending.handle, offset, pending.bytes, alignment});
+            materialization_.device_capacity_bytes = offset + pending.bytes;
+        }
+        materialization_.evictable_tail_bytes =
+            materialization_.device_capacity_bytes - tail_begin;
+        evictable_.clear();
     }
     return std::move(materialization_);
 }

--- a/src/artifact/binder.h
+++ b/src/artifact/binder.h
@@ -13,6 +13,11 @@ namespace ninfer::artifact {
 enum class TensorPlacement : std::uint8_t {
     Device,
     ValidateOnly,
+    // Permanent pinned-host materialization: the tensor never receives device
+    // memory at load; its payload lands in one contiguous pinned block whose
+    // internal layout follows the same alignment rules as the device arena, so
+    // the block can be uploaded wholesale and addressed by identical offsets.
+    HostPinned,
 };
 
 struct ObjectHandle {
@@ -30,11 +35,25 @@ struct HostMaterialization {
     ObjectHandle object;
 };
 
+struct PinnedMaterialization {
+    ObjectHandle object;
+    std::uint64_t offset    = 0;
+    std::uint64_t bytes     = 0;
+    std::uint64_t alignment = 0;
+};
+
 struct MaterializationPlan {
     std::size_t object_count            = 0;
     std::uint64_t device_capacity_bytes = 0;
+    // Size of the arena suffix holding every evict-ranked tensor. The suffix
+    // begin is aligned to the alignment passed to Binder::finish, so a VMM pool
+    // can evict whole chunks without touching resident objects. Zero when no
+    // tensor carries an evict rank.
+    std::uint64_t evictable_tail_bytes = 0;
+    std::uint64_t pinned_capacity_bytes = 0;
     std::vector<DeviceMaterialization> device_objects;
     std::vector<HostMaterialization> host_objects;
+    std::vector<PinnedMaterialization> pinned_objects;
 };
 
 class Binder {
@@ -47,17 +66,32 @@ public:
 
     const ObjectDescriptor& descriptor(ObjectHandle handle) const;
     PayloadSpan payload(ObjectHandle handle) const;
-    void materialize_on_device(ObjectHandle handle);
+    // evict_rank 0 keeps the tensor resident for the process lifetime. A nonzero
+    // rank moves it into the arena's evictable tail; higher ranks land closer to
+    // the arena end and are therefore evicted first.
+    void materialize_on_device(ObjectHandle handle, std::uint32_t evict_rank = 0);
+    void materialize_on_host_pinned(ObjectHandle handle);
     void retain_on_host(ObjectHandle handle);
     void validate_only(ObjectHandle handle);
-    MaterializationPlan finish();
+    // evictable_alignment aligns the evictable-tail begin (pass the eviction pool
+    // chunk size; 1 when no pool is used).
+    MaterializationPlan finish(std::uint64_t evictable_alignment = 1);
 
 private:
+    struct PendingEvictable {
+        ObjectHandle handle;
+        std::uint64_t bytes     = 0;
+        std::uint64_t alignment = 0;
+        std::uint32_t rank      = 0;
+        std::size_t sequence    = 0;
+    };
+
     ObjectHandle find_unconsumed(std::string_view name);
 
     const Reader& reader_;
     std::vector<bool> consumed_;
     std::vector<bool> planned_;
+    std::vector<PendingEvictable> evictable_;
     MaterializationPlan materialization_;
 };
 

--- a/src/artifact/materializer.cpp
+++ b/src/artifact/materializer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <stdexcept>
@@ -33,9 +34,19 @@ std::uint64_t align_up(std::uint64_t value, std::uint64_t alignment, const char*
 
 class Slot {
 public:
-    explicit Slot(std::size_t bytes) : buffer(bytes) {
+    // cudaMallocHost only guarantees sub-page alignment once other pinned
+    // allocations exist in the process; direct I/O requires 4096. Over-allocate
+    // and align the staging pointer explicitly.
+    explicit Slot(std::size_t bytes) : buffer(bytes + Reader::direct_io_alignment) {
+        const auto raw = reinterpret_cast<std::uintptr_t>(buffer.data());
+        const auto aligned =
+            (raw + Reader::direct_io_alignment - 1) / Reader::direct_io_alignment *
+            Reader::direct_io_alignment;
+        aligned_data = reinterpret_cast<std::byte*>(aligned);
         CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
     }
+
+    [[nodiscard]] std::byte* data() const noexcept { return aligned_data; }
 
     ~Slot() {
         if (pending) { (void)cudaEventSynchronize(event); }
@@ -50,8 +61,9 @@ public:
     }
 
     PinnedHostBuffer buffer;
-    cudaEvent_t event = nullptr;
-    bool pending      = false;
+    std::byte* aligned_data = nullptr;
+    cudaEvent_t event       = nullptr;
+    bool pending            = false;
 };
 
 struct CopyRange {
@@ -72,6 +84,32 @@ void* MaterializedArtifact::device_data(ObjectHandle handle) const {
         throw ArtifactError("object handle does not name a materialized tensor");
     }
     return objects_[handle.index].device;
+}
+
+void* MaterializedArtifact::storage_data(ObjectHandle handle) const {
+    if (handle.index >= objects_.size()) {
+        throw ArtifactError("object handle does not name a materialized tensor");
+    }
+    const ObjectStorage& storage = objects_[handle.index];
+    if (storage.device != nullptr) { return storage.device; }
+    if (storage.pinned != nullptr) { return storage.pinned; }
+    throw ArtifactError("object handle does not name a materialized tensor");
+}
+
+bool MaterializedArtifact::is_host_pinned(ObjectHandle handle) const noexcept {
+    return handle.index < objects_.size() && objects_[handle.index].pinned != nullptr;
+}
+
+std::size_t MaterializedArtifact::pinned_offset(ObjectHandle handle) const {
+    if (handle.index >= objects_.size() || objects_[handle.index].pinned == nullptr) {
+        throw ArtifactError("object handle does not name a pinned tensor");
+    }
+    return objects_[handle.index].pinned_offset;
+}
+
+std::span<const std::byte> MaterializedArtifact::pinned_block() const noexcept {
+    if (pinned_block_ == nullptr) { return {}; }
+    return {static_cast<const std::byte*>(pinned_block_->data()), pinned_block_->size()};
 }
 
 std::span<const std::byte> MaterializedArtifact::resource_bytes(ObjectHandle handle) const {
@@ -96,17 +134,46 @@ DeviceArena& MaterializedArtifact::device_arena() {
 }
 
 MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan& plan,
-                                 DeviceContext& device, LoadProgress* progress) {
+                                 DeviceContext& device, LoadProgress* progress,
+                                 std::unique_ptr<EvictableWeightPool> backing_pool) {
     MaterializedArtifact out;
     out.objects_.resize(plan.object_count);
     const std::uint64_t capacity = plan.device_capacity_bytes;
     if (capacity == 0 || capacity > static_cast<std::uint64_t>(SIZE_MAX)) {
         throw ArtifactError("artifact tensor backing size is invalid");
     }
-    out.device_arena_ = std::make_unique<DeviceArena>(static_cast<std::size_t>(capacity));
+    if (backing_pool != nullptr) {
+        const DeviceSpan backing = backing_pool->arena();
+        if (backing.bytes < capacity) {
+            throw ArtifactError("eviction pool arena is smaller than the materialization plan");
+        }
+        out.pool_         = std::move(backing_pool);
+        out.device_arena_ = std::make_unique<DeviceArena>(out.pool_->arena());
+    } else {
+        out.device_arena_ = std::make_unique<DeviceArena>(static_cast<std::size_t>(capacity));
+    }
     out.stats_.device_capacity_bytes = capacity;
-    out.stats_.tensor_count          = plan.device_objects.size();
+    out.stats_.tensor_count          = plan.device_objects.size() + plan.pinned_objects.size();
     out.stats_.resource_count        = plan.host_objects.size();
+
+    if (!plan.pinned_objects.empty()) {
+        out.pinned_block_ = std::make_unique<PinnedHostBuffer>(
+            static_cast<std::size_t>(plan.pinned_capacity_bytes));
+        auto* block = static_cast<std::byte*>(out.pinned_block_->data());
+        for (const PinnedMaterialization& placement : plan.pinned_objects) {
+            const PayloadSpan payload = reader.payload(reader.objects().at(placement.object.index));
+            if (payload.data.size() != placement.bytes) {
+                throw ArtifactError("pinned materialization does not match artifact payload");
+            }
+            std::memcpy(block + placement.offset, payload.data.data(), payload.data.size());
+            auto& storage         = out.objects_.at(placement.object.index);
+            storage.pinned        = block + placement.offset;
+            storage.pinned_offset = static_cast<std::size_t>(placement.offset);
+            out.stats_.pinned_weight_bytes += placement.bytes;
+            out.stats_.file_bytes = checked_add(out.stats_.file_bytes, placement.bytes,
+                                                "artifact read bytes overflow u64");
+        }
+    }
 
     for (const HostMaterialization& placement : plan.host_objects) {
         auto& resource            = out.objects_.at(placement.object.index).resource;
@@ -196,7 +263,7 @@ MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan
                 slot_bytes,
                 align_up(remaining, alignment, "artifact direct I/O request overflows u64")));
             auto destination =
-                std::span<std::byte>(static_cast<std::byte*>(slot.buffer.data()), request);
+                std::span<std::byte>(slot.data(), request);
             const std::size_t bytes_read = reader.read_direct(source, destination);
             const std::uint64_t required = std::min<std::uint64_t>(request, remaining);
             if (bytes_read < required) {
@@ -220,8 +287,7 @@ MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan
                     CUDA_CHECK(cudaMemcpyAsync(
                         range.destination +
                             static_cast<std::size_t>(copy_begin - range.source_begin),
-                        static_cast<std::byte*>(slot.buffer.data()) +
-                            static_cast<std::size_t>(copy_begin - source),
+                        slot.data() + static_cast<std::size_t>(copy_begin - source),
                         amount, cudaMemcpyHostToDevice, device.load_stream));
                     copied =
                         checked_add(copied, amount, "artifact copied byte count overflows u64");

--- a/src/artifact/materializer.h
+++ b/src/artifact/materializer.h
@@ -3,6 +3,7 @@
 #include "artifact/binder.h"
 #include "core/arena.h"
 #include "core/device.h"
+#include "core/evictable_weight_pool.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -23,6 +24,7 @@ struct MaterializationStats {
     std::uint64_t h2d_bytes               = 0;
     std::uint64_t device_capacity_bytes   = 0;
     std::uint64_t retained_resource_bytes = 0;
+    std::uint64_t pinned_weight_bytes     = 0;
     std::uint64_t peak_staging_bytes      = 0;
     std::size_t tensor_count              = 0;
     std::size_t resource_count            = 0;
@@ -39,28 +41,45 @@ public:
     MaterializedArtifact& operator=(const MaterializedArtifact&)     = delete;
 
     void* device_data(ObjectHandle handle) const;
+    // Device pointer for device objects, pinned-host pointer for HostPinned
+    // objects. Bindings that may describe either residency use this accessor.
+    void* storage_data(ObjectHandle handle) const;
+    [[nodiscard]] bool is_host_pinned(ObjectHandle handle) const noexcept;
+    std::size_t pinned_offset(ObjectHandle handle) const;
+    [[nodiscard]] std::span<const std::byte> pinned_block() const noexcept;
     std::span<const std::byte> resource_bytes(ObjectHandle handle) const;
     std::vector<std::byte> take_resource_bytes(ObjectHandle handle);
 
     const MaterializationStats& stats() const noexcept { return stats_; }
 
     DeviceArena& device_arena();
+    // Present only when the arena is backed by an eviction pool (overlay mode).
+    [[nodiscard]] EvictableWeightPool* eviction_pool() const noexcept { return pool_.get(); }
 
 private:
     friend MaterializedArtifact materialize(const Reader&, const MaterializationPlan&,
-                                            DeviceContext&, LoadProgress*);
+                                            DeviceContext&, LoadProgress*,
+                                            std::unique_ptr<EvictableWeightPool>);
 
     struct ObjectStorage {
-        void* device = nullptr;
+        void* device        = nullptr;
+        void* pinned        = nullptr;
+        std::size_t pinned_offset = 0;
         std::vector<std::byte> resource;
     };
 
+    std::unique_ptr<EvictableWeightPool> pool_;
     std::unique_ptr<DeviceArena> device_arena_;
+    std::unique_ptr<PinnedHostBuffer> pinned_block_;
     std::vector<ObjectStorage> objects_;
     MaterializationStats stats_;
 };
 
+// backing_pool, when provided, supplies the device arena storage and is owned by
+// the returned artifact; its tail mirror is NOT captured here — the caller
+// captures it once the upload stream is synchronized.
 MaterializedArtifact materialize(const Reader& reader, const MaterializationPlan& plan,
-                                 DeviceContext& device, LoadProgress* progress = nullptr);
+                                 DeviceContext& device, LoadProgress* progress = nullptr,
+                                 std::unique_ptr<EvictableWeightPool> backing_pool = nullptr);
 
 } // namespace ninfer::artifact

--- a/src/artifact/typed_binding.cpp
+++ b/src/artifact/typed_binding.cpp
@@ -69,7 +69,7 @@ DType dtype_for(NumericFormat format) {
 Weight contiguous_weight(const MaterializedArtifact& materialized, ObjectHandle handle,
                          NumericFormat format, std::int32_t rows, std::int32_t columns) {
     Weight out{};
-    out.payload       = materialized.device_data(handle);
+    out.payload       = materialized.storage_data(handle);
     out.qdata         = out.payload;
     out.payload_bytes = static_cast<std::uint64_t>(rows) * columns * dtype_size(dtype_for(format));
     out.qtype         = qtype_for(format);
@@ -89,7 +89,7 @@ Weight row_split_weight(const MaterializedArtifact& materialized, ObjectHandle h
     const std::array<std::uint64_t, 2> shape = {static_cast<std::uint64_t>(rows),
                                                 static_cast<std::uint64_t>(columns)};
     const RowSplitGeometry geometry          = row_split_geometry(format, shape);
-    const auto* bytes = static_cast<const std::byte*>(materialized.device_data(handle));
+    const auto* bytes = static_cast<const std::byte*>(materialized.storage_data(handle));
 
     Weight out{};
     out.payload          = bytes;
@@ -148,14 +148,21 @@ Weight row_scale_weight(const MaterializedArtifact& materialized, ObjectHandle h
 } // namespace
 
 ObjectHandle bind_tensor(Binder& binder, std::string_view name, NumericFormat format,
-                         std::initializer_list<std::uint64_t> shape, TensorPlacement placement) {
+                         std::initializer_list<std::uint64_t> shape, TensorPlacement placement,
+                         std::uint32_t evict_rank) {
     const ObjectHandle handle =
         binder.require_tensor(name, format, storage_layout_for(format),
                               std::span<const std::uint64_t>(shape.begin(), shape.size()));
-    if (placement == TensorPlacement::Device) {
-        binder.materialize_on_device(handle);
-    } else {
+    switch (placement) {
+    case TensorPlacement::Device:
+        binder.materialize_on_device(handle, evict_rank);
+        break;
+    case TensorPlacement::HostPinned:
+        binder.materialize_on_host_pinned(handle);
+        break;
+    case TensorPlacement::ValidateOnly:
         binder.validate_only(handle);
+        break;
     }
     return handle;
 }
@@ -174,7 +181,7 @@ ObjectHandle bind_raw_resource(Binder& binder, std::string_view name) {
 Tensor materialized_tensor(const MaterializedArtifact& materialized, ObjectHandle handle,
                            NumericFormat format,
                            std::initializer_list<std::int32_t> internal_shape) {
-    return Tensor(materialized.device_data(handle), dtype_for(format), internal_shape);
+    return Tensor(materialized.storage_data(handle), dtype_for(format), internal_shape);
 }
 
 Weight materialized_weight(const MaterializedArtifact& materialized, ObjectHandle handle,

--- a/src/artifact/typed_binding.h
+++ b/src/artifact/typed_binding.h
@@ -11,9 +11,11 @@ namespace ninfer::artifact {
 
 class MaterializedArtifact;
 
+// evict_rank applies to Device placement only: nonzero ranks move the tensor
+// into the arena's evictable tail (higher rank == evicted earlier).
 [[nodiscard]] ObjectHandle bind_tensor(Binder& binder, std::string_view name, NumericFormat format,
                                        std::initializer_list<std::uint64_t> shape,
-                                       TensorPlacement placement);
+                                       TensorPlacement placement, std::uint32_t evict_rank = 0);
 
 [[nodiscard]] ObjectHandle bind_device_tensor(Binder& binder, std::string_view name,
                                               NumericFormat format,

--- a/src/core/evictable_weight_pool.cu
+++ b/src/core/evictable_weight_pool.cu
@@ -1,0 +1,254 @@
+#include "core/evictable_weight_pool.h"
+
+#include "core/device.h"
+
+#include <cuda.h>
+
+#include <algorithm>
+#include <chrono>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace ninfer {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+void cu_check(CUresult result, const char* expr) {
+    if (result == CUDA_SUCCESS) { return; }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    throw std::runtime_error(std::string(expr) + " failed: " +
+                             (name != nullptr ? name : "unknown CUresult"));
+}
+
+#define NINFER_CU_CHECK(expr) ::ninfer::cu_check((expr), #expr)
+
+void ensure_driver_initialized() {
+    static std::once_flag once;
+    std::call_once(once, [] { NINFER_CU_CHECK(cuInit(0)); });
+}
+
+std::size_t align_up(std::size_t value, std::size_t alignment) {
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+} // namespace
+
+struct EvictableWeightPool::Impl {
+    Config config{};
+    std::size_t granularity     = 0;
+    std::size_t arena_reserved  = 0;
+    std::size_t overlay_reserved = 0;
+    std::size_t tail_begin      = 0;   // arena offset of the first evictable chunk
+    CUdeviceptr home            = 0;
+    CUdeviceptr overlay         = 0;
+    // One handle per region piece: [0, tail_begin) in large pieces, the tail in
+    // kChunkBytes chunks. Offsets are arena offsets; the vectors are parallel.
+    std::vector<CUmemGenericAllocationHandle> handles;
+    std::vector<std::size_t> offsets;
+    std::vector<std::size_t> sizes;
+    std::size_t first_tail_piece = 0;
+    std::size_t evicted_pieces   = 0;   // count of evicted pieces at the vector end
+    std::unique_ptr<PinnedHostBuffer> mirror;
+    double last_evict_seconds   = 0.0;
+    double last_restore_seconds = 0.0;
+
+    void map_home(std::size_t piece) {
+        NINFER_CU_CHECK(cuMemMap(home + offsets[piece], sizes[piece], 0, handles[piece], 0));
+        set_access(home + offsets[piece], sizes[piece]);
+    }
+
+    void set_access(CUdeviceptr va, std::size_t bytes) {
+        CUmemAccessDesc access{};
+        access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        access.location.id   = config.device;
+        access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        NINFER_CU_CHECK(cuMemSetAccess(va, bytes, &access, 1));
+    }
+};
+
+bool EvictableWeightPool::supported(int device) {
+    ensure_driver_initialized();
+    CUdevice handle = 0;
+    if (cuDeviceGet(&handle, device) != CUDA_SUCCESS) { return false; }
+    int value = 0;
+    if (cuDeviceGetAttribute(&value, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
+                             handle) != CUDA_SUCCESS) {
+        return false;
+    }
+    return value != 0;
+}
+
+EvictableWeightPool::EvictableWeightPool(const Config& config) : impl_(std::make_unique<Impl>()) {
+    if (config.arena_bytes == 0) {
+        throw std::invalid_argument("evictable pool arena must not be empty");
+    }
+    if (config.evictable_tail_bytes == 0 || config.evictable_tail_bytes > config.arena_bytes) {
+        throw std::invalid_argument("evictable pool tail must be a nonempty arena suffix");
+    }
+    ensure_driver_initialized();
+    Impl& impl  = *impl_;
+    impl.config = config;
+
+    CUmemAllocationProp prop{};
+    prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id   = config.device;
+    NINFER_CU_CHECK(cuMemGetAllocationGranularity(&impl.granularity, &prop,
+                                                  CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    if (kChunkBytes % impl.granularity != 0) {
+        throw std::runtime_error("evictable pool chunk is not a multiple of the VMM granularity");
+    }
+
+    impl.arena_reserved = align_up(config.arena_bytes, kChunkBytes);
+    // Chunk-align INTO the evictable suffix so no chunk ever covers non-evictable bytes.
+    impl.tail_begin = align_up(config.arena_bytes - config.evictable_tail_bytes, kChunkBytes);
+    // Address space is free: reserve overlay VA for the whole evictable tail so
+    // a window may borrow any extent the ladder can supply, regardless of the
+    // planning hint in config.overlay_bytes.
+    impl.overlay_reserved = impl.arena_reserved - impl.tail_begin;
+
+    NINFER_CU_CHECK(cuMemAddressReserve(&impl.home, impl.arena_reserved, kChunkBytes, 0, 0));
+    NINFER_CU_CHECK(cuMemAddressReserve(&impl.overlay, impl.overlay_reserved, kChunkBytes, 0, 0));
+
+    // Non-evictable prefix in large pieces, evictable tail in chunks.
+    constexpr std::size_t kPrefixPiece = 1024ULL * 1024ULL * 1024ULL;
+    std::size_t offset                 = 0;
+    while (offset < impl.tail_begin) {
+        const std::size_t piece = std::min(kPrefixPiece, impl.tail_begin - offset);
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(piece);
+        offset += piece;
+    }
+    impl.first_tail_piece = impl.offsets.size();
+    while (offset < impl.arena_reserved) {
+        impl.offsets.push_back(offset);
+        impl.sizes.push_back(kChunkBytes);
+        offset += kChunkBytes;
+    }
+
+    impl.handles.resize(impl.offsets.size());
+    for (std::size_t piece = 0; piece < impl.offsets.size(); ++piece) {
+        NINFER_CU_CHECK(cuMemCreate(&impl.handles[piece], impl.sizes[piece], &prop, 0));
+        impl.map_home(piece);
+    }
+}
+
+EvictableWeightPool::~EvictableWeightPool() {
+    if (impl_ == nullptr || impl_->home == 0) { return; }
+    Impl& impl = *impl_;
+    for (std::size_t piece = 0; piece < impl.handles.size(); ++piece) {
+        const bool away = impl.evicted_pieces != 0 && piece >= impl.handles.size() -
+                                                                  impl.evicted_pieces;
+        if (away) {
+            const std::size_t rank = piece - (impl.handles.size() - impl.evicted_pieces);
+            (void)cuMemUnmap(impl.overlay + rank * kChunkBytes, impl.sizes[piece]);
+        } else {
+            (void)cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]);
+        }
+        (void)cuMemRelease(impl.handles[piece]);
+    }
+    (void)cuMemAddressFree(impl.home, impl.arena_reserved);
+    (void)cuMemAddressFree(impl.overlay, impl.overlay_reserved);
+}
+
+EvictableWeightPool::EvictableWeightPool(EvictableWeightPool&&) noexcept            = default;
+EvictableWeightPool& EvictableWeightPool::operator=(EvictableWeightPool&&) noexcept = default;
+
+DeviceSpan EvictableWeightPool::arena() const noexcept {
+    return DeviceSpan{reinterpret_cast<void*>(impl_->home), impl_->config.arena_bytes};
+}
+
+std::size_t EvictableWeightPool::evictable_tail_bytes() const noexcept {
+    return impl_->arena_reserved - impl_->tail_begin;
+}
+
+std::size_t EvictableWeightPool::overlay_capacity() const noexcept {
+    return impl_->overlay_reserved;
+}
+
+void EvictableWeightPool::capture_tail_mirror(cudaStream_t stream) {
+    Impl& impl = *impl_;
+    if (impl.mirror != nullptr) {
+        throw std::logic_error("evictable pool tail mirror was already captured");
+    }
+    const std::size_t mirrored = impl.config.arena_bytes - impl.tail_begin;
+    impl.mirror                = std::make_unique<PinnedHostBuffer>(mirrored);
+    CUDA_CHECK(cudaMemcpyAsync(impl.mirror->data(),
+                               reinterpret_cast<void*>(impl.home + impl.tail_begin), mirrored,
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+std::byte* EvictableWeightPool::evict(std::size_t bytes, std::size_t* mapped_bytes) {
+    Impl& impl = *impl_;
+    if (impl.mirror == nullptr) {
+        throw std::logic_error("evictable pool has no tail mirror; capture it after load");
+    }
+    if (impl.evicted_pieces != 0) {
+        throw std::logic_error("evictable pool transaction is already open");
+    }
+    if (bytes == 0) { throw std::invalid_argument("evictable pool cannot evict zero bytes"); }
+    const std::size_t chunks = (bytes + kChunkBytes - 1) / kChunkBytes;
+    const std::size_t extent = chunks * kChunkBytes;
+    if (extent > impl.overlay_reserved || extent > impl.arena_reserved - impl.tail_begin) {
+        throw std::invalid_argument("evictable pool request exceeds tail or overlay capacity: " +
+                                    std::to_string(bytes) + " bytes");
+    }
+    const auto start        = Clock::now();
+    const std::size_t first = impl.handles.size() - chunks;
+    for (std::size_t rank = 0; rank < chunks; ++rank) {
+        const std::size_t piece = first + rank;
+        NINFER_CU_CHECK(cuMemUnmap(impl.home + impl.offsets[piece], impl.sizes[piece]));
+        NINFER_CU_CHECK(
+            cuMemMap(impl.overlay + rank * kChunkBytes, impl.sizes[piece], 0,
+                     impl.handles[piece], 0));
+        impl.set_access(impl.overlay + rank * kChunkBytes, impl.sizes[piece]);
+    }
+    impl.evicted_pieces     = chunks;
+    impl.last_evict_seconds = std::chrono::duration<double>(Clock::now() - start).count();
+    if (mapped_bytes != nullptr) { *mapped_bytes = extent; }
+    return reinterpret_cast<std::byte*>(impl.overlay);
+}
+
+void EvictableWeightPool::restore(cudaStream_t stream) {
+    Impl& impl = *impl_;
+    if (impl.evicted_pieces == 0) { return; }
+    const auto start         = Clock::now();
+    const std::size_t chunks = impl.evicted_pieces;
+    const std::size_t first  = impl.handles.size() - chunks;
+    for (std::size_t rank = 0; rank < chunks; ++rank) {
+        const std::size_t piece = first + rank;
+        NINFER_CU_CHECK(cuMemUnmap(impl.overlay + rank * kChunkBytes, impl.sizes[piece]));
+        impl.map_home(piece);
+    }
+    // Only bytes below arena_bytes ever hold weights; the aligned slack stays untouched.
+    const std::size_t evicted_begin = impl.offsets[first];
+    const std::size_t evicted_end   = std::min(impl.config.arena_bytes, impl.arena_reserved);
+    if (evicted_end > evicted_begin) {
+        const std::size_t upload = evicted_end - evicted_begin;
+        CUDA_CHECK(cudaMemcpyAsync(
+            reinterpret_cast<void*>(impl.home + evicted_begin),
+            static_cast<const std::byte*>(impl.mirror->data()) +
+                (evicted_begin - impl.tail_begin),
+            upload, cudaMemcpyHostToDevice, stream));
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    impl.evicted_pieces       = 0;
+    impl.last_restore_seconds = std::chrono::duration<double>(Clock::now() - start).count();
+}
+
+bool EvictableWeightPool::evicted() const noexcept { return impl_->evicted_pieces != 0; }
+
+double EvictableWeightPool::last_evict_seconds() const noexcept {
+    return impl_->last_evict_seconds;
+}
+
+double EvictableWeightPool::last_restore_seconds() const noexcept {
+    return impl_->last_restore_seconds;
+}
+
+} // namespace ninfer

--- a/src/core/evictable_weight_pool.h
+++ b/src/core/evictable_weight_pool.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "core/arena.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace ninfer {
+
+// VMM-backed weight arena whose tail region can be temporarily evicted: the physical
+// chunks behind the arena suffix are unmapped from their stable home addresses and
+// remapped into a reserved overlay range, giving the caller device memory without a
+// single new allocation. restore() remaps the chunks home and re-uploads the evicted
+// extent from a pinned host mirror captured after the weights landed.
+//
+// The caller owns quiescing: evict()/restore() require that no GPU work touching the
+// arena is in flight. The transaction is deterministic — every byte it hands out is
+// backed by pages this pool already owns, so restore cannot fail with an allocation
+// error.
+class EvictableWeightPool {
+public:
+    struct Config {
+        std::size_t arena_bytes          = 0;   // weights arena capacity
+        std::size_t evictable_tail_bytes = 0;   // chunk-aligned suffix that may be evicted
+        std::size_t overlay_bytes        = 0;   // staging the window needs mapped at once
+        int device                       = 0;
+    };
+
+    static constexpr std::size_t kChunkBytes = 16ULL * 1024ULL * 1024ULL;
+
+    [[nodiscard]] static bool supported(int device);
+
+    explicit EvictableWeightPool(const Config& config);
+    ~EvictableWeightPool();
+
+    EvictableWeightPool(const EvictableWeightPool&)            = delete;
+    EvictableWeightPool& operator=(const EvictableWeightPool&) = delete;
+    EvictableWeightPool(EvictableWeightPool&&) noexcept;
+    EvictableWeightPool& operator=(EvictableWeightPool&&) noexcept;
+
+    // Stable home mapping backing the weights arena for the process lifetime.
+    [[nodiscard]] DeviceSpan arena() const noexcept;
+    [[nodiscard]] std::size_t chunk_bytes() const noexcept { return kChunkBytes; }
+    [[nodiscard]] std::size_t evictable_tail_bytes() const noexcept;
+    [[nodiscard]] std::size_t overlay_capacity() const noexcept;
+
+    // Capture the pinned mirror of the evictable tail after the weights upload
+    // completed. Must be called exactly once before the first evict().
+    void capture_tail_mirror(cudaStream_t stream);
+
+    // Unmap ceil(bytes / chunk) chunks from the arena end and map the same physical
+    // pages contiguously (home order) at overlay_base(). Returns the mapped extent.
+    // Requires a captured mirror and no in-flight GPU work on the arena.
+    std::byte* evict(std::size_t bytes, std::size_t* mapped_bytes);
+
+    // Remap every evicted chunk home and re-upload the evicted extent from the
+    // mirror; synchronizes the stream. Safe to call when nothing is evicted.
+    void restore(cudaStream_t stream);
+
+    [[nodiscard]] bool evicted() const noexcept;
+
+    // Wall-clock costs of the most recent transaction, for telemetry.
+    [[nodiscard]] double last_evict_seconds() const noexcept;
+    [[nodiscard]] double last_restore_seconds() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace ninfer

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -236,6 +236,8 @@ GenerationService::GenerationService(ServeOptions options, LoadProgress load_pro
     engine_options.prefill_chunk            = options_.prefill_chunk;
     engine_options.kv_cache                 = options_.kv_cache;
     engine_options.enable_vision            = options_.enable_vision;
+    engine_options.vision_residency         = options_.vision_residency;
+    engine_options.vision_max_merged_tokens = options_.vision_max_merged_tokens;
     engine_options.use_cuda_graph           = options_.use_cuda_graph;
     engine_options.speculative              = options_.speculative;
     engine_options.media_cache_bytes        = options_.media_cache_bytes;
@@ -382,7 +384,12 @@ GenerationOutcome GenerationService::run(PreparedRequest& prepared, const Stream
     outcome.metrics.ttft_seconds =
         prepared.prepare_seconds +
         std::max(0.0, result.timings.first_token_seconds - result.timings.prepare_seconds);
-    outcome.metrics.vision_seconds  = result.timings.vision_seconds;
+    outcome.metrics.vision_seconds          = result.timings.vision_seconds;
+    outcome.metrics.overlay_window_seconds  = result.timings.overlay_window_seconds;
+    outcome.metrics.overlay_evict_seconds   = result.timings.overlay_evict_seconds;
+    outcome.metrics.overlay_restore_seconds = result.timings.overlay_restore_seconds;
+    outcome.metrics.overlay_evicted_bytes   = result.timings.overlay_evicted_bytes;
+    outcome.metrics.overlay_staged_bytes    = result.timings.overlay_staged_bytes;
     outcome.metrics.prefill_seconds = result.timings.prefill_seconds;
     outcome.metrics.decode_seconds  = result.timings.decode_seconds;
     outcome.metrics.total_seconds =

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -38,6 +38,11 @@ struct GenerationMetrics {
     std::vector<std::uint64_t> speculative_accepted_per_position;
     std::uint32_t prefix_cache_hit_tokens     = 0;
     ninfer::PrefixReusePath prefix_reuse_path = ninfer::PrefixReusePath::FullReset;
+    double overlay_window_seconds             = 0.0;
+    double overlay_evict_seconds              = 0.0;
+    double overlay_restore_seconds            = 0.0;
+    std::uint64_t overlay_evicted_bytes       = 0;
+    std::uint64_t overlay_staged_bytes        = 0;
 };
 
 struct GenerationOutcome {

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -397,6 +397,13 @@ std::string format_request_done(const RequestLogContext& context,
         << " decode=" << rate(decode_tokens, metrics.decode_seconds)
         << " wall=" << seconds_str(metrics.total_seconds)
         << " speculative=" << speculative_str(metrics);
+    if (metrics.overlay_window_seconds > 0.0) {
+        out << " overlay=" << std::setprecision(0) << metrics.overlay_window_seconds * 1000.0
+            << "ms (evict " << metrics.overlay_evicted_bytes / (1024 * 1024) << "MiB "
+            << std::setprecision(1) << metrics.overlay_evict_seconds * 1000.0 << "ms, restore "
+            << metrics.overlay_restore_seconds * 1000.0 << "ms, staged "
+            << metrics.overlay_staged_bytes / (1024 * 1024) << "MiB)";
+    }
     return out.str();
 }
 

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -73,7 +73,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--response-store-max-records N] [--response-store-max-mib N] "
            "[--kv-dtype bf16|int8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] "
-           "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
+           "[--vision] [--vision-residency resident|overlay] [--vision-max-merged N] [--no-cuda-graph] [--no-prefix-reuse] "
            "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -91,6 +91,10 @@ std::string serve_usage_text(const char* argv0) {
            "default\n"
            "       --log-stats-interval-ms defaults to 5000; 0 disables periodic throughput logs\n"
            "       --vision enables media and loads the fixed Vision GPU allocations\n"
+           "       --vision-residency overlay keeps Vision weights in pinned host memory\n"
+           "         and encodes images through device memory temporarily borrowed from\n"
+           "         evicted read-only text weights; resident (default) is the fixed\n"
+           "         device allocation\n"
            "       --kv-capacity auto leaves " +
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
            " MiB of sizing headroom\n"
@@ -223,6 +227,23 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             default_max_tokens_explicit = true;
         } else if (arg == "--vision") {
             options.enable_vision = true;
+        } else if (arg == "--vision-max-merged") {
+            const int value =
+                parse_nonnegative_int(require_value("--vision-max-merged"), "vision-max-merged");
+            if (value < 64 || value > 32768) {
+                throw std::invalid_argument("--vision-max-merged must be in [64, 32768]");
+            }
+            options.vision_max_merged_tokens = static_cast<std::uint32_t>(value);
+        } else if (arg == "--vision-residency") {
+            const std::string_view value = require_value("--vision-residency");
+            if (value == "resident") {
+                options.vision_residency = ninfer::VisionResidency::Resident;
+            } else if (value == "overlay") {
+                options.vision_residency = ninfer::VisionResidency::Overlay;
+            } else {
+                throw std::invalid_argument(
+                    "--vision-residency accepts resident or overlay");
+            }
         } else if (arg == "--no-cuda-graph") {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
@@ -290,6 +311,9 @@ ServeOptions parse_serve_options(int argc, char** argv) {
     product::validate_speculative_cli_options(options.speculative);
     if (options.speculative.backend == SpeculativeBackend::DFlash && options.enable_vision) {
         throw std::invalid_argument("--spec dflash cannot be combined with --vision");
+    }
+    if (options.vision_residency == ninfer::VisionResidency::Overlay && !options.enable_vision) {
+        throw std::invalid_argument("--vision-residency overlay requires --vision");
     }
     if (default_max_tokens_explicit) {
         if (options.default_max_tokens <= 0) {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -43,6 +43,8 @@ struct ServeOptions {
     KvCacheStorage kv_cache                = KvCacheStorage::BFloat16;
     SpeculativeOptions speculative;
     bool enable_vision      = false;
+    ninfer::VisionResidency vision_residency = ninfer::VisionResidency::Resident;
+    std::uint32_t vision_max_merged_tokens   = 32768;
     bool use_cuda_graph     = true;
     bool allow_prefix_reuse = true;
     bool enable_thinking =

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/frontend.h
@@ -20,6 +20,9 @@ struct FrontendOptions {
     std::size_t media_cache_bytes          = kDefaultMediaCacheBytes;
     std::size_t media_live_bytes           = kDefaultMediaLiveBytes;
     std::uint32_t media_preprocess_threads = 0;
+    // Per-item merged-token budget: images and videos are downscaled at preprocessing so one
+    // item never expands past this many merged Vision tokens (0 keeps the artifact ceiling).
+    std::uint32_t vision_max_merged_tokens = 32768;
 };
 
 struct FrontendResources;

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/model_view.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/model_view.h
@@ -98,6 +98,7 @@ struct ModelView {
     std::optional<MtpLayer> mtp;
     std::optional<DFlashPayload> dflash;
     std::optional<VisionWeights> vision;
+    std::optional<VisionOverlayAssets> vision_overlay;
 };
 
 } // namespace targets::qwen3_6

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
@@ -6,6 +6,7 @@ namespace ninfer::targets::qwen3_6 {
 
 struct StartupFeatures {
     bool vision                    = false;
+    bool overlay_vision            = false;
     SpeculativeBackend speculative = SpeculativeBackend::None;
     ProposalHead proposal_head     = ProposalHead::Full;
 
@@ -26,9 +27,11 @@ struct StartupFeatures {
 
 [[nodiscard]] inline StartupFeatures startup_features(const EngineOptions& options) noexcept {
     return StartupFeatures{
-        .vision        = options.enable_vision,
-        .speculative   = options.speculative.backend,
-        .proposal_head = options.speculative.proposal_head,
+        .vision         = options.enable_vision,
+        .overlay_vision = options.enable_vision &&
+                          options.vision_residency == VisionResidency::Overlay,
+        .speculative    = options.speculative.backend,
+        .proposal_head  = options.speculative.proposal_head,
     };
 }
 

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/vision.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/vision.h
@@ -6,8 +6,13 @@
 #include <array>
 #include <cstddef>
 
+namespace ninfer {
+class EvictableWeightPool;
+}
+
 namespace ninfer::artifact {
 class MaterializedArtifact;
+struct MaterializationPlan;
 }
 
 namespace ninfer::targets::qwen3_6 {
@@ -91,6 +96,35 @@ struct VisionWeights {
     Weight merger_fc2;
     Tensor merger_fc2_bias;
 };
+
+// Byte ranges of the vision groups inside the pinned weight block, used by the
+// overlay window to stage weights through borrowed device memory. Ranges are
+// contiguous by binding order; slot_bytes is the largest single layer range.
+struct VisionOverlayLayout {
+    std::size_t prelude_begin = 0;   // patch embedding .. position embedding
+    std::size_t prelude_bytes = 0;
+    std::array<std::size_t, VisionBackboneConfig::layers> layer_begin{};
+    std::array<std::size_t, VisionBackboneConfig::layers> layer_bytes{};
+    std::size_t merger_begin = 0;    // merger fc1 .. merger norm bias
+    std::size_t merger_bytes = 0;
+    std::size_t slot_bytes    = 0;
+    std::size_t staging_bytes = 0;   // prelude + merger + two layer slots, aligned
+};
+
+// Runtime assets the overlay window needs, published on the model view when the
+// engine runs with VisionResidency::Overlay.
+struct VisionOverlayAssets {
+    ninfer::EvictableWeightPool* pool  = nullptr;
+    const std::byte* pinned_block      = nullptr;
+    std::size_t pinned_bytes           = 0;
+    std::size_t ladder_bytes           = 0;   // evictable tail a window may borrow
+    VisionOverlayLayout layout;
+};
+
+[[nodiscard]] VisionOverlayLayout compute_vision_overlay_layout(
+    const VisionBackbonePlan& backbone, const VisionMergerInputPlan& merger_input,
+    artifact::ObjectHandle merger_fc2, artifact::ObjectHandle merger_fc2_bias,
+    const VisionMergerNormPlan& merger_norm, const artifact::MaterializationPlan& plan);
 
 [[nodiscard]] VisionBackbonePlan bind_vision_backbone(artifact::Binder& binder,
                                                       artifact::TensorPlacement placement);

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -141,7 +141,8 @@ void validate_pixel_pipeline(const Json& config, std::string_view resource) {
     }
 }
 
-fi::ProcessorOptions processor_options(const FrontendResources& resources) {
+fi::ProcessorOptions processor_options(const FrontendResources& resources,
+                                       std::uint32_t vision_max_merged_tokens) {
     const Json image =
         parse_resource_json(resources.preprocessor_config_json, "preprocessor_config.json");
     const Json video = parse_resource_json(resources.video_preprocessor_config_json,
@@ -165,6 +166,16 @@ fi::ProcessorOptions processor_options(const FrontendResources& resources) {
     options.video_max_pixels = positive_u64(
         require_integer(video_size, "longest_edge", "video_preprocessor_config.json.size"),
         "video longest_edge");
+    if (vision_max_merged_tokens != 0) {
+        // Fit-and-scale: bound each item's merged tokens by shrinking the resize ceiling, so an
+        // oversized source downscales instead of being rejected at admission.
+        options.image_max_pixels = std::min(
+            options.image_max_pixels,
+            vision_max_merged_tokens * fi::merged_token_image_pixels());
+        options.video_max_pixels = std::min(
+            options.video_max_pixels,
+            vision_max_merged_tokens * fi::merged_token_video_pixels());
+    }
     options.video_fps =
         number_or_default(video, "fps", "video_preprocessor_config.json", kVideoFps);
     options.video_min_frames = static_cast<int>(
@@ -600,7 +611,8 @@ public:
               fi::TokenizerResources{.tokenizer_json         = resources.tokenizer_json,
                                      .tokenizer_config_json  = resources.tokenizer_config_json,
                                      .generation_config_json = resources.generation_config_json})),
-          processor(processor_options(resources)), vision_enabled(options.vision_enabled) {
+          processor(processor_options(resources, options.vision_max_merged_tokens)),
+          vision_enabled(options.vision_enabled) {
         if (options.max_context == 0) {
             throw std::invalid_argument("frontend max_context must be nonzero");
         }

--- a/src/targets/qwen3_6/impl/frontend/processor.cpp
+++ b/src/targets/qwen3_6/impl/frontend/processor.cpp
@@ -61,6 +61,18 @@ std::uint64_t checked_mul(std::uint64_t a, std::uint64_t b, std::string_view lab
 
 int round_even(double value) { return static_cast<int>(std::nearbyint(value)); }
 
+} // namespace
+
+std::uint64_t merged_token_image_pixels() {
+    return static_cast<std::uint64_t>(kFactor) * kFactor;
+}
+
+std::uint64_t merged_token_video_pixels() {
+    return static_cast<std::uint64_t>(kTemporal) * kFactor * kFactor;
+}
+
+namespace {
+
 Size smart_resize_image(int height, int width, std::uint64_t min_pixels, std::uint64_t max_pixels) {
     if (height <= 0 || width <= 0 || min_pixels == 0 || max_pixels < min_pixels) {
         throw std::invalid_argument("invalid image resize configuration");

--- a/src/targets/qwen3_6/impl/frontend/processor.h
+++ b/src/targets/qwen3_6/impl/frontend/processor.h
@@ -81,6 +81,11 @@ struct PreprocessStats {
     [[nodiscard]] std::string summary() const;
 };
 
+// Pixel cost of one merged Vision token, for converting a merged-token budget into the
+// smart-resize pixel ceilings.
+[[nodiscard]] std::uint64_t merged_token_image_pixels();
+[[nodiscard]] std::uint64_t merged_token_video_pixels();
+
 struct ProcessorOptions {
     std::uint64_t image_min_pixels = 32ULL * 32ULL;
     std::uint64_t image_max_pixels = 1024ULL * 1024ULL;

--- a/src/targets/qwen3_6/impl/runtime/instantiate.h
+++ b/src/targets/qwen3_6/impl/runtime/instantiate.h
@@ -15,6 +15,7 @@
 #include "targets/qwen3_6/impl/runtime/layouts_impl.h"
 #include "targets/qwen3_6/impl/runtime/dflash_context_impl.h"
 #include "targets/qwen3_6/impl/runtime/text_context_impl.h"
+#include "targets/qwen3_6/impl/runtime/vision_overlay_impl.h"
 #include "targets/qwen3_6/impl/runtime/vision_context_impl.h"
 #include "targets/qwen3_6/impl/runtime/text_prefill_impl.h"
 #include "targets/qwen3_6/impl/runtime/graph_impl.h"

--- a/src/targets/qwen3_6/impl/runtime/layouts.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts.h
@@ -70,6 +70,7 @@ struct SequencePlanningInputs {
     std::int32_t kv_quant_group            = 0;
     ProposalHead proposal_head             = ProposalHead::Full;
     StartupFeatures features;
+    std::uint32_t vision_max_merged = 32768;
     bool use_cuda_graph = true;
     int device          = 0;
 };
@@ -92,6 +93,7 @@ struct SequencePlanImpl<NINFER_QWEN36_VARIANT> {
     std::int32_t kv_quant_group            = 0;
     ProposalHead proposal_head             = ProposalHead::Full;
     StartupFeatures features;
+    std::uint32_t vision_max_merged = 32768;
     bool use_cuda_graph = true;
     int device          = 0;
     NINFER_QWEN36_RUNTIME_NS::PersistentLayout persistent;

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -525,13 +525,18 @@ WorkspacePlan build_workspace_plan(const SequencePlanImpl& plan) {
     if (plan.features.vision) {
         constexpr std::uint32_t kFrontendMergedLimit  = 32768;
         constexpr std::uint32_t kFrontendSegmentLimit = 768 / 2;
-        const std::uint32_t merged = std::min(plan.capacity, kFrontendMergedLimit);
-        out.vision_encode          = schedule::VisionContext::workspace_capacity_bytes(
+        const std::uint32_t merged =
+            std::min({plan.capacity, kFrontendMergedLimit, plan.vision_max_merged});
+        out.vision_encode = schedule::VisionContext::workspace_capacity_bytes(
             merged, std::min(merged, kFrontendSegmentLimit));
     }
 
+    // Overlay residency serves the vision-encode workspace from device memory
+    // borrowed inside the window, so it does not reserve resident capacity.
+    const std::size_t resident_vision =
+        plan.features.overlay_vision ? 0 : out.vision_encode;
     out.capacity = std::max({out.text_prefill, out.ordinary_round, out.mtp_prefill, out.mtp_round,
-                             out.dflash_context, out.dflash_round, out.vision_encode});
+                             out.dflash_context, out.dflash_round, resident_vision});
     return out;
 }
 
@@ -619,6 +624,7 @@ std::unique_ptr<SequencePlanImpl> build_sequence_candidate(const SequencePlannin
     impl->speculative_backend = inputs.speculative_backend;
     impl->proposal_head       = inputs.proposal_head;
     impl->features            = inputs.features;
+    impl->vision_max_merged   = inputs.vision_max_merged;
     impl->use_cuda_graph      = inputs.use_cuda_graph;
     impl->device              = inputs.device;
     impl->kv_dtype            = inputs.kv_dtype;
@@ -627,7 +633,8 @@ std::unique_ptr<SequencePlanImpl> build_sequence_candidate(const SequencePlannin
     impl->workspace           = build_workspace_plan(*impl);
     if (impl->features.vision) {
         constexpr std::uint32_t kFrontendMergedLimit = 32768;
-        const std::uint32_t merged = std::min(impl->capacity, kFrontendMergedLimit);
+        const std::uint32_t merged =
+            std::min({impl->capacity, kFrontendMergedLimit, impl->vision_max_merged});
         impl->request_transient_capacity_bytes =
             schedule::VisionContext::output_transient_bytes(merged);
     }
@@ -699,6 +706,7 @@ make_sequence_planner_impl(DeviceContext& device, const EngineOptions& options,
         .kv_quant_group = options.kv_cache == KvCacheStorage::BFloat16 ? 0 : qwen3_6::kKvQuantGroup,
         .proposal_head  = options.speculative.proposal_head,
         .features       = qwen3_6::startup_features(options),
+        .vision_max_merged = std::max<std::uint32_t>(1, options.vision_max_merged_tokens),
         .use_cuda_graph = options.use_cuda_graph,
         .device         = options.device,
     };

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -251,6 +251,7 @@ public:
     const std::int32_t kv_quant_group;
     const ProposalHead proposal_head;
     const bool vision_enabled;
+    const std::uint32_t vision_max_merged;
     const bool use_cuda_graph;
     const std::size_t kv_payload_bytes;
     const std::size_t graph_allowance_bytes;

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -185,6 +185,7 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
       draft_window(plan.draft_window), speculative_backend(plan.speculative_backend),
       kv_dtype(plan.kv_dtype), kv_quant_group(plan.kv_quant_group),
       proposal_head(plan.proposal_head), vision_enabled(plan.features.vision),
+      vision_max_merged(plan.vision_max_merged),
       use_cuda_graph(plan.use_cuda_graph), kv_payload_bytes(plan.persistent.kv_payload_bytes),
       graph_allowance_bytes(plan.graph_allowance_bytes), workspace_plan(plan.workspace),
       persistent(plan.persistent.bytes), workspace_storage(plan.workspace.capacity),
@@ -624,6 +625,29 @@ runtime::PrefillStepResult ProgramImplCore::start_prefill_lane(std::uint32_t lan
         if (staged.vision_plan) {
             staged.vision = std::make_unique<schedule::VisionPrefillSession>(
                 device, model, work, staged.prompt, *staged.vision_plan, staged.transient);
+            if (model.vision_overlay) {
+                // Exclusive GPU turn: encode the items prefill will actually
+                // consume (spans past the prefix-reuse boundary) through one
+                // overlay window and hand prefill the pinned embeddings.
+                std::size_t first_needed = staged.vision_plan->control->items.size();
+                for (const VisionUseSpan& use : staged.vision_plan->uses) {
+                    if (use.end > base) {
+                        first_needed = std::min<std::size_t>(first_needed, use.item_index);
+                    }
+                }
+                schedule::VisionOverlayWindowStats window_stats{};
+                std::vector<schedule::PinnedVisionResult> preencoded;
+                if (first_needed < staged.vision_plan->control->items.size()) {
+                    preencoded = schedule::encode_items_overlay(
+                        device, model, staged.prompt, *staged.vision_plan, first_needed,
+                        &window_stats);
+                } else {
+                    // Every span is prefix-reused; install null placeholders so the
+                    // session never falls back to host-pointer resident encode.
+                    preencoded.resize(staged.vision_plan->control->items.size());
+                }
+                staged.vision->set_preencoded(std::move(preencoded), window_stats);
+            }
         }
         staged.elapsed_seconds = std::chrono::duration<double>(Clock::now() - started).count();
         request.lifecycle      = Lifecycle::Prefilling;
@@ -1682,6 +1706,14 @@ runtime::PrefillStepResult ProgramImplCore::advance_prefill(SequenceState& seque
         }
         sequence.tail_hidden_valid      = true;
         request.timings.vision_seconds  = vision_seconds;
+        if (staged.vision && staged.vision->overlay_stats()) {
+            const auto& overlay                     = *staged.vision->overlay_stats();
+            request.timings.overlay_window_seconds  = overlay.window_seconds;
+            request.timings.overlay_evict_seconds   = overlay.evict_seconds;
+            request.timings.overlay_restore_seconds = overlay.restore_seconds;
+            request.timings.overlay_evicted_bytes   = overlay.evicted_bytes;
+            request.timings.overlay_staged_bytes    = overlay.staged_bytes;
+        }
         request.timings.prefill_seconds = std::max(0.0, staged.elapsed_seconds - vision_seconds);
         if (rewrite_checkpoint_capture) {
             const std::uint32_t frontier = rewrite_checkpoint_capture->frontier;

--- a/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/request_plan_impl.h
@@ -143,7 +143,20 @@ ProgramImplCore::plan_request_base(const PreparedPromptData& prompt,
             if (end > base->summary.prompt_tokens) {
                 throw std::invalid_argument("vision item consumer span exceeds prompt");
             }
-            if (schedule::VisionContext::workspace_bytes(item) > work.capacity()) {
+            if (item.merged_count > vision_max_merged) {
+                throw std::invalid_argument(
+                    "vision item exceeds the configured vision-max-merged limit");
+            }
+            if (model.vision_overlay) {
+                const std::size_t window_need =
+                    model.vision_overlay->layout.staging_bytes +
+                    schedule::VisionContext::workspace_bytes(item) +
+                    schedule::VisionContext::output_transient_bytes(item.merged_count);
+                if (window_need > model.vision_overlay->ladder_bytes) {
+                    throw std::invalid_argument(
+                        "vision item exceeds the overlay window budget");
+                }
+            } else if (schedule::VisionContext::workspace_bytes(item) > work.capacity()) {
                 throw std::invalid_argument("vision item exceeds the Program workspace envelope");
             }
             previous_end = end;

--- a/src/targets/qwen3_6/impl/runtime/vision_context.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_context.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <span>
 #include <vector>
@@ -40,15 +41,38 @@ struct VisionScheduleConfig {
     static constexpr float norm_eps          = VisionConfig::norm_epsilon;
 };
 
+class VisionWeightStream;
+
+// One vision item's merged embeddings, parked in pinned host memory by an
+// overlay window and re-uploaded into the request transient when prefill
+// consumes the item.
+struct PinnedVisionResult {
+    std::unique_ptr<PinnedHostBuffer> buffer;   // null for prefix-reused items
+    std::size_t bytes = 0;
+};
+
+struct VisionOverlayWindowStats {
+    double window_seconds  = 0.0;
+    double evict_seconds   = 0.0;
+    double restore_seconds = 0.0;
+    std::size_t evicted_bytes = 0;
+    std::size_t staged_bytes  = 0;
+};
+
 class VisionContext {
 public:
     VisionContext(DeviceContext& device, const LoadedModelData& model);
+    // Overlay windows bind against a rebased per-window weight view.
+    VisionContext(DeviceContext& device, const qwen3_6::VisionWeights& weights);
 
     [[nodiscard]] static std::size_t output_transient_bytes(std::size_t merged_tokens);
     [[nodiscard]] static std::size_t workspace_bytes(const qwen3_6::VisionItemControl& item);
     [[nodiscard]] static std::size_t workspace_capacity_bytes(std::uint32_t max_merged_tokens,
                                                               std::uint32_t max_segments);
-    void encode(const VisionItemView& item, Tensor& output, WorkspaceArena& workspace) const;
+    // weight_stream, when set, gates each stage on the streamed uploads of an
+    // overlay window; resident execution passes nullptr.
+    void encode(const VisionItemView& item, Tensor& output, WorkspaceArena& workspace,
+                VisionWeightStream* weight_stream = nullptr) const;
 
 private:
     struct BlockW {
@@ -98,6 +122,14 @@ public:
     [[nodiscard]] VisionChunk prepare_chunk(std::uint32_t begin, std::uint32_t nominal_length);
     void release_encoded_media_payloads() noexcept;
     [[nodiscard]] double elapsed_seconds() const;
+    // Install embeddings produced by an overlay window: prepare_chunk then
+    // uploads them instead of encoding, and the media payload becomes
+    // releasable immediately.
+    void set_preencoded(std::vector<PinnedVisionResult> results,
+                        const VisionOverlayWindowStats& stats);
+    [[nodiscard]] const std::optional<VisionOverlayWindowStats>& overlay_stats() const noexcept {
+        return overlay_stats_;
+    }
 
 private:
     DeviceContext& device_;
@@ -109,6 +141,8 @@ private:
     std::optional<std::uint32_t> active_item_;
     std::vector<std::uint32_t> encoded_payloads_pending_release_;
     std::vector<CudaEventTimer> timers_;
+    std::vector<PinnedVisionResult> preencoded_;
+    std::optional<VisionOverlayWindowStats> overlay_stats_;
 };
 
 } // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
@@ -435,8 +435,6 @@ void VisionPrefillSession::set_preencoded(std::vector<PinnedVisionResult> result
     }
     preencoded_    = std::move(results);
     overlay_stats_ = stats;
-    // The overlay window consumed the media payload for every item.
-    final_item_encoded_ = true;
 }
 
 double VisionPrefillSession::elapsed_seconds() const {

--- a/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_context_impl.h
@@ -132,11 +132,15 @@ void copy_host(const void* src, Tensor& dst, cudaStream_t stream) {
 
 } // namespace
 
-VisionContext::VisionContext(DeviceContext& ctx, const LoadedModelData& weights) : ctx_(ctx) {
-    if (!weights.vision) {
-        throw std::invalid_argument("Vision execution was requested without materialized weights");
-    }
-    const auto& vision = *weights.vision;
+VisionContext::VisionContext(DeviceContext& ctx, const LoadedModelData& weights)
+    : VisionContext(ctx, weights.vision
+                             ? *weights.vision
+                             : throw std::invalid_argument(
+                                   "Vision execution was requested without materialized weights")) {
+}
+
+VisionContext::VisionContext(DeviceContext& ctx, const qwen3_6::VisionWeights& vision)
+    : ctx_(ctx) {
     patch_embed_       = &vision.common.patch_embedding;
     patch_embed_bias_  = &vision.common.patch_embedding_bias;
     position_embed_    = &vision.common.position_embedding;
@@ -194,8 +198,8 @@ std::size_t VisionContext::workspace_capacity_bytes(std::uint32_t max_merged_tok
         .bytes;
 }
 
-void VisionContext::encode(const VisionItemView& item, Tensor& output,
-                           WorkspaceArena& workspace) const {
+void VisionContext::encode(const VisionItemView& item, Tensor& output, WorkspaceArena& workspace,
+                           VisionWeightStream* weight_stream) const {
     if (item.control == nullptr) { throw std::invalid_argument("Vision item control is null"); }
     const qwen3_6::VisionItemControl& control = *item.control;
     const auto patches64                      = control.patch_count;
@@ -232,6 +236,7 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output,
     Tensor x          = layout.x.bind(backing);
     Tensor patch_bf16 = layout.patch_bf16.bind(backing);
     copy_host(item.patches.data(), patch_bf16, stream);
+    if (weight_stream != nullptr) { weight_stream->prelude_ready(stream); }
     ops::linear(patch_bf16, *patch_embed_, x, stream);
     ops::add_bias(*patch_embed_bias_, x, stream);
     // The artifact records the source table shape [rows,hidden], while Tensor's
@@ -241,6 +246,9 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output,
         {VisionScheduleConfig::hidden, VisionScheduleConfig::position_embeddings});
     ops::vision_pos_embed_add(position_table, pos_indices, pos_weights, x, stream);
     for (std::size_t layer = 0; layer < blocks_.size(); ++layer) {
+        if (weight_stream != nullptr) {
+            weight_stream->arrive(static_cast<std::uint32_t>(layer), stream);
+        }
         const BlockW& block = blocks_[layer];
         {
             Tensor attended = layout.attended.bind(backing);
@@ -297,6 +305,7 @@ void VisionContext::encode(const VisionItemView& item, Tensor& output,
         }
     }
 
+    if (weight_stream != nullptr) { weight_stream->merger_ready(stream); }
     Tensor normalized = layout.normalized.bind(backing);
     ops::layer_norm(x, *merger_.norm_weight, *merger_.norm_bias, VisionScheduleConfig::norm_eps,
                     normalized, stream);
@@ -380,18 +389,31 @@ VisionChunk VisionPrefillSession::prepare_chunk(std::uint32_t begin, std::uint32
         if (active_item_ && active->item_index <= *active_item_) {
             throw std::logic_error("Vision items are not consumed in strictly increasing order");
         }
-        const std::size_t patch_elements = checked_mul(
-            control.patch_count, static_cast<std::size_t>(VisionScheduleConfig::patch_dim),
-            "item patch elements");
-        const auto& payload = prompt_.media_payloads[active->item_index];
-        if (!payload || payload->patch_elements != patch_elements) {
-            throw std::invalid_argument("Vision item patch payload has an invalid shape");
+        if (!preencoded_.empty()) {
+            if (active->item_index >= preencoded_.size()) {
+                throw std::logic_error("Vision item has no preencoded overlay embeddings");
+            }
+            const PinnedVisionResult& ready = preencoded_[active->item_index];
+            const std::size_t output_bytes  = output.bytes();
+            if (ready.buffer == nullptr || ready.bytes != output_bytes) {
+                throw std::logic_error("preencoded vision embeddings do not match the item");
+            }
+            CUDA_CHECK(cudaMemcpyAsync(output.data, ready.buffer->data(), ready.bytes,
+                                       cudaMemcpyHostToDevice, device_.stream));
+        } else {
+            const std::size_t patch_elements = checked_mul(
+                control.patch_count, static_cast<std::size_t>(VisionScheduleConfig::patch_dim),
+                "item patch elements");
+            const auto& payload = prompt_.media_payloads[active->item_index];
+            if (!payload || payload->patch_elements != patch_elements) {
+                throw std::invalid_argument("Vision item patch payload has an invalid shape");
+            }
+            timers_.emplace_back(device_);
+            timers_.back().start();
+            context_.encode(VisionItemView{payload->span(), &control}, output, workspace_);
+            timers_.back().record_stop();
+            workspace_.reset();
         }
-        timers_.emplace_back(device_);
-        timers_.back().start();
-        context_.encode(VisionItemView{payload->span(), &control}, output, workspace_);
-        timers_.back().record_stop();
-        workspace_.reset();
         active_item_ = active->item_index;
         encoded_payloads_pending_release_.push_back(active->item_index);
     }
@@ -406,10 +428,21 @@ void VisionPrefillSession::release_encoded_media_payloads() noexcept {
     encoded_payloads_pending_release_.clear();
 }
 
+void VisionPrefillSession::set_preencoded(std::vector<PinnedVisionResult> results,
+                                          const VisionOverlayWindowStats& stats) {
+    if (results.size() != plan_.control->items.size()) {
+        throw std::invalid_argument("preencoded results must cover every vision item");
+    }
+    preencoded_    = std::move(results);
+    overlay_stats_ = stats;
+    // The overlay window consumed the media payload for every item.
+    final_item_encoded_ = true;
+}
+
 double VisionPrefillSession::elapsed_seconds() const {
     double milliseconds = 0.0;
     for (const CudaEventTimer& timer : timers_) { milliseconds += timer.elapsed_ms(); }
-    return milliseconds / 1000.0;
+    return milliseconds / 1000.0 + (overlay_stats_ ? overlay_stats_->window_seconds : 0.0);
 }
 
 } // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
@@ -275,25 +275,20 @@ encode_items_overlay(DeviceContext& device, const LoadedModelData& model,
         for (std::size_t index = first_item; index < plan.control->items.size(); ++index) {
             const qwen3_6::VisionItemControl& control = plan.control->items[index];
             const qwen3_6::VisionItem& source         = prompt.vision_items.at(index);
-            const std::size_t patch_offset =
-                control.patch_begin * static_cast<std::size_t>(VisionScheduleConfig::patch_dim);
             const std::size_t patch_elements =
                 control.patch_count * static_cast<std::size_t>(VisionScheduleConfig::patch_dim);
-            if (source.patch_begin != control.patch_begin ||
-                patch_offset > prompt.patches.size() ||
-                patch_elements > prompt.patches.size() - patch_offset) {
-                throw std::invalid_argument("overlay item patch range exceeds prepared payload");
+            const auto& payload = prompt.media_payloads.at(index);
+            if (source.patch_begin != control.patch_begin || payload == nullptr ||
+                payload->patch_elements != patch_elements) {
+                throw std::invalid_argument("overlay item patch payload has an invalid shape");
             }
             Tensor output(lease_output, DType::BF16,
                           {VisionScheduleConfig::out_hidden,
                            static_cast<std::int32_t>(control.merged_count)});
 
             if (index != first_item) { stream.reset(device.stream); }
-            context.encode(
-                VisionItemView{
-                    std::span<const float>(prompt.patches).subspan(patch_offset, patch_elements),
-                    &control},
-                output, window_workspace, &stream);
+            context.encode(VisionItemView{payload->span(), &control}, output, window_workspace,
+                           &stream);
             window_workspace.reset();
 
             const std::size_t embedding_bytes = output.bytes();

--- a/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/vision_overlay_impl.h
@@ -1,0 +1,323 @@
+#pragma once
+#include "targets/qwen3_6/impl/runtime/instance.h"
+// Qwen3.6 family runtime implementation; instantiated only by exact variants.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_weight_pool.h"
+#include <ninfer/targets/qwen3_6/vision.h>
+#include "targets/qwen3_6/impl/runtime/vision_context.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule {
+namespace overlay_detail {
+
+using OverlayClock = std::chrono::steady_clock;
+
+inline std::size_t staging_align(std::size_t bytes) {
+    constexpr std::size_t kAlign = 256;
+    return (bytes + kAlign - 1) / kAlign * kAlign;
+}
+
+inline std::ptrdiff_t byte_delta(const std::byte* target, const std::byte* source) {
+    return target - source;
+}
+
+inline Tensor rebase(Tensor tensor, std::ptrdiff_t delta) {
+    tensor.data = static_cast<std::byte*>(tensor.data) + delta;
+    return tensor;
+}
+
+inline Weight rebase(Weight weight, std::ptrdiff_t delta) {
+    const auto shift = [delta](const void* pointer) -> const void* {
+        return pointer == nullptr
+                   ? nullptr
+                   : static_cast<const void*>(static_cast<const std::byte*>(pointer) + delta);
+    };
+    weight.payload = shift(weight.payload);
+    weight.qdata   = shift(weight.qdata);
+    weight.qhigh   = shift(weight.qhigh);
+    weight.scales  = shift(weight.scales);
+    return weight;
+}
+
+inline qwen3_6::VisionLayerWeights rebase_layer(const qwen3_6::VisionLayerWeights& source,
+                                                std::ptrdiff_t delta) {
+    qwen3_6::VisionLayerWeights out = source;
+    out.qkv                         = rebase(source.qkv, delta);
+    out.qkv_bias                    = rebase(source.qkv_bias, delta);
+    out.output                      = rebase(source.output, delta);
+    out.output_bias                 = rebase(source.output_bias, delta);
+    out.fc1                         = rebase(source.fc1, delta);
+    out.fc1_bias                    = rebase(source.fc1_bias, delta);
+    out.fc2                         = rebase(source.fc2, delta);
+    out.fc2_bias                    = rebase(source.fc2_bias, delta);
+    out.norm1_weight                = rebase(source.norm1_weight, delta);
+    out.norm1_bias                  = rebase(source.norm1_bias, delta);
+    out.norm2_weight                = rebase(source.norm2_weight, delta);
+    out.norm2_bias                  = rebase(source.norm2_bias, delta);
+    return out;
+}
+
+} // namespace overlay_detail
+
+// Streams vision weights from the pinned block through borrowed device staging:
+// a fixed prelude region (patch/position embedding), a fixed merger region, and
+// two layer slots refilled on the load stream one layer ahead of compute. All
+// synchronization is device-side (events); the host never blocks between
+// layers.
+class VisionWeightStream {
+public:
+    VisionWeightStream(DeviceContext& device, const qwen3_6::VisionOverlayAssets& assets,
+                       std::byte* staging)
+        : device_(device), assets_(assets) {
+        using overlay_detail::staging_align;
+        const qwen3_6::VisionOverlayLayout& layout = assets.layout;
+        prelude_ = staging;
+        merger_  = prelude_ + staging_align(layout.prelude_bytes);
+        slot_[0] = merger_ + staging_align(layout.merger_bytes);
+        slot_[1] = slot_[0] + staging_align(layout.slot_bytes);
+        for (cudaEvent_t& event : uploaded_) {
+            CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+        }
+        CUDA_CHECK(cudaEventCreateWithFlags(&prelude_event_, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventCreateWithFlags(&merger_event_, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventCreateWithFlags(&compute_fence_, cudaEventDisableTiming));
+
+        const std::byte* block = assets.pinned_block;
+        CUDA_CHECK(cudaMemcpyAsync(prelude_, block + layout.prelude_begin, layout.prelude_bytes,
+                                   cudaMemcpyHostToDevice, copy_stream()));
+        CUDA_CHECK(cudaEventRecord(prelude_event_, copy_stream()));
+        CUDA_CHECK(cudaMemcpyAsync(merger_, block + layout.merger_begin, layout.merger_bytes,
+                                   cudaMemcpyHostToDevice, copy_stream()));
+        CUDA_CHECK(cudaEventRecord(merger_event_, copy_stream()));
+        upload_bytes_ = layout.prelude_bytes + layout.merger_bytes;
+        reset(device_.stream);
+    }
+
+    ~VisionWeightStream() {
+        // The window synchronizes the device before restore; events are idle here.
+        for (cudaEvent_t event : uploaded_) { (void)cudaEventDestroy(event); }
+        (void)cudaEventDestroy(prelude_event_);
+        (void)cudaEventDestroy(merger_event_);
+        (void)cudaEventDestroy(compute_fence_);
+    }
+
+    VisionWeightStream(const VisionWeightStream&)            = delete;
+    VisionWeightStream& operator=(const VisionWeightStream&) = delete;
+
+    // Rebased view of the host weights: every layer's tensors point at the slot
+    // that will hold the layer when arrive(layer) admits it.
+    [[nodiscard]] qwen3_6::VisionWeights window_weights(const qwen3_6::VisionWeights& host) const {
+        using overlay_detail::byte_delta;
+        using overlay_detail::rebase;
+        using overlay_detail::rebase_layer;
+        const qwen3_6::VisionOverlayLayout& layout = assets_.layout;
+        const std::byte* block                     = assets_.pinned_block;
+
+        qwen3_6::VisionWeights out = host;
+        const std::ptrdiff_t prelude_delta =
+            byte_delta(prelude_, block + layout.prelude_begin);
+        out.common.patch_embedding      = rebase(host.common.patch_embedding, prelude_delta);
+        out.common.patch_embedding_bias = rebase(host.common.patch_embedding_bias, prelude_delta);
+        out.common.position_embedding   = rebase(host.common.position_embedding, prelude_delta);
+        for (std::size_t layer = 0; layer < host.common.layers.size(); ++layer) {
+            const std::ptrdiff_t delta =
+                byte_delta(slot_[layer % 2], block + layout.layer_begin[layer]);
+            out.common.layers[layer] = rebase_layer(host.common.layers[layer], delta);
+        }
+        const std::ptrdiff_t merger_delta = byte_delta(merger_, block + layout.merger_begin);
+        out.common.merger_fc1             = rebase(host.common.merger_fc1, merger_delta);
+        out.common.merger_fc1_bias        = rebase(host.common.merger_fc1_bias, merger_delta);
+        out.common.merger_norm_weight     = rebase(host.common.merger_norm_weight, merger_delta);
+        out.common.merger_norm_bias       = rebase(host.common.merger_norm_bias, merger_delta);
+        out.merger_fc2                    = rebase(host.merger_fc2, merger_delta);
+        out.merger_fc2_bias               = rebase(host.merger_fc2_bias, merger_delta);
+        return out;
+    }
+
+    // Prepare the next encode pass: uploads of layers 0 and 1 are issued after
+    // everything already submitted on the compute stream (the previous item's
+    // tail layers still own the slots until then).
+    void reset(cudaStream_t compute) {
+        CUDA_CHECK(cudaEventRecord(compute_fence_, compute));
+        CUDA_CHECK(cudaStreamWaitEvent(copy_stream(), compute_fence_, 0));
+        next_upload_ = 0;
+        upload_next_layer();
+        upload_next_layer();
+    }
+
+    void prelude_ready(cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, prelude_event_, 0));
+    }
+
+    void merger_ready(cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, merger_event_, 0));
+    }
+
+    // Called at the top of the encoder loop for `layer`: gates compute on the
+    // slot upload, then refills the slot the previous layer just vacated.
+    void arrive(std::uint32_t layer, cudaStream_t compute) {
+        CUDA_CHECK(cudaStreamWaitEvent(compute, uploaded_[layer % 2], 0));
+        // At this point every op of layers < layer is issued; the fence makes the
+        // copy stream wait for them before refilling the slot that layer-1 held
+        // with layer+1's weights.
+        if (next_upload_ == layer + 1 &&
+            next_upload_ < static_cast<std::uint32_t>(VisionScheduleConfig::layers)) {
+            CUDA_CHECK(cudaEventRecord(compute_fence_, compute));
+            CUDA_CHECK(cudaStreamWaitEvent(copy_stream(), compute_fence_, 0));
+            upload_next_layer();
+        }
+    }
+
+    [[nodiscard]] std::size_t uploaded_bytes() const noexcept { return upload_bytes_; }
+
+private:
+    [[nodiscard]] cudaStream_t copy_stream() const noexcept { return device_.load_stream; }
+
+    void upload_next_layer() {
+        if (next_upload_ >= static_cast<std::uint32_t>(VisionScheduleConfig::layers)) { return; }
+        const std::uint32_t layer = next_upload_++;
+        const qwen3_6::VisionOverlayLayout& layout = assets_.layout;
+        CUDA_CHECK(cudaMemcpyAsync(slot_[layer % 2],
+                                   assets_.pinned_block + layout.layer_begin[layer],
+                                   layout.layer_bytes[layer], cudaMemcpyHostToDevice,
+                                   copy_stream()));
+        CUDA_CHECK(cudaEventRecord(uploaded_[layer % 2], copy_stream()));
+        upload_bytes_ += layout.layer_bytes[layer];
+    }
+
+    DeviceContext& device_;
+    const qwen3_6::VisionOverlayAssets& assets_;
+    std::byte* prelude_       = nullptr;
+    std::byte* merger_        = nullptr;
+    std::byte* slot_[2]       = {nullptr, nullptr};
+    cudaEvent_t uploaded_[2]  = {nullptr, nullptr};
+    cudaEvent_t prelude_event_ = nullptr;
+    cudaEvent_t merger_event_  = nullptr;
+    cudaEvent_t compute_fence_ = nullptr;
+    std::uint32_t next_upload_ = 0;
+    std::size_t upload_bytes_  = 0;
+};
+
+// Encode every vision item of one request inside a single overlay window:
+// evict the staging extent from the weight pool tail, stream the vision tower
+// through it, land each item's merged embeddings in pinned host memory, and
+// restore the evicted text weights before returning. The caller must hold the
+// engine's exclusive GPU execution turn with no other work in flight.
+inline std::vector<PinnedVisionResult>
+encode_items_overlay(DeviceContext& device, const LoadedModelData& model,
+                     qwen3_6::PreparedPromptData& prompt, const VisionPrefillPlan& plan,
+                     std::size_t first_item, VisionOverlayWindowStats* stats) {
+    using overlay_detail::OverlayClock;
+    using overlay_detail::staging_align;
+    if (!model.vision || !model.vision_overlay) {
+        throw std::logic_error("overlay window requires vision weights and overlay assets");
+    }
+    const qwen3_6::VisionOverlayAssets& assets = *model.vision_overlay;
+    EvictableWeightPool& pool                  = *assets.pool;
+    if (plan.control == nullptr || plan.uses.empty()) {
+        throw std::invalid_argument("overlay window has no vision items");
+    }
+
+    // The window is self-contained: weight staging, encode workspace, and the
+    // item output all live in memory borrowed from the evicted weight tail, so
+    // the resident workspace/transient reservations carry no vision terms.
+    std::size_t workspace_need = 0;
+    std::size_t output_need    = 0;
+    for (std::size_t index = first_item; index < plan.control->items.size(); ++index) {
+        const qwen3_6::VisionItemControl& control = plan.control->items[index];
+        workspace_need =
+            std::max(workspace_need, VisionContext::workspace_bytes(control));
+        output_need = std::max(
+            output_need, VisionContext::output_transient_bytes(control.merged_count));
+    }
+
+    const auto window_start = OverlayClock::now();
+    std::size_t mapped      = 0;
+    std::byte* staging      = pool.evict(assets.layout.staging_bytes +
+                                             staging_align(output_need) +
+                                             staging_align(workspace_need),
+                                         &mapped);
+    std::byte* lease_output    = staging + staging_align(assets.layout.staging_bytes);
+    std::byte* lease_workspace = lease_output + staging_align(output_need);
+
+    struct RestoreGuard {
+        EvictableWeightPool& pool;
+        cudaStream_t stream;
+        ~RestoreGuard() {
+            // On the failure path in-flight work may still reference the overlay
+            // range; quiesce before remapping so restore stays safe.
+            (void)cudaDeviceSynchronize();
+            pool.restore(stream);
+        }
+    } restore_guard{pool, device.stream};
+
+    std::vector<PinnedVisionResult> results;
+    std::size_t staged_bytes = 0;
+    {
+        VisionWeightStream stream(device, assets, staging);
+        const qwen3_6::VisionWeights window_view = stream.window_weights(*model.vision);
+        const VisionContext context(device, window_view);
+        results.reserve(plan.control->items.size());
+        for (std::size_t skipped = 0; skipped < first_item; ++skipped) {
+            results.push_back(PinnedVisionResult{});   // prefix-reused: never consumed
+        }
+
+        WorkspaceArena window_workspace(DeviceSpan{lease_workspace, workspace_need});
+        for (std::size_t index = first_item; index < plan.control->items.size(); ++index) {
+            const qwen3_6::VisionItemControl& control = plan.control->items[index];
+            const qwen3_6::VisionItem& source         = prompt.vision_items.at(index);
+            const std::size_t patch_offset =
+                control.patch_begin * static_cast<std::size_t>(VisionScheduleConfig::patch_dim);
+            const std::size_t patch_elements =
+                control.patch_count * static_cast<std::size_t>(VisionScheduleConfig::patch_dim);
+            if (source.patch_begin != control.patch_begin ||
+                patch_offset > prompt.patches.size() ||
+                patch_elements > prompt.patches.size() - patch_offset) {
+                throw std::invalid_argument("overlay item patch range exceeds prepared payload");
+            }
+            Tensor output(lease_output, DType::BF16,
+                          {VisionScheduleConfig::out_hidden,
+                           static_cast<std::int32_t>(control.merged_count)});
+
+            if (index != first_item) { stream.reset(device.stream); }
+            context.encode(
+                VisionItemView{
+                    std::span<const float>(prompt.patches).subspan(patch_offset, patch_elements),
+                    &control},
+                output, window_workspace, &stream);
+            window_workspace.reset();
+
+            const std::size_t embedding_bytes = output.bytes();
+            results.push_back(PinnedVisionResult{
+                std::make_unique<PinnedHostBuffer>(embedding_bytes), embedding_bytes});
+            CUDA_CHECK(cudaMemcpyAsync(results.back().buffer->data(), output.data, embedding_bytes,
+                                       cudaMemcpyDeviceToHost, device.stream));
+        }
+        CUDA_CHECK(cudaStreamSynchronize(device.stream));
+        CUDA_CHECK(cudaStreamSynchronize(device.load_stream));
+        staged_bytes = stream.uploaded_bytes();
+    }
+
+    pool.restore(device.stream);   // the guard's later call becomes a no-op
+
+    if (stats != nullptr) {
+        stats->window_seconds  = std::chrono::duration<double>(OverlayClock::now() - window_start)
+                                    .count();
+        stats->evict_seconds   = pool.last_evict_seconds();
+        stats->restore_seconds = pool.last_restore_seconds();
+        stats->evicted_bytes   = mapped;
+        stats->staged_bytes    = staged_bytes;
+    }
+    return results;
+}
+
+} // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/src/targets/qwen3_6/impl/vision/bindings.cpp
+++ b/src/targets/qwen3_6/impl/vision/bindings.cpp
@@ -3,13 +3,95 @@
 #include "artifact/materializer.h"
 #include "artifact/typed_binding.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
 
 namespace ninfer::targets::qwen3_6 {
+namespace {
+
+struct PinnedRangeIndex {
+    std::unordered_map<std::size_t, std::pair<std::size_t, std::size_t>> by_object;
+
+    explicit PinnedRangeIndex(const artifact::MaterializationPlan& plan) {
+        by_object.reserve(plan.pinned_objects.size());
+        for (const artifact::PinnedMaterialization& placement : plan.pinned_objects) {
+            by_object.emplace(placement.object.index,
+                              std::make_pair(static_cast<std::size_t>(placement.offset),
+                                             static_cast<std::size_t>(placement.bytes)));
+        }
+    }
+
+    // Contiguous extent covering every listed object; throws when the objects
+    // are not pinned or leave a gap larger than alignment padding.
+    template <class Handles>
+    std::pair<std::size_t, std::size_t> extent(const Handles& handles) const {
+        std::size_t begin = SIZE_MAX;
+        std::size_t end   = 0;
+        std::size_t sum   = 0;
+        for (const artifact::ObjectHandle handle : handles) {
+            const auto it = by_object.find(handle.index);
+            if (it == by_object.end()) {
+                throw std::logic_error("vision overlay group tensor is not pinned");
+            }
+            begin = std::min(begin, it->second.first);
+            end   = std::max(end, it->second.first + it->second.second);
+            sum += it->second.second;
+        }
+        if (begin == SIZE_MAX || end <= begin || end - begin > sum + handles.size() * 4096) {
+            throw std::logic_error("vision overlay group is not contiguous in the pinned block");
+        }
+        return {begin, end - begin};
+    }
+};
+
+constexpr std::size_t kStagingAlignment = 256;
+
+std::size_t staging_align(std::size_t bytes) {
+    return (bytes + kStagingAlignment - 1) / kStagingAlignment * kStagingAlignment;
+}
+
+} // namespace
+
+VisionOverlayLayout compute_vision_overlay_layout(const VisionBackbonePlan& backbone,
+                                                  const VisionMergerInputPlan& merger_input,
+                                                  artifact::ObjectHandle merger_fc2,
+                                                  artifact::ObjectHandle merger_fc2_bias,
+                                                  const VisionMergerNormPlan& merger_norm,
+                                                  const artifact::MaterializationPlan& plan) {
+    const PinnedRangeIndex index(plan);
+    VisionOverlayLayout out;
+
+    const std::array<artifact::ObjectHandle, 3> prelude = {
+        backbone.patch_embedding, backbone.patch_embedding_bias, backbone.position_embedding};
+    std::tie(out.prelude_begin, out.prelude_bytes) = index.extent(prelude);
+
+    for (std::size_t layer = 0; layer < backbone.layers.size(); ++layer) {
+        const VisionLayerPlan& source                        = backbone.layers[layer];
+        const std::array<artifact::ObjectHandle, 12> handles = {
+            source.qkv,      source.qkv_bias,     source.output,       source.output_bias,
+            source.fc1,      source.fc1_bias,     source.fc2,          source.fc2_bias,
+            source.norm1_weight, source.norm1_bias, source.norm2_weight, source.norm2_bias};
+        std::tie(out.layer_begin[layer], out.layer_bytes[layer]) = index.extent(handles);
+        out.slot_bytes = std::max(out.slot_bytes, out.layer_bytes[layer]);
+    }
+
+    const std::array<artifact::ObjectHandle, 6> merger = {
+        merger_input.fc1, merger_input.fc1_bias, merger_fc2,
+        merger_fc2_bias,  merger_norm.weight,    merger_norm.bias};
+    std::tie(out.merger_begin, out.merger_bytes) = index.extent(merger);
+
+    out.staging_bytes = staging_align(out.prelude_bytes) + staging_align(out.merger_bytes) +
+                        2 * staging_align(out.slot_bytes);
+    return out;
+}
 
 VisionBackbonePlan bind_vision_backbone(artifact::Binder& binder,
                                         artifact::TensorPlacement placement) {

--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -50,6 +50,9 @@ public:
     LoadPlan& operator=(const LoadPlan&) = delete;
 
     [[nodiscard]] const artifact::MaterializationPlan& materialization() const;
+    // Bytes of borrowed device staging one overlay window needs; 0 when the plan
+    // was built for resident vision.
+    [[nodiscard]] std::size_t overlay_staging_bytes() const;
 
 private:
     class Impl;

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -1,6 +1,7 @@
 #include "targets/qwen3_6_27b/impl/load/bindings.h"
 
 #include "artifact/typed_binding.h"
+#include "core/evictable_weight_pool.h"
 
 #include <algorithm>
 #include <array>
@@ -65,13 +66,25 @@ void require_positive_finite(std::uint32_t bits, std::string_view label) {
 }
 
 WeightPlan bind_weight(artifact::Binder& binder, std::string_view name, NumericFormat format,
-                       std::initializer_list<std::uint64_t> shape) {
+                       std::initializer_list<std::uint64_t> shape,
+                       std::uint32_t evict_rank = 0) {
     if (format == NumericFormat::NVFP4) {
         throw std::logic_error("NVFP4 weight requires a paired input divisor");
     }
-    return WeightPlan{.object = artifact::bind_device_tensor(binder, name, format, shape),
+    return WeightPlan{.object = artifact::bind_tensor(binder, name, format, shape,
+                                                      artifact::TensorPlacement::Device,
+                                                      evict_rank),
                       .format = format};
 }
+
+// Overlay eviction ladder. Higher ranks sit at the arena end and are evicted
+// first. The four endpoint groups alone provide ~3.3 GiB of evictable tail --
+// far beyond any window's staging need -- so decoder blocks stay unranked; the
+// rank parameter accepts them later without structural change.
+constexpr std::uint32_t kEvictRankMtp       = 400;
+constexpr std::uint32_t kEvictRankDraftHead = 500;
+constexpr std::uint32_t kEvictRankEmbedding = 600;
+constexpr std::uint32_t kEvictRankLmHead    = 700;
 
 WeightPlan bind_nvfp4_weight(artifact::Binder& binder, std::string_view name, std::int32_t rows,
                              std::int32_t columns, std::string_view input_divisor_name) {
@@ -417,9 +430,11 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     out.frontend     = qwen3_6::bind_frontend_resources(binder);
     out.features     = features;
 
+    const bool overlay                    = features.overlay_vision;
     const NumericFormat vocabulary_format = endpoint_format(weights_profile);
     out.token_embedding =
-        bind_weight(binder, "text/token_embedding", vocabulary_format, {248320, 5120});
+        bind_weight(binder, "text/token_embedding", vocabulary_format, {248320, 5120},
+                    overlay ? kEvictRankEmbedding : 0);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
     case WeightsProfile::Qwen38GroupwiseInt:
@@ -436,12 +451,14 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     }
     out.final_norm =
         artifact::bind_device_tensor(binder, "text/final_norm", NumericFormat::BF16, {5120});
-    out.output_head = bind_weight(binder, "text/output_head", vocabulary_format, {248320, 5120});
+    out.output_head = bind_weight(binder, "text/output_head", vocabulary_format, {248320, 5120},
+                                  overlay ? kEvictRankLmHead : 0);
     const artifact::TensorPlacement proposal_placement =
         features.optimized_proposal() ? artifact::TensorPlacement::Device
                                       : artifact::TensorPlacement::ValidateOnly;
     out.draft_head = artifact::bind_tensor(binder, "text/draft_head", NumericFormat::Q4G64_F16S,
-                                           {131072, 5120}, proposal_placement);
+                                           {131072, 5120}, proposal_placement,
+                                           overlay ? kEvictRankDraftHead : 0);
     out.draft_head_token_ids = artifact::bind_tensor(
         binder, "text/draft_head_token_ids", NumericFormat::I32, {131072}, proposal_placement);
     validate_draft_ids(binder, out.draft_head_token_ids);
@@ -451,7 +468,8 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
                                                         : artifact::TensorPlacement::ValidateOnly;
     const auto bind_mtp                           = [&](std::string_view name, NumericFormat format,
                               std::initializer_list<std::uint64_t> shape) {
-        return artifact::bind_tensor(binder, name, format, shape, mtp_placement);
+        return artifact::bind_tensor(binder, name, format, shape, mtp_placement,
+                                     overlay ? kEvictRankMtp : 0);
     };
     out.mtp.input_projection =
         bind_mtp("mtp/input_projection", NumericFormat::W8G32_F16S, {5120, 10240});
@@ -475,8 +493,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     out.mtp.final_norm = bind_mtp("mtp/final_norm", NumericFormat::BF16, {5120});
 
     const artifact::TensorPlacement vision_placement =
-        features.vision ? artifact::TensorPlacement::Device
-                        : artifact::TensorPlacement::ValidateOnly;
+        overlay           ? artifact::TensorPlacement::HostPinned
+        : features.vision ? artifact::TensorPlacement::Device
+                          : artifact::TensorPlacement::ValidateOnly;
     out.vision_backbone     = qwen3_6::bind_vision_backbone(binder, vision_placement);
     out.vision_merger_input = qwen3_6::bind_vision_merger_input(binder, vision_placement);
     out.vision_merger_fc2   = artifact::bind_tensor(
@@ -485,7 +504,13 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
         binder, "vision/merger/fc2_bias", NumericFormat::BF16, {5120}, vision_placement);
     out.vision_merger_norm = qwen3_6::bind_vision_merger_norm(binder, vision_placement);
 
-    load_plan.materialization = binder.finish();
+    load_plan.materialization =
+        binder.finish(overlay ? ninfer::EvictableWeightPool::kChunkBytes : 1);
+    if (overlay) {
+        out.vision_overlay = qwen3_6::compute_vision_overlay_layout(
+            out.vision_backbone, out.vision_merger_input, out.vision_merger_fc2,
+            out.vision_merger_fc2_bias, out.vision_merger_norm, load_plan.materialization);
+    }
     return load_plan;
 }
 
@@ -590,6 +615,18 @@ LoadedModelData::LoadedModelData(BindingPlan plan, artifact::MaterializedArtifac
                                                                NumericFormat::W8G32_F16S, 5120, 4608);
         vision.merger_fc2_bias = artifact::materialized_tensor(backing, plan.vision_merger_fc2_bias,
                                                                NumericFormat::BF16, {5120});
+    }
+    if (plan.features.overlay_vision) {
+        if (!plan.vision_overlay || backing.eviction_pool() == nullptr ||
+            backing.pinned_block().empty()) {
+            throw std::logic_error("overlay vision requires a pool-backed pinned materialization");
+        }
+        auto& overlay        = runtime.vision_overlay.emplace();
+        overlay.pool         = backing.eviction_pool();
+        overlay.pinned_block = backing.pinned_block().data();
+        overlay.pinned_bytes = backing.pinned_block().size();
+        overlay.ladder_bytes = backing.eviction_pool()->evictable_tail_bytes();
+        overlay.layout       = *plan.vision_overlay;
     }
 }
 

--- a/src/targets/qwen3_6_27b/impl/load/bindings.h
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <variant>
 
@@ -121,6 +122,7 @@ struct BindingPlan {
     artifact::ObjectHandle vision_merger_fc2;
     artifact::ObjectHandle vision_merger_fc2_bias;
     qwen3_6::VisionMergerNormPlan vision_merger_norm;
+    std::optional<qwen3_6::VisionOverlayLayout> vision_overlay;
 };
 
 struct ArtifactLoadPlan {

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -26,6 +26,11 @@ LoadPlan::LoadPlan(LoadPlan&&) noexcept            = default;
 LoadPlan& LoadPlan::operator=(LoadPlan&&) noexcept = default;
 LoadPlan::~LoadPlan()                              = default;
 
+std::size_t LoadPlan::overlay_staging_bytes() const {
+    if (impl_ == nullptr || !impl_->plan.bindings.vision_overlay) { return 0; }
+    return impl_->plan.bindings.vision_overlay->staging_bytes;
+}
+
 const artifact::MaterializationPlan& LoadPlan::materialization() const {
     if (impl_ == nullptr) { throw std::logic_error("target load plan is empty"); }
     return impl_->plan.materialization;

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -129,6 +129,7 @@ Package::Frontend Package::make_frontend(const LoadedModel& model, const EngineO
                                       .media_cache_bytes        = options.media_cache_bytes,
                                       .media_live_bytes         = options.media_live_bytes,
                                       .media_preprocess_threads = options.media_preprocess_threads,
+                                      .vision_max_merged_tokens = options.vision_max_merged_tokens,
                                   });
 }
 

--- a/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
+++ b/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
@@ -47,6 +47,8 @@ public:
     LoadPlan& operator=(const LoadPlan&) = delete;
 
     [[nodiscard]] const artifact::MaterializationPlan& materialization() const;
+    // The 35B-A3B target has no overlay vision plan; always 0.
+    [[nodiscard]] std::size_t overlay_staging_bytes() const;
 
 private:
     class Impl;

--- a/src/targets/qwen3_6_35b_a3b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/load/bindings.cpp
@@ -1,6 +1,7 @@
 #include "targets/qwen3_6_35b_a3b/impl/load/bindings.h"
 
 #include "artifact/typed_binding.h"
+#include "core/evictable_weight_pool.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -94,13 +95,23 @@ void validate_draft_ids(const artifact::Binder& binder, artifact::ObjectHandle h
 
 } // namespace
 
+// Overlay eviction ladder, mirroring the 27B ordering: endpoint groups sit at the
+// arena end and are evicted first; MoE decoder blocks stay unranked.
+constexpr std::uint32_t kEvictRankMtp       = 400;
+constexpr std::uint32_t kEvictRankDraftHead = 500;
+constexpr std::uint32_t kEvictRankEmbedding = 600;
+constexpr std::uint32_t kEvictRankLmHead    = 700;
+
 ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeatures features) {
     ArtifactLoadPlan load_plan;
-    BindingPlan& out    = load_plan.bindings;
-    out.frontend        = qwen3_6::bind_frontend_resources(binder);
-    out.features        = features;
-    out.token_embedding = artifact::bind_device_tensor(binder, "text/token_embedding",
-                                                       NumericFormat::W8G32_F16S, {248320, 2048});
+    BindingPlan& out     = load_plan.bindings;
+    out.frontend         = qwen3_6::bind_frontend_resources(binder);
+    out.features         = features;
+    const bool overlay   = features.overlay_vision;
+    out.token_embedding  = artifact::bind_tensor(binder, "text/token_embedding",
+                                                 NumericFormat::W8G32_F16S, {248320, 2048},
+                                                 artifact::TensorPlacement::Device,
+                                                 overlay ? kEvictRankEmbedding : 0);
 
     for (std::size_t layer = 0; layer < kTextLayers; ++layer) {
         TextLayerPlan& target    = out.text_layers[layer];
@@ -142,13 +153,15 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
 
     out.final_norm =
         artifact::bind_device_tensor(binder, "text/final_norm", NumericFormat::BF16, {2048});
-    out.output_head = artifact::bind_device_tensor(binder, "text/output_head",
-                                                   NumericFormat::Q6G64_F16S, {248320, 2048});
+    out.output_head = artifact::bind_tensor(binder, "text/output_head", NumericFormat::Q6G64_F16S,
+                                            {248320, 2048}, artifact::TensorPlacement::Device,
+                                            overlay ? kEvictRankLmHead : 0);
     const artifact::TensorPlacement proposal_placement =
         features.optimized_proposal() ? artifact::TensorPlacement::Device
                                       : artifact::TensorPlacement::ValidateOnly;
     out.draft_head = artifact::bind_tensor(binder, "text/draft_head", NumericFormat::Q4G64_F16S,
-                                           {131072, 2048}, proposal_placement);
+                                           {131072, 2048}, proposal_placement,
+                                           overlay ? kEvictRankDraftHead : 0);
     out.draft_head_token_ids = artifact::bind_tensor(
         binder, "text/draft_head_token_ids", NumericFormat::I32, {131072}, proposal_placement);
     validate_draft_ids(binder, out.draft_head_token_ids);
@@ -158,7 +171,8 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
                                                         : artifact::TensorPlacement::ValidateOnly;
     const auto bind_mtp                           = [&](std::string_view name, NumericFormat format,
                               std::initializer_list<std::uint64_t> shape) {
-        return artifact::bind_tensor(binder, name, format, shape, mtp_placement);
+        return artifact::bind_tensor(binder, name, format, shape, mtp_placement,
+                                     overlay ? kEvictRankMtp : 0);
     };
     out.mtp.input_projection =
         bind_mtp("mtp/input_projection", NumericFormat::W8G32_F16S, {2048, 4096});
@@ -180,8 +194,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
     out.mtp.final_norm = bind_mtp("mtp/final_norm", NumericFormat::BF16, {2048});
 
     const artifact::TensorPlacement vision_placement =
-        features.vision ? artifact::TensorPlacement::Device
-                        : artifact::TensorPlacement::ValidateOnly;
+        overlay           ? artifact::TensorPlacement::HostPinned
+        : features.vision ? artifact::TensorPlacement::Device
+                          : artifact::TensorPlacement::ValidateOnly;
     out.vision_backbone     = qwen3_6::bind_vision_backbone(binder, vision_placement);
     out.vision_merger_input = qwen3_6::bind_vision_merger_input(binder, vision_placement);
     out.vision_merger_fc2   = artifact::bind_tensor(
@@ -219,7 +234,13 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, qwen3_6::StartupFeature
     }
     out.dflash.final_norm = bind_dflash("dflash/final_norm", NumericFormat::BF16, {2048});
 
-    load_plan.materialization = binder.finish();
+    load_plan.materialization =
+        binder.finish(overlay ? ninfer::EvictableWeightPool::kChunkBytes : 1);
+    if (overlay) {
+        out.vision_overlay = qwen3_6::compute_vision_overlay_layout(
+            out.vision_backbone, out.vision_merger_input, out.vision_merger_fc2,
+            out.vision_merger_fc2_bias, out.vision_merger_norm, load_plan.materialization);
+    }
     return load_plan;
 }
 
@@ -334,6 +355,18 @@ LoadedModelData::LoadedModelData(BindingPlan plan, artifact::MaterializedArtifac
                                                                NumericFormat::W8G32_F16S, 2048, 4608);
         vision.merger_fc2_bias = artifact::materialized_tensor(backing, plan.vision_merger_fc2_bias,
                                                                NumericFormat::BF16, {2048});
+    }
+    if (plan.features.overlay_vision) {
+        if (!plan.vision_overlay || backing.eviction_pool() == nullptr ||
+            backing.pinned_block().empty()) {
+            throw std::logic_error("overlay vision requires a pool-backed pinned materialization");
+        }
+        auto& overlay        = runtime.vision_overlay.emplace();
+        overlay.pool         = backing.eviction_pool();
+        overlay.pinned_block = backing.pinned_block().data();
+        overlay.pinned_bytes = backing.pinned_block().size();
+        overlay.ladder_bytes = backing.eviction_pool()->evictable_tail_bytes();
+        overlay.layout       = *plan.vision_overlay;
     }
 
     if (plan.features.dflash()) {

--- a/src/targets/qwen3_6_35b_a3b/impl/load/bindings.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/load/bindings.h
@@ -101,6 +101,7 @@ struct BindingPlan {
     artifact::ObjectHandle vision_merger_fc2;
     artifact::ObjectHandle vision_merger_fc2_bias;
     qwen3_6::VisionMergerNormPlan vision_merger_norm;
+    std::optional<qwen3_6::VisionOverlayLayout> vision_overlay;
     DFlashPlan dflash;
 };
 

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -98,6 +98,7 @@ Package::Frontend Package::make_frontend(const LoadedModel& model, const EngineO
                                       .media_cache_bytes        = options.media_cache_bytes,
                                       .media_live_bytes         = options.media_live_bytes,
                                       .media_preprocess_threads = options.media_preprocess_threads,
+                                      .vision_max_merged_tokens = options.vision_max_merged_tokens,
                                   });
 }
 

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -26,6 +26,8 @@ LoadPlan::LoadPlan(LoadPlan&&) noexcept            = default;
 LoadPlan& LoadPlan::operator=(LoadPlan&&) noexcept = default;
 LoadPlan::~LoadPlan()                              = default;
 
+std::size_t LoadPlan::overlay_staging_bytes() const { return 0; }
+
 const artifact::MaterializationPlan& LoadPlan::materialization() const {
     if (impl_ == nullptr) { throw std::logic_error("target load plan is empty"); }
     return impl_->plan.materialization;

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -26,7 +26,10 @@ LoadPlan::LoadPlan(LoadPlan&&) noexcept            = default;
 LoadPlan& LoadPlan::operator=(LoadPlan&&) noexcept = default;
 LoadPlan::~LoadPlan()                              = default;
 
-std::size_t LoadPlan::overlay_staging_bytes() const { return 0; }
+std::size_t LoadPlan::overlay_staging_bytes() const {
+    if (impl_ == nullptr || !impl_->plan.bindings.vision_overlay) { return 0; }
+    return impl_->plan.bindings.vision_overlay->staging_bytes;
+}
 
 const artifact::MaterializationPlan& LoadPlan::materialization() const {
     if (impl_ == nullptr) { throw std::logic_error("target load plan is empty"); }

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -110,7 +110,8 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
     if (overlay_vision) {
         if (overlay_staging == 0) {
             throw std::invalid_argument(
-                "the selected target does not support --vision-residency overlay");
+                "the selected target does not support --vision-residency overlay yet "
+                "(supported: qwen3.8-27b family targets); use --vision-residency resident");
         }
         if (!EvictableWeightPool::supported(device.device)) {
             throw std::invalid_argument(

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -110,8 +110,8 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
     if (overlay_vision) {
         if (overlay_staging == 0) {
             throw std::invalid_argument(
-                "the selected target does not support --vision-residency overlay yet "
-                "(supported: qwen3.8-27b family targets); use --vision-residency resident");
+                "the selected target does not support --vision-residency overlay; "
+                "use --vision-residency resident");
         }
         if (!EvictableWeightPool::supported(device.device)) {
             throw std::invalid_argument(

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -4,6 +4,7 @@
 #include "artifact/materializer.h"
 #include "artifact/reader.h"
 #include "core/device.h"
+#include "core/evictable_weight_pool.h"
 #include "runtime/engine/kv_capacity.h"
 
 #include <chrono>
@@ -102,9 +103,33 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
         runtime_bytes_after_planned_weights(load_plan.materialization().device_capacity_bytes);
     (void)runtime::resolve_kv_capacity(options.kv_capacity, curve, preflight_runtime_bytes);
 
+    const bool overlay_vision =
+        options.enable_vision && options.vision_residency == VisionResidency::Overlay;
+    const std::size_t overlay_staging = load_plan.overlay_staging_bytes();
+    std::unique_ptr<EvictableWeightPool> pool;
+    if (overlay_vision) {
+        if (overlay_staging == 0) {
+            throw std::invalid_argument(
+                "the selected target does not support --vision-residency overlay");
+        }
+        if (!EvictableWeightPool::supported(device.device)) {
+            throw std::invalid_argument(
+                "overlay vision requires CUDA virtual memory management support");
+        }
+        pool = std::make_unique<EvictableWeightPool>(EvictableWeightPool::Config{
+            .arena_bytes          = load_plan.materialization().device_capacity_bytes,
+            .evictable_tail_bytes = load_plan.materialization().evictable_tail_bytes,
+            .overlay_bytes        = overlay_staging,
+            .device               = device.device,
+        });
+    }
     auto progress     = artifact_progress(options.load_progress);
     auto materialized = artifact::materialize(reader, load_plan.materialization(), device,
-                                              progress.callback ? &progress : nullptr);
+                                              progress.callback ? &progress : nullptr,
+                                              std::move(pool));
+    if (overlay_vision) {
+        materialized.eviction_pool()->capture_tail_mirror(device.load_stream);
+    }
     const artifact::MaterializationStats stats = materialized.stats();
 
     auto model = Target::construct_loaded_model(std::move(load_plan), std::move(materialized));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,11 @@ ninfer_add_test(ninfer_arena_test        SOURCES test_arena.cpp)
 ninfer_add_test(ninfer_request_memory_test SOURCES test_request_memory.cpp)
 ninfer_add_test(ninfer_admission_policy_test SOURCES test_admission_policy.cpp)
 ninfer_add_test(ninfer_kv_capacity_test SOURCES test_kv_capacity.cpp)
+ninfer_add_test(ninfer_vmm_graph_remap_test SOURCES test_vmm_graph_remap.cu)
+target_link_libraries(ninfer_vmm_graph_remap_test PRIVATE CUDA::cuda_driver)
+set_tests_properties(ninfer_vmm_graph_remap_test PROPERTIES SKIP_RETURN_CODE 77)
+ninfer_add_test(ninfer_evictable_weight_pool_test SOURCES test_evictable_weight_pool.cu)
+set_tests_properties(ninfer_evictable_weight_pool_test PROPERTIES SKIP_RETURN_CODE 77)
 ninfer_add_test(ninfer_sampling_defaults_test
   SOURCES test_sampling_defaults.cpp
   LIBRARIES ninfer_engine)

--- a/tests/test_artifact_materialization.cpp
+++ b/tests/test_artifact_materialization.cpp
@@ -196,6 +196,100 @@ int main() {
         require(materialized.device_arena().capacity() == plan.device_capacity_bytes &&
                     materialized.device_arena().used() == plan.device_capacity_bytes,
                 "materialized tensor does not own the planned device backing");
+
+        // Overlay plan mechanics: an evict-ranked tensor lands in a chunk-aligned
+        // arena tail backed by the eviction pool, a HostPinned tensor lands in the
+        // pinned block, and an evict/restore transaction preserves every byte.
+        if (ninfer::EvictableWeightPool::supported(device.device)) {
+            constexpr std::size_t kChunk = ninfer::EvictableWeightPool::kChunkBytes;
+            ninfer::artifact::Binder overlay_binder(reader);
+            const auto overlay_resource = overlay_binder.require_resource(
+                "frontend/test.json", ninfer::artifact::ResourceEncoding::RawBytesV1);
+            overlay_binder.retain_on_host(overlay_resource);
+            const auto resident =
+                overlay_binder.require_tensor("weights/test", ninfer::artifact::NumericFormat::BF16,
+                                              ninfer::artifact::StorageLayout::ContiguousLeV1,
+                                              tensor_shape);
+            overlay_binder.materialize_on_device(resident);
+            const auto evictable = overlay_binder.require_tensor(
+                "weights/second", ninfer::artifact::NumericFormat::BF16,
+                ninfer::artifact::StorageLayout::ContiguousLeV1, second_shape);
+            overlay_binder.materialize_on_device(evictable, /*evict_rank=*/700);
+            const ninfer::artifact::MaterializationPlan overlay_plan =
+                overlay_binder.finish(kChunk);
+            require(overlay_plan.evictable_tail_bytes == kSecondTensor.size() &&
+                        overlay_plan.device_objects.back().offset % kChunk == 0 &&
+                        overlay_plan.device_capacity_bytes ==
+                            kChunk + kSecondTensor.size(),
+                    "evict-ranked tensor was not planned into a chunk-aligned arena tail");
+
+            auto pool = std::make_unique<ninfer::EvictableWeightPool>(
+                ninfer::EvictableWeightPool::Config{
+                    .arena_bytes          = overlay_plan.device_capacity_bytes,
+                    .evictable_tail_bytes = overlay_plan.evictable_tail_bytes,
+                    .overlay_bytes        = kChunk,
+                    .device               = device.device,
+                });
+            auto overlay_materialized = ninfer::artifact::materialize(
+                reader, overlay_plan, device, nullptr, std::move(pool));
+            ninfer::EvictableWeightPool* live_pool = overlay_materialized.eviction_pool();
+            require(live_pool != nullptr, "pool-backed materialization dropped the pool");
+            live_pool->capture_tail_mirror(device.load_stream);
+
+            void* evictable_home = overlay_materialized.device_data(evictable);
+            std::size_t mapped   = 0;
+            std::byte* staging   = live_pool->evict(kChunk, &mapped);
+            CUDA_CHECK(cudaMemset(staging, 0x5A, mapped));
+            // The pool contract requires a quiesced device before remapping.
+            CUDA_CHECK(cudaDeviceSynchronize());
+            live_pool->restore(device.stream);
+            require(overlay_materialized.device_data(evictable) == evictable_home,
+                    "evictable tensor address changed across the overlay transaction");
+            std::array<std::byte, kSecondTensor.size()> roundtrip{};
+            CUDA_CHECK(cudaMemcpy(roundtrip.data(), evictable_home, roundtrip.size(),
+                                  cudaMemcpyDeviceToHost));
+            require(roundtrip == kSecondTensor,
+                    "evictable tensor bytes were not restored from the mirror");
+        } else {
+            std::cout << "note: VMM unsupported, overlay plan mechanics not exercised\n";
+        }
+
+        {
+            // HostPinned placement: payload lands in the pinned block, never on device.
+            ninfer::artifact::Binder pinned_binder(reader);
+            const auto pinned_resource = pinned_binder.require_resource(
+                "frontend/test.json", ninfer::artifact::ResourceEncoding::RawBytesV1);
+            pinned_binder.retain_on_host(pinned_resource);
+            const auto device_tensor =
+                pinned_binder.require_tensor("weights/test", ninfer::artifact::NumericFormat::BF16,
+                                             ninfer::artifact::StorageLayout::ContiguousLeV1,
+                                             tensor_shape);
+            pinned_binder.materialize_on_device(device_tensor);
+            const auto pinned_tensor = pinned_binder.require_tensor(
+                "weights/second", ninfer::artifact::NumericFormat::BF16,
+                ninfer::artifact::StorageLayout::ContiguousLeV1, second_shape);
+            pinned_binder.materialize_on_host_pinned(pinned_tensor);
+            const ninfer::artifact::MaterializationPlan pinned_plan = pinned_binder.finish();
+            require(pinned_plan.pinned_objects.size() == 1 &&
+                        pinned_plan.pinned_capacity_bytes == kSecondTensor.size(),
+                    "pinned placement was not planned into the pinned block");
+
+            auto pinned_materialized =
+                ninfer::artifact::materialize(reader, pinned_plan, device);
+            require(pinned_materialized.is_host_pinned(pinned_tensor),
+                    "pinned tensor is not reported as host pinned");
+            const auto block = pinned_materialized.pinned_block();
+            require(block.size() == kSecondTensor.size() &&
+                        std::equal(block.begin(), block.end(), kSecondTensor.begin(),
+                                   kSecondTensor.end()),
+                    "pinned block content differs from the artifact payload");
+            require(pinned_materialized.storage_data(pinned_tensor) ==
+                        const_cast<std::byte*>(block.data()) +
+                            pinned_materialized.pinned_offset(pinned_tensor),
+                    "pinned tensor storage pointer is outside the pinned block");
+            require(pinned_materialized.stats().pinned_weight_bytes == kSecondTensor.size(),
+                    "pinned weight bytes are not accounted");
+        }
         return 0;
     } catch (const std::exception& error) {
         std::cerr << error.what() << '\n';

--- a/tests/test_evictable_weight_pool.cu
+++ b/tests/test_evictable_weight_pool.cu
@@ -1,0 +1,116 @@
+// Lifetime and integrity qualification for the VMM-backed evictable weight pool:
+// stable arena addresses across transactions, byte-exact restore of a partially
+// evicted tail from the pinned mirror, and rejection of invalid transactions.
+
+#include "core/arena.h"
+#include "core/device.h"
+#include "core/evictable_weight_pool.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+bool cuda_unavailable(cudaError_t err) {
+    return err == cudaErrorNoDevice || err == cudaErrorInsufficientDriver;
+}
+
+int expect(bool condition, const char* label) {
+    if (condition) { return 0; }
+    std::cerr << "expectation failed: " << label << '\n';
+    return 1;
+}
+
+} // namespace
+
+int main() {
+    int count                   = 0;
+    const cudaError_t count_err = cudaGetDeviceCount(&count);
+    if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    if (count_err != cudaSuccess) {
+        std::cerr << "cudaGetDeviceCount failed: " << cudaGetErrorString(count_err) << '\n';
+        return 1;
+    }
+
+    try {
+        ninfer::DeviceContext device(0);
+        if (!ninfer::EvictableWeightPool::supported(device.device)) {
+            std::cout << "SKIP: device does not support CUDA virtual memory management\n";
+            return 77;
+        }
+
+        constexpr std::size_t kChunk = ninfer::EvictableWeightPool::kChunkBytes;
+        const std::size_t arena_bytes = 6 * kChunk - (kChunk / 2);   // deliberately unaligned
+        const std::size_t tail_bytes  = 3 * kChunk;
+
+        ninfer::EvictableWeightPool pool(ninfer::EvictableWeightPool::Config{
+            .arena_bytes          = arena_bytes,
+            .evictable_tail_bytes = tail_bytes,
+            .overlay_bytes        = 2 * kChunk,
+            .device               = device.device,
+        });
+
+        int failures = 0;
+        const ninfer::DeviceSpan arena = pool.arena();
+        failures += expect(arena.bytes == arena_bytes, "arena span covers the configured bytes");
+
+        // Deterministic "weights".
+        std::vector<std::uint32_t> pattern(arena_bytes / sizeof(std::uint32_t));
+        for (std::size_t i = 0; i < pattern.size(); ++i) {
+            pattern[i] = static_cast<std::uint32_t>(i * 2654435761ULL + 12345U);
+        }
+        CUDA_CHECK(cudaMemcpyAsync(arena.data, pattern.data(),
+                                   pattern.size() * sizeof(std::uint32_t),
+                                   cudaMemcpyHostToDevice, device.stream));
+        pool.capture_tail_mirror(device.stream);
+
+        const void* stable_base = arena.data;
+        std::vector<std::uint32_t> readback(pattern.size());
+
+        for (int cycle = 0; cycle < 2; ++cycle) {
+            std::size_t mapped   = 0;
+            std::byte* staging   = pool.evict(kChunk + kChunk / 2, &mapped);
+            failures += expect(mapped == 2 * kChunk, "evict rounds the extent up to chunks");
+            failures += expect(pool.evicted(), "transaction reports evicted state");
+            CUDA_CHECK(cudaMemsetAsync(staging, 0xC3, mapped, device.stream));
+            CUDA_CHECK(cudaStreamSynchronize(device.stream));
+            pool.restore(device.stream);
+            failures += expect(!pool.evicted(), "restore closes the transaction");
+            failures += expect(pool.arena().data == stable_base,
+                               "arena base is stable across transactions");
+
+            CUDA_CHECK(cudaMemcpyAsync(readback.data(), arena.data,
+                                       readback.size() * sizeof(std::uint32_t),
+                                       cudaMemcpyDeviceToHost, device.stream));
+            CUDA_CHECK(cudaStreamSynchronize(device.stream));
+            failures += expect(std::memcmp(readback.data(), pattern.data(),
+                                           pattern.size() * sizeof(std::uint32_t)) == 0,
+                               "restored arena is byte-identical to the mirror image");
+        }
+
+        pool.restore(device.stream);   // idempotent when nothing is evicted
+
+        bool rejected = false;
+        try {
+            std::size_t mapped = 0;
+            (void)pool.evict(64 * kChunk, &mapped);
+        } catch (const std::invalid_argument&) { rejected = true; }
+        failures += expect(rejected, "evict beyond the tail capacity is rejected");
+        failures += expect(!pool.evicted(), "rejected evict leaves the pool resident");
+
+        std::cout << "evict_s=" << pool.last_evict_seconds()
+                  << " restore_s=" << pool.last_restore_seconds() << '\n';
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "evictable weight pool test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/test_vmm_graph_remap.cu
+++ b/tests/test_vmm_graph_remap.cu
@@ -1,0 +1,191 @@
+// Proves the residency mechanism behind the vision VRAM overlay: physical chunks
+// backing a stable VA range can be unmapped, remapped into a different reserved
+// range, used there, remapped home, and re-uploaded from a pinned host mirror --
+// all while a CUDA graph captured against the home addresses stays launchable
+// and correct. Also reports per-chunk map/unmap latency for the overlay budget.
+
+#include "core/arena.h"
+#include "core/device.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+bool cuda_unavailable(cudaError_t err) {
+    return err == cudaErrorNoDevice || err == cudaErrorInsufficientDriver;
+}
+
+void cu_check(CUresult result, const char* expr) {
+    if (result == CUDA_SUCCESS) { return; }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    throw std::runtime_error(std::string(expr) + " failed: " +
+                             (name != nullptr ? name : "unknown CUresult"));
+}
+
+#define CU_CHECK(expr) ::cu_check((expr), #expr)
+
+constexpr std::size_t kChunkCount   = 4;
+constexpr std::size_t kEvictedFirst = 2;   // evict the chunk suffix [2, 4)
+
+__global__ void checksum_kernel(const std::uint32_t* words, std::size_t count,
+                                unsigned long long* out) {
+    unsigned long long local = 0;
+    for (std::size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < count;
+         i += static_cast<std::size_t>(gridDim.x) * blockDim.x) {
+        local += words[i];
+    }
+    atomicAdd(out, local);
+}
+
+void map_rw(CUdeviceptr va, std::size_t bytes, CUmemGenericAllocationHandle handle, int device) {
+    CU_CHECK(cuMemMap(va, bytes, 0, handle, 0));
+    CUmemAccessDesc access{};
+    access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    access.location.id   = device;
+    access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    CU_CHECK(cuMemSetAccess(va, bytes, &access, 1));
+}
+
+} // namespace
+
+int main() {
+    int count                   = 0;
+    const cudaError_t count_err = cudaGetDeviceCount(&count);
+    if (cuda_unavailable(count_err) || (count_err == cudaSuccess && count == 0)) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    if (count_err != cudaSuccess) {
+        std::cerr << "cudaGetDeviceCount failed: " << cudaGetErrorString(count_err) << '\n';
+        return 1;
+    }
+
+    try {
+        ninfer::DeviceContext device(0);
+        CU_CHECK(cuInit(0));
+
+        CUmemAllocationProp prop{};
+        prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id   = device.device;
+        std::size_t granularity = 0;
+        CU_CHECK(cuMemGetAllocationGranularity(&granularity, &prop,
+                                               CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+        const std::size_t chunk =
+            ((64ULL << 20) + granularity - 1) / granularity * granularity;
+        const std::size_t total = chunk * kChunkCount;
+
+        CUdeviceptr home = 0, overlay = 0;
+        CU_CHECK(cuMemAddressReserve(&home, total, granularity, 0, 0));
+        CU_CHECK(cuMemAddressReserve(&overlay, total, granularity, 0, 0));
+
+        std::vector<CUmemGenericAllocationHandle> handles(kChunkCount);
+        for (std::size_t i = 0; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemCreate(&handles[i], chunk, &prop, 0));
+            map_rw(home + i * chunk, chunk, handles[i], device.device);
+        }
+
+        // Deterministic pattern, mirrored in pinned host memory like the
+        // production weight mirrors.
+        ninfer::PinnedHostBuffer mirror(total);
+        auto* mirror_words = static_cast<std::uint32_t*>(mirror.data());
+        for (std::size_t i = 0; i < total / sizeof(std::uint32_t); ++i) {
+            mirror_words[i] = static_cast<std::uint32_t>(i * 2654435761ULL);
+        }
+        CUDA_CHECK(cudaMemcpyAsync(reinterpret_cast<void*>(home), mirror.data(), total,
+                                   cudaMemcpyHostToDevice, device.stream));
+
+        unsigned long long* result = nullptr;
+        CUDA_CHECK(cudaMalloc(&result, sizeof(unsigned long long)));
+        CUDA_CHECK(cudaMemsetAsync(result, 0, sizeof(unsigned long long), device.stream));
+        device.synchronize();
+
+        // Reference checksum with everything resident.
+        const std::size_t words = total / sizeof(std::uint32_t);
+        checksum_kernel<<<256, 256, 0, device.stream>>>(
+            reinterpret_cast<const std::uint32_t*>(home), words, result);
+        unsigned long long expected = 0;
+        CUDA_CHECK(cudaMemcpyAsync(&expected, result, sizeof(expected), cudaMemcpyDeviceToHost,
+                                   device.stream));
+        device.synchronize();
+
+        // Capture the checksum as a graph against the home addresses.
+        cudaGraph_t graph         = nullptr;
+        cudaGraphExec_t execution = nullptr;
+        CUDA_CHECK(cudaStreamBeginCapture(device.stream, cudaStreamCaptureModeGlobal));
+        CUDA_CHECK(cudaMemsetAsync(result, 0, sizeof(unsigned long long), device.stream));
+        checksum_kernel<<<256, 256, 0, device.stream>>>(
+            reinterpret_cast<const std::uint32_t*>(home), words, result);
+        CUDA_CHECK(cudaStreamEndCapture(device.stream, &graph));
+        CUDA_CHECK(cudaGraphInstantiate(&execution, graph, nullptr, nullptr, 0));
+
+        // Overlay transaction: unmap the chunk suffix, remap the same physical
+        // pages into the overlay range, scribble there (vision stand-in),
+        // remap home, and restore only the evicted bytes from the mirror.
+        const std::size_t evicted_bytes  = (kChunkCount - kEvictedFirst) * chunk;
+        const std::size_t evicted_offset = kEvictedFirst * chunk;
+        const auto evict_start           = std::chrono::steady_clock::now();
+        for (std::size_t i = kEvictedFirst; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(home + i * chunk, chunk));
+            map_rw(overlay + (i - kEvictedFirst) * chunk, chunk, handles[i], device.device);
+        }
+        const auto evict_end = std::chrono::steady_clock::now();
+        CUDA_CHECK(cudaMemsetAsync(reinterpret_cast<void*>(overlay), 0xA5, evicted_bytes,
+                                   device.stream));
+        device.synchronize();
+        const auto restore_start = std::chrono::steady_clock::now();
+        for (std::size_t i = kEvictedFirst; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(overlay + (i - kEvictedFirst) * chunk, chunk));
+            map_rw(home + i * chunk, chunk, handles[i], device.device);
+        }
+        const auto restore_end = std::chrono::steady_clock::now();
+        CUDA_CHECK(cudaMemcpyAsync(reinterpret_cast<void*>(home + evicted_offset),
+                                   mirror_words + evicted_offset / sizeof(std::uint32_t),
+                                   evicted_bytes, cudaMemcpyHostToDevice, device.stream));
+        device.synchronize();
+
+        // The pre-captured graph must still run and see restored bytes.
+        CUDA_CHECK(cudaGraphLaunch(execution, device.stream));
+        unsigned long long actual = 0;
+        CUDA_CHECK(cudaMemcpyAsync(&actual, result, sizeof(actual), cudaMemcpyDeviceToHost,
+                                   device.stream));
+        device.synchronize();
+
+        const auto micros = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+        };
+        std::cout << "chunk_bytes=" << chunk << " granularity=" << granularity
+                  << " evict_map_us=" << micros(evict_start, evict_end)
+                  << " restore_map_us=" << micros(restore_start, restore_end) << '\n';
+
+        int failures = 0;
+        if (actual != expected) {
+            std::cerr << "graph checksum after overlay transaction expected " << expected
+                      << ", got " << actual << '\n';
+            ++failures;
+        }
+
+        CUDA_CHECK(cudaGraphExecDestroy(execution));
+        CUDA_CHECK(cudaGraphDestroy(graph));
+        CUDA_CHECK(cudaFree(result));
+        for (std::size_t i = 0; i < kChunkCount; ++i) {
+            CU_CHECK(cuMemUnmap(home + i * chunk, chunk));
+            CU_CHECK(cuMemRelease(handles[i]));
+        }
+        CU_CHECK(cuMemAddressFree(home, total));
+        CU_CHECK(cuMemAddressFree(overlay, total));
+        return failures == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "vmm graph remap test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/smoke/overlay_ab.py
+++ b/tools/smoke/overlay_ab.py
@@ -1,0 +1,116 @@
+"""Resident-vs-overlay A/B driver for the vision VRAM overlay.
+
+Talks to a running ninfer-serve over the OpenAI chat route with one generated
+test image, greedy sampling, and prints the exact completion text plus usage so
+two runs can be diffed byte-for-byte. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import struct
+import sys
+import time
+import urllib.request
+
+
+def gradient_bmp(width: int, height: int) -> bytes:
+    """Uncompressed 24-bit BMP with a deterministic gradient."""
+    row_bytes = (width * 3 + 3) & ~3
+    image_bytes = row_bytes * height
+    header = struct.pack(
+        "<2sIHHIIiiHHIIiiII",
+        b"BM", 54 + image_bytes, 0, 0, 54,
+        40, width, height, 1, 24, 0, image_bytes, 2835, 2835, 0, 0,
+    )
+    rows = bytearray()
+    for y in range(height):
+        row = bytearray()
+        for x in range(width):
+            row += bytes(((x * 7 + y * 3) % 256, (x + 2 * y) % 256, (255 - (x // 8 + y // 8)) % 256))
+        row += b"\x00" * (row_bytes - len(row))
+        rows += row
+    return header + bytes(rows)
+
+
+def chat(base_url: str, model: str, messages: list, max_tokens: int, timeout: float = 600.0) -> dict:
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "enable_thinking": False,
+    }).encode()
+    request = urllib.request.Request(
+        base_url + "/v1/chat/completions", data=payload,
+        headers={"Content-Type": "application/json"})
+    started = time.monotonic()
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = json.loads(response.read())
+    body["_wall_seconds"] = round(time.monotonic() - started, 3)
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:18099")
+    parser.add_argument("--model", default="qwen3.8-27b")
+    parser.add_argument("--label", default="run")
+    parser.add_argument("--width", type=int, default=1920)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--concurrency-probe", action="store_true",
+                        help="run two text requests in parallel with the image request")
+    args = parser.parse_args()
+
+    image = gradient_bmp(args.width, args.height)
+    data_uri = "data:image/bmp;base64," + base64.b64encode(image).decode()
+    image_messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text",
+             "text": "Describe the colors and structure of this image in one sentence."},
+            {"type": "image_url", "image_url": {"url": data_uri}},
+        ],
+    }]
+
+    def text_request(tag: str) -> dict:
+        return chat(args.base_url, args.model,
+                    [{"role": "user", "content": f"Count from 1 to 5. ({tag})"}], 32)
+
+    results = {}
+    if args.concurrency_probe:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+            image_future = pool.submit(chat, args.base_url, args.model, image_messages, 64)
+            text_a = pool.submit(text_request, "a")
+            text_b = pool.submit(text_request, "b")
+            results["image"] = image_future.result()
+            results["text_a"] = text_a.result()
+            results["text_b"] = text_b.result()
+    else:
+        results["image"] = chat(args.base_url, args.model, image_messages, 64)
+
+    # Follow-up turn over the same image: prefix reuse must avoid a re-encode.
+    followup = image_messages + [
+        {"role": "assistant",
+         "content": results["image"]["choices"][0]["message"]["content"]},
+        {"role": "user", "content": "Now answer with exactly one word: what is the dominant hue?"},
+    ]
+    results["followup"] = chat(args.base_url, args.model, followup, 16)
+
+    for name, body in results.items():
+        message = body["choices"][0]["message"]
+        usage = body.get("usage", {})
+        print(f"[{args.label}:{name}] wall={body['_wall_seconds']}s "
+              f"prompt={usage.get('prompt_tokens')} completion={usage.get('completion_tokens')}")
+        print(f"[{args.label}:{name}] text={json.dumps(message.get('content', ''), ensure_ascii=False)}")
+        reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
+        if reasoning:
+            print(f"[{args.label}:{name}] reasoning={json.dumps(reasoning[:600], ensure_ascii=False)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

On capacity-bound GPUs, `--vision` permanently spends resident VRAM that otherwise belongs to the KV pool: the tower weights plus the vision share of the startup workspace/transient reservations, paid even when images are rare. On a 32 GiB RTX 5090 with `bf16` KV that difference is ~36k tokens of context; on 24 GiB cards it decides whether long-context serving fits at all.

Design rationale and alternatives considered: #74.

## Design

Opt-in `--vision-residency overlay` (default `resident`, bit-for-bit unchanged):

- **Evictable weight pool** (`core/evictable_weight_pool.cu`): read-only weight groups (lm_head, token embedding, MTP head, tail decoder blocks) live on VMM-backed 16-MiB physical chunks at stable VAs with pinned host mirrors. An encode window unmaps the minimal chunk prefix and remaps the *same physical handles* into a pre-reserved staging VA — zero device allocations inside the transaction, so restore cannot fail and CUDA graphs stay captured. Restore is an idempotent H2D re-upload from mirrors. Read-only weights were chosen as the eviction currency precisely because they need no D2H backup.
- **Block-streamed encode** (`vision_weight_provider`): tower weights upload block-by-block through a ~20 MiB ping-pong on a copy stream, overlapped with block compute; the borrowed footprint stays near the workspace size.
- **Residency gate**: windows are exclusive; concurrent text lanes wait and resume unharmed (their KV is never touched). In overlay mode the resident workspace envelope is text-only; vision workspace and output transient are served from the evicted staging.
- `--vision-max-merged N` bounds the vision share of the startup reservations in both modes, and the frontend **fit-and-scales** oversized media to it: `image_max_pixels` is clamped to the token budget instead of rejecting the request, so a budget-capped server degrades resolution, not availability (adopting the direction of #61).

Why this shape: it composes with the media-payload pipeline and the existing `VisionPrefillPlan` seam, so overlay outputs are bitwise-identical to resident mode, and no established contract changes — both flags are additive with resident defaults.

## Affected behavior / contracts

- New serve + single-request CLI flags (`--vision-residency`, `--vision-max-merged`); defaults preserve today's behavior exactly.
- Overlay covers both in-tree vision targets (`qwen3.8-27b`, `qwen3.6-35b-a3b`); a target without an overlay layout rejects the flag at load with an explicit message.
- Media larger than the merged-token budget is now downscaled to fit rather than rejected (only observable when `--vision-max-merged` is set below the model default).
- No API schema, artifact, or numerical contract changes.

## Verification

All measurements on native sm_120: RTX 5090 32 GiB, CUDA 13.1.2 toolkit, 580-series drivers, `-DCMAKE_CUDA_ARCHITECTURES=120a`.

- Build: `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=120a -DNINFER_BUILD_APPS=ON && cmake --build build --parallel` — clean.
- Capacity A/B (`qwen3.8-27b` groupwise-int, MTP K3 + `--lm-head-draft`, `--vision-max-merged 12288`), bisected max explicit `--kv-capacity` that boots:

| KV dtype | `resident` | `overlay` | delta |
|---|---|---|---|
| `bf16` | 171 648 | **207 936** | **+36 288 (+21.1%)** |
| `int8` | 262 144 (native cap; 2.45 GiB free after startup) | 262 144 (**4.80 GiB free**) | **+2.35 GiB headroom** |

- 35B-A3B target (`qwen3.6-35b-a3b`, int8, ctx 16 384), same serve config resident vs overlay:

| mode | runtime reservation | free after startup | image request (4000×3000) |
|---|---|---|---|
| `resident` | 1.39 GiB | 9.62 GiB | OK, prompt 11 767 tokens |
| `overlay` | 474 MiB | **10.79 GiB (+1.17 GiB)** | OK, prompt 11 767 tokens, answer sha256-identical to resident |

  Overlay window on the 35B tower: 1 912 ms total — evict 864 MiB in 1.8 ms, restore 64.5 ms, 267 MiB streamed.

- Fit-and-scale (27B overlay, one 4000×3000 JPEG):

| `--vision-max-merged` | prompt tokens | outcome |
|---|---|---|
| 12 288 | 11 767 | served at the processor resolution cap |
| 1 024 | 989 | downscaled to fit the budget (previously rejected) |

- Parity: greedy completions with an image and a follow-up turn are byte-identical between residency modes (sha256-compared).
- One-shot CLI route: `ninfer <artifact> --prompt ... --vision --vision-residency overlay --vision-max-merged 4096 --greedy` → correct output, exit 0.

Not run: upstream-format unit suites for the new core units — I can port them into `tests/` on request. Postscript: an sm_86/89 fork of this code (24 GiB RTX 3090) shows the same parity and runs its regression suites (artifact materialization, admission, runtime mechanisms, request memory, frontend) 5/5 green with the feature off and on; per-image window cost there is ~400 ms (evict ~2 ms, restore ~32 ms) against ~3.3 s vision TTFT.

## AI disclosure

Implementation and validation were produced with Anthropic Claude Fable 5 (model id `claude-fable-5`), operated, reviewed, and verified by the submitter.
