### PR TITLE
feat(serve): accept json_object/json_schema response_format with prompt injection

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -81,7 +81,8 @@ The endpoint supports:
 - function tools, tool choices, assistant tool-call history, and tool-result messages;
 - the top-level `reasoning_effort` field;
 - the `enable_thinking` extension;
-- `chat_template_kwargs.preserve_thinking` and the top-level `preserve_thinking` alias.
+- `chat_template_kwargs.preserve_thinking` and the top-level `preserve_thinking` alias;
+- the top-level `response_format` field with types `text`, `json_object`, and `json_schema`.
 
 The request `model` must equal the public model ID: the artifact `identity.model_id` by default, or
 the explicit `--model-id` override. Reasoning is returned separately as `reasoning_content`; answer
@@ -109,6 +110,16 @@ select the corresponding template effort when available. The other OpenAI protoc
 prompts. It defaults to the server setting, which is off unless `--preserve-thinking` is used. If
 both OpenAI spellings are present they must carry the same boolean value. Unknown non-null
 `chat_template_kwargs` are rejected.
+
+`response_format` accepts `{"type":"text"}`, `{"type":"json_object"}`, and
+`{"type":"json_schema","json_schema":{"name":...,"strict":...,"schema":{...}}}`. The engine has
+no token-level constraint, so the JSON types are enforced by injecting an instruction into the
+prompt: `json_object` requests a single JSON object and nothing else; `json_schema` additionally
+embeds the client `schema` object. The instruction is appended to a leading system turn when one
+is present, otherwise a system turn is prepended. The `name` and `strict` fields of `json_schema`
+are carried for wire compatibility only. Any other `response_format` type, a non-object
+`response_format`, or a `json_schema` entry without an object `schema` returns HTTP 400 with code
+`response_format_not_supported`.
 
 Streaming begins with an assistant-role chunk, sends separate reasoning and content deltas, then a
 finish-reason chunk and `[DONE]`. When `stream_options.include_usage` is true, a final empty

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -442,19 +442,54 @@ void reject_unsupported_features(const Json& body) {
             throw ApiException(std::move(error));
         }
     }
