### PR TITLE
Feat/windows build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize all text files to LF so content-addressed resources (chat-template
+# SHA-256 digests, test fixtures) are byte-identical on every platform.
+* text=auto eol=lf
+
+# Binary assets.
+*.png binary
+*.mp4 binary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ endif()
 
 project(ninfer LANGUAGES C CXX CUDA)
 
+# Link the shared CUDA runtime from every target. CMake's default (static) makes
+# Windows embed cudart_static.lib through device-linked static archives while the
+# targets also link CUDA::cudart, and the two runtimes collide at link time; Linux
+# already resolves everything against the shared libcudart.
+set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
+
 # --- Global settings ---------------------------------------------------------
 option(NINFER_BUILD_APPS "Build the NInfer CLI and server" ON)
 option(BUILD_TESTING "Build NInfer tests" OFF)
@@ -24,6 +30,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD 20)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)        # clangd / IDE tooling
+if(WIN32)
+  # windows.h participates in the artifact-reader include graph and cpp-httplib uses
+  # Winsock directly; keep its macros out of project code.
+  add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
+endif()
+if(MSVC)
+  # Sources and tests embed UTF-8 comments and tokenizer literals; keep MSVC from
+  # re-encoding them through the active ANSI code page.
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:C,CXX>:/utf-8>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/utf-8>)
+  # CUDA's cuda.lib import library ships /DEFAULTLIB:LIBCMT directives that conflict
+  # with the project-wide /MD runtime (LNK4098). The driver itself lives in
+  # nvcuda.dll and needs no static CRT.
+  add_link_options(/NODEFAULTLIB:LIBCMT)
+endif()
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -55,11 +77,30 @@ if(NINFER_BUILD_APPS OR BUILD_TESTING)
 endif()
 
 find_package(CUDAToolkit REQUIRED)
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
-  libavformat>=60 libavcodec>=60 libavutil>=58 libswscale>=7)
-if(NINFER_BUILD_MEDIA_ACQUIRE)
-  pkg_check_modules(LIBCURL REQUIRED IMPORTED_TARGET libcurl>=7.85)
+
+# FFmpeg and curl come from host pkg-config on Linux and from the vcpkg manifest
+# (vcpkg.json) on Windows. Both branches publish the same NINFER_FFMPEG_TARGET and
+# NINFER_CURL_TARGET interface targets for the library definitions below.
+if(WIN32)
+  find_package(FFMPEG REQUIRED)
+  add_library(ninfer_ffmpeg_dependencies INTERFACE)
+  target_include_directories(ninfer_ffmpeg_dependencies INTERFACE ${FFMPEG_INCLUDE_DIRS})
+  target_link_directories(ninfer_ffmpeg_dependencies INTERFACE ${FFMPEG_LIBRARY_DIRS})
+  target_link_libraries(ninfer_ffmpeg_dependencies INTERFACE ${FFMPEG_LIBRARIES})
+  set(NINFER_FFMPEG_TARGET ninfer_ffmpeg_dependencies)
+  if(NINFER_BUILD_MEDIA_ACQUIRE)
+    find_package(CURL 7.85 REQUIRED)
+    set(NINFER_CURL_TARGET CURL::libcurl)
+  endif()
+else()
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+    libavformat>=60 libavcodec>=60 libavutil>=58 libswscale>=7)
+  set(NINFER_FFMPEG_TARGET PkgConfig::FFMPEG)
+  if(NINFER_BUILD_MEDIA_ACQUIRE)
+    pkg_check_modules(LIBCURL REQUIRED IMPORTED_TARGET libcurl>=7.85)
+    set(NINFER_CURL_TARGET PkgConfig::LIBCURL)
+  endif()
 endif()
 find_package(Threads REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -121,15 +121,16 @@ notes.
 
 NInfer currently requires:
 
-- 64-bit Linux;
+- 64-bit Linux or 64-bit Windows;
 - NVIDIA GeForce RTX 5090 (`sm_120a`);
 - NVIDIA driver support for CUDA 13.1 and the CUDA Toolkit 13.1 or newer;
-- CMake 3.28 or newer and a C++20-capable host compiler;
-- `pkg-config`;
+- CMake 3.28 or newer and a C++20-capable host compiler (MSVC 2022 on Windows);
 - FFmpeg development libraries: `libavformat >= 60`, `libavcodec >= 60`,
   `libavutil >= 58`, and `libswscale >= 7`;
 - `libcurl >= 7.85`;
-- Ninja, when using the commands below.
+- on Linux, `pkg-config` plus Ninja for the commands below;
+- on Windows, [vcpkg](https://github.com/microsoft/vcpkg); the `vcpkg.json` manifest
+  supplies FFmpeg and curl.
 
 The build rejects CUDA architectures other than `120a`. There is no install target or packaged
 binary distribution; NInfer is run from its source build tree.
@@ -152,6 +153,35 @@ build/apps/ninfer-serve
 ```
 
 Tests, benchmarks, and maintainer tools are excluded from the default build.
+
+### Windows
+
+Windows builds are native (MSVC + nvcc) and resolve FFmpeg and curl through the `vcpkg.json`
+manifest instead of `pkg-config`. From a PowerShell prompt:
+
+```powershell
+git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+C:\vcpkg\bootstrap-vcpkg.bat
+
+git clone https://github.com/Neroued/ninfer.git
+cd ninfer
+
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+  -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake --build build --config Release --parallel
+```
+
+The first configure restores or builds the manifest dependencies; packages are cached under
+`%LOCALAPPDATA%\vcpkg\archives`, so later configurations are fast. The executables land in
+`build\apps\Release\`. Before launching them, put the vcpkg runtime DLLs and the CUDA runtime
+on `PATH`:
+
+```powershell
+$env:PATH = "$PWD\build\vcpkg_installed\x64-windows\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.1\bin;$env:PATH"
+.\build\apps\Release\ninfer models\qwen3_8_27b.ninfer --prompt "Hello"
+```
+
+Debug builds follow the same steps with `--config Debug`.
 
 ## Docker
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,18 +269,25 @@ add_library(ninfer_text STATIC
   text/unicode.cpp
   ${PROJECT_SOURCE_DIR}/third_party/utf8proc/utf8proc.c)
 ninfer_internal_includes(ninfer_text)
+# utf8proc.h falls back to dllimport declarations for the shared-library build on
+# Windows; this tree compiles it into a static archive.
+target_compile_definitions(ninfer_text PUBLIC UTF8PROC_STATIC)
 
 add_library(ninfer_media_decode STATIC
   media/decode/decode.cpp)
 ninfer_internal_includes(ninfer_media_decode)
-target_link_libraries(ninfer_media_decode PRIVATE PkgConfig::FFMPEG)
+target_link_libraries(ninfer_media_decode PRIVATE ${NINFER_FFMPEG_TARGET})
 
 if(NINFER_BUILD_MEDIA_ACQUIRE)
   # Product-only path/data/HTTP acquisition. No target package links this library.
   add_library(ninfer_media_acquire STATIC
     product/media_acquire/acquire.cpp)
   ninfer_internal_includes(ninfer_media_acquire)
-  target_link_libraries(ninfer_media_acquire PRIVATE PkgConfig::LIBCURL)
+  target_link_libraries(ninfer_media_acquire PRIVATE ${NINFER_CURL_TARGET})
+  if(WIN32)
+    # curl's Winsock transport requires ws2_32 at link time.
+    target_link_libraries(ninfer_media_acquire PRIVATE ws2_32)
+  endif()
 endif()
 
 if(NINFER_BUILD_PROMPT_INPUT)

--- a/src/artifact/reader.cpp
+++ b/src/artifact/reader.cpp
@@ -15,10 +15,20 @@
 #include <unordered_map>
 #include <utility>
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 namespace ninfer::artifact {
 namespace {
@@ -181,6 +191,66 @@ struct TransparentStringHash {
 class MappedFile {
 public:
     explicit MappedFile(const std::filesystem::path& path) {
+#ifdef _WIN32
+        mapping_file_ = ::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (mapping_file_ == INVALID_HANDLE_VALUE) {
+            throw std::system_error(static_cast<int>(::GetLastError()), std::system_category(),
+                                    "CreateFileW " + path.string());
+        }
+
+        LARGE_INTEGER file_size {};
+        if (!::GetFileSizeEx(mapping_file_, &file_size)) {
+            const auto error = ::GetLastError();
+            ::CloseHandle(mapping_file_);
+            mapping_file_ = INVALID_HANDLE_VALUE;
+            throw std::system_error(static_cast<int>(error), std::system_category(),
+                                    "GetFileSizeEx " + path.string());
+        }
+        if (file_size.QuadPart < 0 ||
+            static_cast<std::uint64_t>(file_size.QuadPart) >
+                static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            ::CloseHandle(mapping_file_);
+            mapping_file_ = INVALID_HANDLE_VALUE;
+            throw ArtifactError("artifact size does not fit the process address space");
+        }
+
+        size_ = static_cast<std::size_t>(file_size.QuadPart);
+        if (size_ != 0) {
+            mapping_ = ::CreateFileMappingW(mapping_file_, nullptr, PAGE_READONLY, 0, 0, nullptr);
+            if (mapping_ == nullptr) {
+                const auto error = ::GetLastError();
+                ::CloseHandle(mapping_file_);
+                mapping_file_ = INVALID_HANDLE_VALUE;
+                throw std::system_error(static_cast<int>(error), std::system_category(),
+                                        "CreateFileMappingW " + path.string());
+            }
+            const void* view = ::MapViewOfFile(mapping_, FILE_MAP_READ, 0, 0, 0);
+            if (view == nullptr) {
+                const auto error = ::GetLastError();
+                ::CloseHandle(mapping_);
+                ::CloseHandle(mapping_file_);
+                mapping_      = nullptr;
+                mapping_file_ = INVALID_HANDLE_VALUE;
+                throw std::system_error(static_cast<int>(error), std::system_category(),
+                                        "MapViewOfFile " + path.string());
+            }
+            data_ = static_cast<const std::byte*>(view);
+        }
+
+        // Direct reads bypass the system cache like the POSIX O_DIRECT path below.
+        direct_file_ =
+            ::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                          FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING | FILE_FLAG_OVERLAPPED |
+                              FILE_FLAG_SEQUENTIAL_SCAN,
+                          nullptr);
+        if (direct_file_ == INVALID_HANDLE_VALUE) {
+            const auto error = ::GetLastError();
+            close_mapping();
+            throw std::system_error(static_cast<int>(error), std::system_category(),
+                                    "CreateFileW direct " + path.string());
+        }
+#else
         const int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC | O_DIRECT);
         if (fd < 0) {
             throw std::system_error(errno, std::generic_category(), "open " + path.string());
@@ -212,11 +282,19 @@ public:
         fd_   = fd;
         data_ = static_cast<const std::byte*>(mapping);
         size_ = size;
+#endif
     }
 
     ~MappedFile() {
+#ifdef _WIN32
+        if (data_ != nullptr) { ::UnmapViewOfFile(data_); }
+        if (mapping_ != nullptr) { ::CloseHandle(mapping_); }
+        if (direct_file_ != INVALID_HANDLE_VALUE) { ::CloseHandle(direct_file_); }
+        if (mapping_file_ != INVALID_HANDLE_VALUE) { ::CloseHandle(mapping_file_); }
+#else
         if (data_ != nullptr) { ::munmap(const_cast<std::byte*>(data_), size_); }
         if (fd_ >= 0) { ::close(fd_); }
+#endif
     }
 
     MappedFile(const MappedFile&)            = delete;
@@ -232,6 +310,41 @@ public:
             reinterpret_cast<std::uintptr_t>(destination.data()) % alignment != 0) {
             throw ArtifactError("direct artifact read is not 4096-byte aligned");
         }
+#ifdef _WIN32
+        std::size_t total = 0;
+        while (total < destination.size()) {
+            // ReadFile transfers at most DWORD bytes per call.
+            constexpr std::size_t max_chunk = std::size_t {1} << 30;
+            const auto amount =
+                static_cast<DWORD>(std::min(max_chunk, destination.size() - total));
+            const auto offset = absolute_offset + total;
+
+            OVERLAPPED overlapped {};
+            overlapped.Offset     = static_cast<DWORD>(offset & 0xFFFFFFFFULL);
+            overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
+
+            DWORD bytes = 0;
+            if (::ReadFile(direct_file_, destination.data() + total, amount, &bytes,
+                           &overlapped) == FALSE) {
+                auto error = ::GetLastError();
+                if (error == ERROR_IO_PENDING) {
+                    if (::GetOverlappedResult(direct_file_, &overlapped, &bytes, TRUE) != FALSE) {
+                        error = ERROR_SUCCESS;
+                    } else {
+                        error = ::GetLastError();
+                    }
+                }
+                if (error == ERROR_HANDLE_EOF) { break; }
+                if (error != ERROR_SUCCESS) {
+                    throw std::system_error(static_cast<int>(error), std::system_category(),
+                                            "direct artifact read");
+                }
+            }
+            total += bytes;
+            if (bytes != amount) { break; }
+        }
+        return total;
+#else
         if (absolute_offset > static_cast<std::uint64_t>(std::numeric_limits<off_t>::max()) ||
             destination.size() > static_cast<std::size_t>(std::numeric_limits<ssize_t>::max())) {
             throw ArtifactError("direct artifact read exceeds platform I/O limits");
@@ -246,10 +359,30 @@ public:
             throw std::system_error(errno, std::generic_category(), "direct artifact read");
         }
         return static_cast<std::size_t>(bytes);
+#endif
     }
 
 private:
+#ifdef _WIN32
+    void close_mapping() {
+        if (data_ != nullptr) {
+            ::UnmapViewOfFile(data_);
+            data_ = nullptr;
+        }
+        if (mapping_ != nullptr) {
+            ::CloseHandle(mapping_);
+            mapping_ = nullptr;
+        }
+        ::CloseHandle(mapping_file_);
+        mapping_file_ = INVALID_HANDLE_VALUE;
+    }
+
+    HANDLE mapping_file_   = INVALID_HANDLE_VALUE;
+    HANDLE direct_file_    = INVALID_HANDLE_VALUE;
+    HANDLE mapping_        = nullptr;
+#else
     int fd_                = -1;
+#endif
     const std::byte* data_ = nullptr;
     std::size_t size_      = 0;
 };

--- a/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cu
+++ b/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cu
@@ -72,7 +72,11 @@ void launch_tma(const std::uint8_t* activation_codes, const std::uint8_t* activa
 
     const dim3 grid(Geometry::kOutputRows / Schedule::kBlockN, tokens / Schedule::kBlockM);
     nvfp4_w4a4_tma_kernel<Geometry, Schedule>
-        <<<grid, Schedule::kThreads, kSharedBytes, stream>>>(descriptors, alpha, epilogue, output);
+        <<<grid, Schedule::kThreads, kSharedBytes, stream>>>(descriptors.a_codes,
+                                                             descriptors.b_codes,
+                                                             descriptors.a_scales,
+                                                             descriptors.b_scales, alpha, epilogue,
+                                                             output);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
+++ b/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
@@ -182,7 +182,12 @@ __device__ __forceinline__ void nvfp4_tma_load_2d(void* destination, const CUten
 template <class Geometry, class Schedule, class Epilogue, class OutputPolicy>
 __global__
 __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4_tma_kernel(
-    const __grid_constant__ Nvfp4W4a4TmaDescriptors descriptors, float alpha,
+    // The tensor maps travel as separate grid-constant parameters because MSVC's x64
+    // ABI cannot pass the over-aligned Nvfp4W4a4TmaDescriptors aggregate by value.
+    const __grid_constant__ CUtensorMap a_codes_map,
+    const __grid_constant__ CUtensorMap b_codes_map,
+    const __grid_constant__ CUtensorMap a_scales_map,
+    const __grid_constant__ CUtensorMap b_scales_map, float alpha,
     const __grid_constant__ Epilogue epilogue, const __grid_constant__ OutputPolicy output) {
     static_assert((Geometry::kInputRows % Schedule::kBlockK) == 0);
     static_assert((Geometry::kOutputRows % Schedule::kBlockN) == 0);
@@ -222,17 +227,17 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
                 nvfp4_mbarrier_arrive_expect_tx(&shared.full[stage], kTransactionBytes);
 
                 auto& tensors = shared.scratch.tensors;
-                nvfp4_tma_load_2d(tensors.a_codes[stage], &descriptors.a_codes,
+                nvfp4_tma_load_2d(tensors.a_codes[stage], &a_codes_map,
                                   k_tile * Schedule::kCodeRowBytes, token_begin,
                                   &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.b_codes[stage], &descriptors.b_codes,
+                nvfp4_tma_load_2d(tensors.b_codes[stage], &b_codes_map,
                                   k_tile * Schedule::kCodeRowBytes, row_begin, &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.a_scale4[stage], &descriptors.a_scales, (k_tile / 2) * 16,
+                nvfp4_tma_load_2d(tensors.a_scale4[stage], &a_scales_map, (k_tile / 2) * 16,
                                   token_begin, &shared.full[stage]);
                 const int b_scale_row = ((row_begin / 128) * Geometry::kScaleTilesPerRow +
                                          k_tile * Schedule::kK64PerStage) *
                                         32;
-                nvfp4_tma_load_2d(tensors.b_scales[stage], &descriptors.b_scales, 0, b_scale_row,
+                nvfp4_tma_load_2d(tensors.b_scales[stage], &b_scales_map, 0, b_scale_row,
                                   &shared.full[stage]);
             }
         }

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cu
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cu
@@ -72,7 +72,11 @@ void launch_nvfp4_linear_swiglu_w4a4_tma(const std::uint8_t* activation_codes,
     constexpr int kPairN = M256N128S3::kBlockN / 2;
     const dim3 grid((Geometry::kOutputRows / 2) / kPairN, tokens / M256N128S3::kBlockM);
     nvfp4_linear_swiglu_w4a4_tma_kernel<Geometry, M256N128S3>
-        <<<grid, M256N128S3::kThreads, kSharedBytes, stream>>>(descriptors, alpha, output);
+        <<<grid, M256N128S3::kThreads, kSharedBytes, stream>>>(descriptors.a_codes,
+                                                               descriptors.b_codes,
+                                                               descriptors.a_scales,
+                                                               descriptors.b_scales, alpha,
+                                                               output);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
@@ -46,11 +46,14 @@ template <class Geometry, class Schedule>
 __global__ __launch_bounds__(
     Schedule::kThreads,
     Schedule::
-        kMinBlocksPerSm) void nvfp4_linear_swiglu_w4a4_tma_kernel(const __grid_constant__
-                                                                      Nvfp4W4a4TmaDescriptors
-                                                                          descriptors,
-                                                                  float alpha,
-                                                                  __nv_bfloat16* __restrict__ output) {
+        kMinBlocksPerSm) void nvfp4_linear_swiglu_w4a4_tma_kernel(
+        // The tensor maps travel as separate grid-constant parameters because MSVC's
+        // x64 ABI cannot pass the over-aligned Nvfp4W4a4TmaDescriptors aggregate by value.
+        const __grid_constant__ CUtensorMap a_codes_map,
+        const __grid_constant__ CUtensorMap b_codes_map,
+        const __grid_constant__ CUtensorMap a_scales_map,
+        const __grid_constant__ CUtensorMap b_scales_map, float alpha,
+        __nv_bfloat16* __restrict__ output) {
     static_assert(Geometry::kOutputRows == 34816);
     static_assert(Geometry::kInputRows == 5120);
     static_assert((Geometry::kInputRows % Schedule::kBlockK) == 0);
@@ -98,16 +101,16 @@ __global__ __launch_bounds__(
                 nvfp4_mbarrier_arrive_expect_tx(&shared.full[stage], kTransactionBytes);
 
                 auto& tensors = shared.scratch.tensors;
-                nvfp4_tma_load_2d(tensors.a_codes[stage], &descriptors.a_codes,
+                nvfp4_tma_load_2d(tensors.a_codes[stage], &a_codes_map,
                                   k_tile * Schedule::kCodeRowBytes, token_begin,
                                   &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.b_codes[stage], &descriptors.b_codes,
+                nvfp4_tma_load_2d(tensors.b_codes[stage], &b_codes_map,
                                   k_tile * Schedule::kCodeRowBytes, pair_begin,
                                   &shared.full[stage]);
                 nvfp4_tma_load_2d(tensors.b_codes[stage] + kPairN * Schedule::kCodeRowBytes,
-                                  &descriptors.b_codes, k_tile * Schedule::kCodeRowBytes,
+                                  &b_codes_map, k_tile * Schedule::kCodeRowBytes,
                                   pair_begin + kIntermediate, &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.a_scale4[stage], &descriptors.a_scales, (k_tile / 2) * 16,
+                nvfp4_tma_load_2d(tensors.a_scale4[stage], &a_scales_map, (k_tile / 2) * 16,
                                   token_begin, &shared.full[stage]);
 
                 const int gate_scale_row = ((pair_begin / 128) * Geometry::kScaleTilesPerRow +
@@ -117,9 +120,9 @@ __global__ __launch_bounds__(
                     (((pair_begin + kIntermediate) / 128) * Geometry::kScaleTilesPerRow +
                      k_tile * Schedule::kK64PerStage) *
                     32;
-                nvfp4_tma_load_2d(tensors.b_scales[stage][0], &descriptors.b_scales, 0,
+                nvfp4_tma_load_2d(tensors.b_scales[stage][0], &b_scales_map, 0,
                                   gate_scale_row, &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.b_scales[stage][1], &descriptors.b_scales, 0,
+                nvfp4_tma_load_2d(tensors.b_scales[stage][1], &b_scales_map, 0,
                                   up_scale_row, &shared.full[stage]);
             }
         }

--- a/src/product/load_progress/load_progress.cpp
+++ b/src/product/load_progress/load_progress.cpp
@@ -1,6 +1,10 @@
 #include "product/load_progress/load_progress.h"
 
+#if defined(_WIN32)
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <algorithm>
 #include <array>
@@ -60,7 +64,12 @@ std::string format_line(std::string_view phase, std::uint64_t done, std::uint64_
 } // namespace
 
 LoadProgressRendererOptions stderr_load_progress_options() noexcept {
-    if (::isatty(STDERR_FILENO) == 1) {
+#if defined(_WIN32)
+    const bool interactive = ::_isatty(::_fileno(stderr)) == 1;
+#else
+    const bool interactive = ::isatty(STDERR_FILENO) == 1;
+#endif
+    if (interactive) {
         return LoadProgressRendererOptions{
             .mode                 = LoadProgressOutputMode::Interactive,
             .min_refresh_interval = std::chrono::milliseconds(200),

--- a/src/product/media_acquire/acquire.cpp
+++ b/src/product/media_acquire/acquire.cpp
@@ -2,9 +2,14 @@
 
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/socket.h>
+#endif
 
 #include <algorithm>
 #include <array>
@@ -143,6 +148,17 @@ UrlParts parse_url(std::string_view value) {
 }
 
 std::string resolve_public(const UrlParts& url, bool allow_private) {
+#ifdef _WIN32
+    static std::once_flag winsock_init;
+    std::call_once(winsock_init, [] {
+        WSADATA data {};
+        const int result = ::WSAStartup(MAKEWORD(2, 2), &data);
+        if (result != 0) {
+            throw Error(ErrorKind::RemoteUnavailable,
+                        "failed to initialize Winsock: " + std::to_string(result));
+        }
+    });
+#endif
     addrinfo hints{};
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -150,7 +166,12 @@ std::string resolve_public(const UrlParts& url, bool allow_private) {
     const int rc      = getaddrinfo(url.host.c_str(), url.port.c_str(), &hints, &raw);
     if (rc != 0) {
         throw Error(ErrorKind::RemoteUnavailable,
-                    "failed to resolve media URL host: " + std::string(gai_strerror(rc)));
+                    "failed to resolve media URL host: " +
+#ifdef _WIN32
+                        std::to_string(rc));
+#else
+                        std::string(gai_strerror(rc)));
+#endif
     }
     std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> addresses(raw, freeaddrinfo);
     std::string selected;
@@ -287,7 +308,7 @@ std::vector<std::uint8_t> read_path(const Source& source, const Policy& policy) 
     if (!policy.media_root.empty()) {
         const std::filesystem::path root = std::filesystem::weakly_canonical(policy.media_root, ec);
         const auto relative              = std::filesystem::relative(path, root, ec);
-        if (ec || relative.empty() || relative.native().starts_with("..")) {
+        if (ec || relative.empty() || relative.generic_string().starts_with("..")) {
             throw std::invalid_argument("media path is outside configured media root");
         }
     }

--- a/src/serve/console_log.cpp
+++ b/src/serve/console_log.cpp
@@ -38,7 +38,11 @@ std::string format_console_log_prefix(std::chrono::system_clock::time_point time
     const std::time_t wall_seconds =
         std::chrono::system_clock::to_time_t(std::chrono::system_clock::time_point(whole_seconds));
     std::tm local{};
+#ifdef _WIN32
+    localtime_s(&local, &wall_seconds);
+#else
     localtime_r(&wall_seconds, &local);
+#endif
 
     std::ostringstream out;
     out << '[' << std::put_time(&local, "%Y-%m-%d %H:%M:%S") << '.' << std::setfill('0')

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -15,7 +15,11 @@
 #include <system_error>
 #include <utility>
 
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 
 namespace ninfer::serve {
 namespace {
@@ -31,8 +35,12 @@ std::uint64_t unix_time_ms() {
 std::string new_server_instance_id() {
     const auto now    = std::chrono::system_clock::now().time_since_epoch();
     const auto micros = std::chrono::duration_cast<std::chrono::microseconds>(now).count();
-    return "serve-" + std::to_string(static_cast<long long>(::getpid())) + '-' +
-           std::to_string(micros);
+#ifdef _WIN32
+    const auto process_id = static_cast<long long>(::_getpid());
+#else
+    const auto process_id = static_cast<long long>(::getpid());
+#endif
+    return "serve-" + std::to_string(process_id) + '-' + std::to_string(micros);
 }
 
 std::filesystem::path normalized_absolute_path(const std::string& value) {

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -17,10 +17,17 @@ SequencePlan<Variant>::SequencePlan(
     std::unique_ptr<detail::SequencePlanImpl<Variant>> impl) noexcept
     : impl_(std::move(impl)) {}
 
+// The move operations are written out instead of "= default": MSVC does not emit
+// code for an explicitly-defaulted specialization that this translation unit never
+// uses, which leaves the symbols undefined for callers in other units.
 template <>
-SequencePlan<Variant>::SequencePlan(SequencePlan&&) noexcept = default;
+SequencePlan<Variant>::SequencePlan(SequencePlan&& other) noexcept
+    : impl_(std::move(other.impl_)) {}
 template <>
-SequencePlan<Variant>& SequencePlan<Variant>::operator=(SequencePlan&&) noexcept = default;
+SequencePlan<Variant>& SequencePlan<Variant>::operator=(SequencePlan&& other) noexcept {
+    impl_ = std::move(other.impl_);
+    return *this;
+}
 template <>
 SequencePlan<Variant>::~SequencePlan() = default;
 
@@ -60,9 +67,13 @@ SequencePlanner<Variant>::SequencePlanner(
     : impl_(std::move(impl)) {}
 
 template <>
-SequencePlanner<Variant>::SequencePlanner(SequencePlanner&&) noexcept = default;
+SequencePlanner<Variant>::SequencePlanner(SequencePlanner&& other) noexcept
+    : impl_(std::move(other.impl_)) {}
 template <>
-SequencePlanner<Variant>& SequencePlanner<Variant>::operator=(SequencePlanner&&) noexcept = default;
+SequencePlanner<Variant>& SequencePlanner<Variant>::operator=(SequencePlanner&& other) noexcept {
+    impl_ = std::move(other.impl_);
+    return *this;
+}
 template <>
 SequencePlanner<Variant>::~SequencePlanner() = default;
 
@@ -85,9 +96,13 @@ RequestBasePlan<Variant>::RequestBasePlan(
     : impl_(std::move(impl)) {}
 
 template <>
-RequestBasePlan<Variant>::RequestBasePlan(RequestBasePlan&&) noexcept = default;
+RequestBasePlan<Variant>::RequestBasePlan(RequestBasePlan&& other) noexcept
+    : impl_(std::move(other.impl_)) {}
 template <>
-RequestBasePlan<Variant>& RequestBasePlan<Variant>::operator=(RequestBasePlan&&) noexcept = default;
+RequestBasePlan<Variant>& RequestBasePlan<Variant>::operator=(RequestBasePlan&& other) noexcept {
+    impl_ = std::move(other.impl_);
+    return *this;
+}
 template <>
 RequestBasePlan<Variant>::~RequestBasePlan() = default;
 
@@ -102,9 +117,13 @@ RequestPlan<Variant>::RequestPlan(std::unique_ptr<detail::RequestPlanImpl<Varian
     : impl_(std::move(impl)) {}
 
 template <>
-RequestPlan<Variant>::RequestPlan(RequestPlan&&) noexcept = default;
+RequestPlan<Variant>::RequestPlan(RequestPlan&& other) noexcept
+    : impl_(std::move(other.impl_)) {}
 template <>
-RequestPlan<Variant>& RequestPlan<Variant>::operator=(RequestPlan&&) noexcept = default;
+RequestPlan<Variant>& RequestPlan<Variant>::operator=(RequestPlan&& other) noexcept {
+    impl_ = std::move(other.impl_);
+    return *this;
+}
 template <>
 RequestPlan<Variant>::~RequestPlan() = default;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "ninfer",
+  "version-string": "0.1.0",
+  "builtin-baseline": "7f3781e19cc7d4e4882a4caec01668c6f7b5c163",
+  "dependencies": [
+    "curl",
+    {
+      "name": "ffmpeg",
+      "features": [
+        "zlib"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# PR: native Windows (MSVC + nvcc) build via vcpkg

**Base:** `Neroued/ninfer` `master` → **Head:** `Don-Moahskarton:ninfer:feat/windows-build`
**Branch head:** `3f349252` (6 commits, 15 files, +352/−42), based on current `master` (`feaf4dd0`)

## Summary

Adds native Windows (MSVC 2022 + nvcc) build support. FFmpeg and curl are resolved
through a vcpkg manifest instead of pkg-config, the artifact reader and a few
product/serve components get Win32 ports, and two MSVC-specific compile/link
fixes are applied. Linux builds are unchanged (pkg-config path kept as-is).

Every change in this PR is motivated by the Windows build:

- `build(windows)`: vcpkg manifest for FFmpeg/curl, shared CUDA runtime, MSVC
  `/utf-8`, `NOMINMAX`/`WIN32_LEAN_AND_MEAN`, `/NODEFAULTLIB:LIBCMT`
- `feat(windows)`: Win32 file mapping + unbuffered overlapped I/O in the artifact
  reader; Win32 ports of `isatty`, DNS resolution (WSAStartup), `localtime_s`,
  `_getpid`; media-root traversal check fixed to compare generic (forward-slash)
  paths
- `fix(msvc)`: nvfp4 TMA kernels take the four `CUtensorMap` tensor maps as
  separate `__grid_constant__` parameters (MSVC's x64 ABI cannot pass the
  over-aligned descriptors aggregate by value)
- `fix(msvc)`: explicit move operations for the qwen3.6 plan template
  specializations (MSVC leaves explicitly-defaulted specializations unemitted,
  breaking cross-TU links)
- `docs(windows)` + `chore(windows)`: README build instructions, and `.gitattributes`
  normalizing text files to LF so content-addressed fixtures stay byte-identical
  across platforms

## Proof: Windows build

Clean configure + full Release build on Windows 10/11, RTX 5090 Laptop GPU
(`sm_120a`), native toolchain:

- MSVC 14.38 (Visual Studio 2022 Community, x64)
- CMake 3.31.6, CUDA 13.1.80 (`nvcc`)
- vcpkg manifest mode, baseline `7f3781e19cc7d4e4882a4caec01668c6f7b5c163`
  (curl 8.21.0, ffmpeg 9.0.1)

```powershell
git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
C:\vcpkg\bootstrap-vcpkg.bat
git clone https://github.com/Neroued/ninfer.git
cd ninfer

cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
  -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
cmake --build build --config Release --parallel
```