-    if (body.contains("response_format") && !body.at("response_format").is_null()) {
-        const Json& fmt  = body.at("response_format");
-        std::string type = fmt.is_object() && fmt.contains("type") && fmt.at("type").is_string()
-                               ? fmt.at("type").get<std::string>()
-                               : std::string();
-        if (type != "text") {
-            ApiError error;
-            error.message = "only response_format {type:text} is supported";
-            error.param   = "response_format";
-            error.code    = "response_format_not_supported";
-            throw ApiException(std::move(error));
-        }
+}
+
+// Accepts {type:text}, {type:json_object}, and {type:json_schema} (schema and
+// strict are carried; name is ignored). The `strict` flag is parsed for wire
+// compatibility only — there is no token-level constraint in this engine.
+void parse_response_format(const Json& body, GenerationRequest& out) {
+    if (!body.contains("response_format") || body.at("response_format").is_null()) {
+        return;
     }
+    const Json& fmt = body.at("response_format");
+    if (!fmt.is_object()) {
+        bad_request("response_format must be an object", "response_format",
+                    "response_format_not_supported");
+    }
+    if (!fmt.contains("type") || !fmt.at("type").is_string()) {
+        bad_request("response_format.type must be a string", "response_format",
+                    "response_format_not_supported");
+    }
+    const std::string type = fmt.at("type").get<std::string>();
+    if (type == "text") {
+        out.structured_output = StructuredOutput{StructuredOutputType::Text, {}};
+        return;
+    }
+    if (type == "json_object") {
+        out.structured_output = StructuredOutput{StructuredOutputType::JsonObject, {}};
+        return;
+    }
+    if (type == "json_schema") {
+        if (!fmt.contains("json_schema") || !fmt.at("json_schema").is_object()) {
+            bad_request("response_format.json_schema must be an object", "response_format",
+                        "response_format_not_supported");
+        }
+        const Json& js = fmt.at("json_schema");
+        if (!js.contains("schema") || !js.at("schema").is_object()) {
+            bad_request("response_format.json_schema.schema must be an object",
+                        "response_format", "response_format_not_supported");
+        }
+        out.structured_output =
+            StructuredOutput{StructuredOutputType::JsonSchema, js.at("schema").dump()};
+        return;
+    }
+    ApiError error;
+    error.status  = 400;
+    error.message = "response_format.type '" + type + "' is not supported; only text, "
+                    "json_object, and json_schema are accepted";
+    error.param   = "response_format";
+    error.code    = "response_format_not_supported";
+    throw ApiException(std::move(error));
 }
 
 Json base_chunk(const std::string& id, const std::string& model, std::int64_t created) {
@@ -548,6 +583,7 @@ GenerationRequest parse_chat_completion_request(const Json& body, const RequestL
     parse_messages(body, out);
     parse_stop(body, out);
     parse_sampling(body, out);
+    parse_response_format(body, out);
 
     out.stream = get_bool(body, "stream", false);
     if (body.contains("stream_options") && body.at("stream_options").is_object()) {

--- a/src/serve/openai_schema.h
+++ b/src/serve/openai_schema.h
@@ -19,7 +19,7 @@ namespace ninfer::serve {
 // OpenAI and Anthropic schema layers.
 
 // Parse an already-decoded JSON body into a GenerationRequest. Throws ApiException
-// on malformed or unsupported requests (n>1, tools, non-text response_format, ...).
+// on malformed or unsupported requests (n>1, tools, unknown response_format type, ...).
 GenerationRequest parse_chat_completion_request(const nlohmann::json& body,
                                                 const RequestLimits& limits);
 

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -89,6 +89,21 @@ enum class ToolChoiceMode {
     Named,
 };
 
+// Wire value of `response_format.type` accepted by the OpenAI layer. The engine
+// performs no token-level constraint; JSON modes are prompt-injected (see
+// translate.cpp) in the same soft-JSON spirit as llama.cpp's json_object path.
+enum class StructuredOutputType : std::uint8_t {
+    None,
+    Text,
+    JsonObject,
+    JsonSchema,
+};
+
+struct StructuredOutput {
+    StructuredOutputType type = StructuredOutputType::None;
+    std::string schema_json; // serialized `json_schema.schema` for JsonSchema
+};
+
 struct ToolChoice {
     ToolChoiceMode mode = ToolChoiceMode::Auto;
     std::string name;
@@ -170,6 +185,7 @@ struct GenerationRequest {
     std::vector<ToolDefinition> tools;
     std::size_t tool_name_max_length = 64;
     ToolChoice tool_choice;
+    StructuredOutput structured_output;
     std::vector<std::string> stop_strings;
     int max_tokens      = 0; // 0 => use server default
     bool max_tokens_set = false;

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -157,12 +157,42 @@ ResolvedPromptSemantics resolve_prompt_semantics(const GenerationRequest& reques
     return result;
 }
 
+// JSON response formats have no token-level constraint in this engine, so they
+// are enforced by an instruction injected into the prompt — the same soft-JSON
+// approach llama.cpp pairs with its json_object grammar. JsonObject asks for a
+// bare object; JsonSchema additionally carries the client's schema.
+std::string structured_output_instruction(const StructuredOutput& output) {
+    std::string text = "You must respond with a single JSON object and nothing else: "
+                       "no prose, no explanations, no markdown code fences.";
+    if (output.type == StructuredOutputType::JsonSchema) {
+        text += " The object must conform to this JSON schema:\n" + output.schema_json;
+    }
+    return text;
+}
+
 ninfer::PromptInput to_prompt_input(const GenerationRequest& request,
                                     const ResolvedPromptSemantics& semantics,
                                     const MediaAcquirer& acquire_media) {
+    std::vector<ChatTurn> turns = request.messages;
+    const StructuredOutput& output = request.structured_output;
+    if (output.type == StructuredOutputType::JsonObject ||
+        output.type == StructuredOutputType::JsonSchema) {
+        ContentPart instruction;
+        instruction.kind = ContentKind::Text;
+        instruction.text = structured_output_instruction(output);
+        if (!turns.empty() && turns.front().role == ChatRole::System) {
+            turns.front().content.push_back(std::move(instruction));
+        } else {
+            ChatTurn system;
+            system.role    = ChatRole::System;
+            system.content = std::vector<ContentPart>{std::move(instruction)};
+            turns.insert(turns.begin(), std::move(system));
+        }
+    }
+
     ninfer::PromptInput input;
-    input.messages.reserve(request.messages.size());
-    for (const ChatTurn& turn : request.messages) {
+    input.messages.reserve(turns.size());
+    for (const ChatTurn& turn : turns) {
         ninfer::ChatMessage message;
         message.role              = turn.role;
         message.reasoning_content = turn.reasoning_content;

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -358,17 +358,33 @@ int test_reject_unsupported() {
 
     Json rf               = base;
     rf["response_format"] = Json{{"type", "json_object"}};
-    failures +=
-        check(throws_api([&] { (void)parse_chat_completion_request(rf, default_limits()); }),
-              "json response_format rejected");
+    GenerationRequest rf_req =
+        parse_chat_completion_request(rf, default_limits());
+    failures += check(rf_req.structured_output.type == StructuredOutputType::JsonObject,
+                      "json_object response_format accepted");
 
     Json rf_text               = base;
     rf_text["response_format"] = Json{{"type", "text"}};
     bool text_ok               = true;
+    GenerationRequest text_req;
     try {
-        (void)parse_chat_completion_request(rf_text, default_limits());
+        text_req = parse_chat_completion_request(rf_text, default_limits());
     } catch (...) { text_ok = false; }
     failures += check(text_ok, "text response_format accepted");
+    failures += check(text_req.structured_output.type == StructuredOutputType::Text,
+                      "text response_format recorded");
+
+    Json rf_unknown = base;
+    rf_unknown["response_format"] = Json{{"type", "json"}};
+    failures += check(api_code([&] { (void)parse_chat_completion_request(rf_unknown, default_limits()); })
+                          == "response_format_not_supported",
+                      "unknown response_format type rejected with code");
+
+    Json rf_malformed = base;
+    rf_malformed["response_format"] = Json{{"type", "json_schema"}};
+    failures += check(api_code([&] { (void)parse_chat_completion_request(rf_malformed, default_limits()); })
+                          == "response_format_not_supported",
+                      "json_schema without schema rejected");
 
     Json no_model = {{"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
     failures +=
@@ -380,6 +396,86 @@ int test_reject_unsupported() {
     failures += check(
         throws_api([&] { (void)parse_chat_completion_request(function_role, default_limits()); }),
         "function role rejected");
+    return failures;
+}
+
+int test_response_format() {
+    int failures = 0;
+
+    // json_object without a system message: instruction becomes a new leading
+    // system turn, original turns untouched.
+    {
+        Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+            {"response_format", Json{{"type", "json_object"}}},
+        };
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const ninfer::PromptInput input = translate(req);
+        failures += check(input.messages.size() == 2, "json_object: system turn injected");
+        failures += check(input.messages.front().role == ninfer::ChatRole::System,
+                          "json_object: leading system");
+        failures += check(joined_text(input.messages.front()).find("single JSON object") !=
+                              std::string::npos,
+                          "json_object: instruction text present");
+        failures += check(input.messages.back().role == ninfer::ChatRole::User,
+                          "json_object: user turn kept");
+        failures += check(joined_text(input.messages.back()) == "hi", "json_object: user text kept");
+    }
+
+    // json_object with an existing system message: appended to it, not duplicated.
+    {
+        Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "system"}, {"content", "be brief"}},
+                                      Json{{"role", "user"}, {"content", "hi"}}})},
+            {"response_format", Json{{"type", "json_object"}}},
+        };
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const ninfer::PromptInput input = translate(req);
+        failures += check(input.messages.size() == 2, "json_object: no duplicate system turn");
+        const std::string system_text = joined_text(input.messages.front());
+        failures += check(system_text.find("be brief") != std::string::npos,
+                          "json_object: original system text kept");
+        failures += check(system_text.find("single JSON object") != std::string::npos,
+                          "json_object: instruction appended to system");
+    }
+
+    // json_schema: the client schema is embedded in the instruction.
+    {
+        Json schema = Json{{"type", "object"},
+                           {"properties", Json{{"facts", Json{{"type", "array"}}}}},
+                           {"required", Json::array({"facts"})}};
+        Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "extract"}}})},
+            {"response_format",
+             Json{{"type", "json_schema"},
+                  {"json_schema", Json{{"name", "facts"}, {"schema", schema}, {"strict", true}}}}},
+        };
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        failures += check(req.structured_output.type == StructuredOutputType::JsonSchema,
+                          "json_schema parsed");
+        failures += check(req.structured_output.schema_json.find("\"facts\"") != std::string::npos,
+                          "json_schema: schema serialized");
+        const ninfer::PromptInput input = translate(req);
+        failures += check(joined_text(input.messages.front()).find("\"facts\"") != std::string::npos,
+                          "json_schema: schema embedded in prompt");
+    }
+
+    // text and absent: no injection.
+    {
+        Json body = {
+            {"model", "m"},
+            {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})},
+            {"response_format", Json{{"type", "text"}}},
+        };
+        const GenerationRequest req = parse_chat_completion_request(body, default_limits());
+        const ninfer::PromptInput input = translate(req);
+        failures += check(input.messages.size() == 1, "text: no injection");
+        failures += check(input.messages.front().role == ninfer::ChatRole::User,
+                          "text: user turn is first");
+    }
     return failures;
 }
 
@@ -715,6 +811,7 @@ int main() {
     failures += test_instruction_roles_preserved();
     failures += test_parse_media_in_translate();
     failures += test_reject_unsupported();
+    failures += test_response_format();
     failures += test_parse_function_tools_and_choices();
     failures += test_parse_tool_history_messages();
     failures += test_parse_stop_and_max_tokens();


### PR DESCRIPTION
## Problem

The OpenAI-compatible Chat Completions layer rejects every `response_format`
other than `{"type":"text"}` (HTTP 400, `response_format_not_supported`), so
clients that request structured output cannot use the server at all. A
concrete consumer: the Hindsight memory system, whose fact-extraction batch
path always sends `{"type":"json_schema", ...}` and failed every request
against a ninfer backend.

## Design

The engine applies no token-level constraint, so the JSON modes are enforced
by injecting an instruction into the prompt — the same soft-JSON approach that
llama.cpp pairs with its `json_object` grammar:

- `json_object`: appends an instruction to respond with a single JSON object
  and nothing else.
- `json_schema`: the same instruction plus the client's `schema` object.

The instruction is appended to a leading system turn when one is present,
otherwise a system turn is prepended. `json_schema.name` and `.strict` are
carried for wire compatibility only. All other `response_format` values, a
non-object `response_format`, and a `json_schema` entry without an object
`schema` are still rejected with `response_format_not_supported`.

Prompt injection was chosen because the engine has no grammar facility in its
decode path; it is the existing precedent for this class of feature and keeps
the change local to the serve layer — no engine, artifact, or CLI contract is
touched.

## Affected behavior / contract

- `POST /v1/chat/completions` now accepts `response_format` types `text`,
  `json_object`, and `json_schema`; everything else still returns HTTP 400
  with code `response_format_not_supported`.
- Schema tests updated: `tests/test_openai_schema.cpp` (parse/accept/record
  cases for all three types, rejection cases, and prompt-injection cases for
  both JSON modes with and without a leading system turn).
- Serving documentation updated in the same change, as required for an OpenAI
  surface change: `docs/serving.md` (supported-fields list plus a contract
  paragraph describing the accepted shapes and rejection behavior).

## Verification

Focused serve-layer build and contract test, run on the PR head:

```bash
g++ -std=c++20 -I include -I third_party -I src \
  tests/test_openai_schema.cpp src/serve/openai_schema.cpp src/serve/translate.cpp \
  -o ninfer_openai_schema_test
./ninfer_openai_schema_test
```

Result: compiles clean; the contract test passes (`ok`, exit 0), including the
new `response_format` cases.

The canonical build and test suite was also run on a supported CUDA host
against the same change:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
cmake --build build --parallel
ctest --test-dir build --output-on-failure
```

Result: build clean, tests pass.

Live end-to-end: the patched serve layer was deployed on a CUDA host and
exercised with real `json_schema` traffic (Hindsight fact extraction, which
sends `response_format: json_schema` on its batch path) — requests that
previously failed with HTTP 400 now return structured output and fact
extraction completes.

## Checks not run and resulting limitation

- The focused verification above was compiled on a CPU-only development host
  (no CUDA toolchain); the full suite and the live run on the CUDA host cover
  the remaining ground.
- No numerical, performance, or Op claims are made; this change touches none
  of those paths.

## AI-generation disclosure

The implementation was generated with **Qwen3.8 27B (`qwen3.8-27b`, thinking
model)** via the Hermes Agent harness (agentic tool use, compilation, and test
execution). The complete diff was reviewed before submission and the
verification above was run against this exact code.
