### PR TITLE
fix(frontend): keep literal vision tokens out of media binding

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -407,6 +407,10 @@ curl http://127.0.0.1:8080/v1/messages \
 The endpoint supports top-level system text, ordered mid-conversation system messages,
 user/assistant history, text and image blocks, thinking blocks, tool-use history, tool results,
 client-defined tools, non-streaming responses, and Anthropic SSE events.
+`tool_result` blocks remain in request order, including nested text and image blocks; their order
+does not need to match the preceding assistant `tool_use` blocks. Literal Qwen Vision control-token
+spellings in text, reasoning, tool definitions, or tool arguments remain text and do not create
+media placeholders.
 Mid-conversation system messages remain at their `messages` array position and are not merged into
 the top-level system instruction. A system section must follow a user/tool-result message and be
 final or immediately precede an assistant message; it cannot interrupt a tool-use/tool-result pair.

--- a/src/targets/qwen3_6/impl/frontend/chat_template.cpp
+++ b/src/targets/qwen3_6/impl/frontend/chat_template.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace ninfer::targets::qwen3_6::frontend_internal {
 namespace {
@@ -33,6 +34,24 @@ constexpr std::string_view kXHighReasoningInstructions =
     "Reasoning effort is set to xhigh. Please think carefully through the task, validate key "
     "assumptions, consider plausible alternatives, and prioritize correctness, consistency, and "
     "clarity in the final answer.";
+
+constexpr std::array<std::string_view, 4> kVisionControlTokens = {
+    "<|vision_start|>", "<|vision_end|>", "<|image_pad|>", "<|video_pad|>"};
+constexpr std::string_view kControlTokenBreak = "\xE2\x81\xA0"; // U+2060 WORD JOINER
+
+// Text content can legitimately quote the chat template or one of its Vision
+// control tokens. Keep those strings readable, but break their exact added-token
+// spelling so that only structured Image/Video parts can create media slots.
+std::string escape_literal_vision_tokens(std::string text) {
+    for (const std::string_view token : kVisionControlTokens) {
+        std::size_t search = 0;
+        while ((search = text.find(token, search)) != std::string::npos) {
+            text.insert(search + 2, kControlTokenBreak);
+            search += token.size() + kControlTokenBreak.size();
+        }
+    }
+    return text;
+}
 
 bool is_instruction_role(ChatRole role) noexcept {
     return role == ChatRole::System || role == ChatRole::Developer;
@@ -214,7 +233,7 @@ std::string render_tools_system_block(const std::vector<std::string>& tool_jsons
     rendered += "# Tools\n\nYou have access to the following functions:\n\n<tools>";
     for (const std::string& tool : tool_jsons) {
         rendered += "\n";
-        rendered += tojson_text(OrderedJson::parse(tool));
+        rendered += escape_literal_vision_tokens(tojson_text(OrderedJson::parse(tool)));
     }
     rendered += "\n</tools>";
     rendered += std::string(kToolInstructions);
@@ -269,23 +288,34 @@ std::string ChatMessage::rendered_content(bool add_vision_id, int* image_count,
     int& images      = image_count == nullptr ? local_images : *image_count;
     int& videos      = video_count == nullptr ? local_videos : *video_count;
     std::string out;
+    std::string text_run;
+    const auto flush_text_run = [&] {
+        if (text_run.empty()) { return; }
+        out += escape_literal_vision_tokens(std::move(text_run));
+        text_run.clear();
+    };
     for (const ChatPart& part : parts) {
         switch (part.kind) {
         case ChatPartKind::Text:
-            out += part.text;
+            // Consecutive text parts are one semantic text run. Escape after
+            // coalescing so part boundaries cannot reconstruct a control token.
+            text_run += part.text;
             break;
         case ChatPartKind::Image:
+            flush_text_run();
             ++images;
             if (add_vision_id) { out += "Picture " + std::to_string(images) + ": "; }
             out += "<|vision_start|><|image_pad|><|vision_end|>";
             break;
         case ChatPartKind::Video:
+            flush_text_run();
             ++videos;
             if (add_vision_id) { out += "Video " + std::to_string(videos) + ": "; }
             out += "<|vision_start|><|video_pad|><|vision_end|>";
             break;
         }
     }
+    flush_text_run();
     return out;
 }
 
@@ -394,7 +424,7 @@ RenderedChat CompiledChatTemplate::render(const std::vector<ChatMessage>& messag
         std::string reasoning;
         std::string body = content;
         if (!message.reasoning_content.empty()) {
-            reasoning = message.reasoning_content;
+            reasoning = escape_literal_vision_tokens(message.reasoning_content);
         } else if (!effort_template) {
             ThinkParts parts = derive_think_parts(content);
             reasoning        = std::move(parts.reasoning);
@@ -422,7 +452,8 @@ RenderedChat CompiledChatTemplate::render(const std::vector<ChatMessage>& messag
                 } else {
                     rendered += "\n";
                 }
-                rendered += render_tool_call(message.tool_calls[call_index], effort_template);
+                rendered += escape_literal_vision_tokens(
+                    render_tool_call(message.tool_calls[call_index], effort_template));
             }
         }
         rendered += "<|im_end|>\n";

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -42,6 +42,16 @@ int check(bool condition, const char* message) {
     return 1;
 }
 
+std::size_t count_occurrences(std::string_view text, std::string_view needle) {
+    std::size_t count  = 0;
+    std::size_t search = 0;
+    while ((search = text.find(needle, search)) != std::string_view::npos) {
+        ++count;
+        search += needle.size();
+    }
+    return count;
+}
+
 float bf16_value(std::uint16_t bits) {
     return std::bit_cast<float>(static_cast<std::uint32_t>(bits) << 16U);
 }
@@ -344,6 +354,47 @@ int test_official_chat_template() {
                                        no_generation) ==
                           "<|im_start|>system\n<|im_end|>\n<|im_start|>user\nhello<|im_end|>\n",
                       "empty leading system prompt differs from the official template");
+
+    fi::ChatMessage literal_markers =
+        chat_message(ninfer::ChatRole::System, "quoted <|vision_");
+    literal_markers.parts.push_back(fi::ChatPart::text_part("start|><|image_"));
+    literal_markers.parts.push_back(fi::ChatPart::text_part("pad|><|vision_"));
+    literal_markers.parts.push_back(fi::ChatPart::text_part("end|> and <|video_"));
+    literal_markers.parts.push_back(fi::ChatPart::text_part("pad|>"));
+    fi::ChatMessage parallel_tools = chat_message(ninfer::ChatRole::Assistant, "");
+    parallel_tools.reasoning_content = "quoted reasoning <|video_pad|>";
+    parallel_tools.tool_calls.push_back(
+        {.id = "call_A",
+         .name = "read",
+         .arguments_json = R"({"path":"quoted <|image_pad|>.png"})"});
+    parallel_tools.tool_calls.push_back(
+        {.id = "call_B", .name = "read", .arguments_json = R"({"path":"b.png"})"});
+    fi::ChatMessage result_b = chat_message(ninfer::ChatRole::Tool, "result B: ");
+    result_b.tool_call_id    = "call_B";
+    result_b.parts.push_back(fi::ChatPart::image({}));
+    fi::ChatMessage result_a = chat_message(ninfer::ChatRole::Tool, "result A: ");
+    result_a.tool_call_id    = "call_A";
+    result_a.parts.push_back(fi::ChatPart::image({}));
+    result_a.parts.push_back(fi::ChatPart::text_part(" then "));
+    result_a.parts.push_back(fi::ChatPart::image({}));
+    fi::ChatRenderOptions media_options = no_generation;
+    media_options.tool_jsons.push_back(
+        R"({"type":"function","function":{"name":"read","description":"quoted <|vision_start|><|image_pad|><|vision_end|> and <|video_pad|>","parameters":{"type":"object"}}})");
+    const std::string media_history = render_chat_text(
+        {std::move(literal_markers), chat_message(ninfer::ChatRole::User, "inspect"),
+         std::move(parallel_tools), std::move(result_b), std::move(result_a)},
+        media_options);
+    const std::string escaped_break = "\xE2\x81\xA0";
+    failures += check(
+        count_occurrences(media_history, "<|image_pad|>") == 3 &&
+            count_occurrences(media_history, "<|video_pad|>") == 0 &&
+            count_occurrences(media_history, "<|vision_start|>") == 3 &&
+            count_occurrences(media_history, "<|vision_end|>") == 3 &&
+            media_history.find("<|" + escaped_break + "image_pad|>") != std::string::npos &&
+            media_history.find("<|" + escaped_break + "video_pad|>") != std::string::npos &&
+            media_history.find("<|" + escaped_break + "vision_start|>") != std::string::npos &&
+            media_history.find("<|" + escaped_break + "vision_end|>") != std::string::npos,
+        "literal Vision tokens collided with structured tool-result media placeholders");
 
     fi::ChatMessage tool_assistant = chat_message(ninfer::ChatRole::Assistant, "");
     tool_assistant.tool_calls.push_back(

--- a/tests/test_anthropic_schema.cpp
+++ b/tests/test_anthropic_schema.cpp
@@ -469,6 +469,78 @@ int test_tool_use_result_roundtrip() {
     return failures;
 }
 
+int test_parallel_tool_result_media_order() {
+    const Json image = Json{{"type", "image"},
+                            {"source", Json{{"type", "base64"},
+                                            {"media_type", "image/png"},
+                                            {"data", "AA=="}}}};
+    const auto tool_use = [](const char* id) {
+        return Json{{"type", "tool_use"},
+                    {"id", id},
+                    {"name", "read"},
+                    {"input", Json{{"path", std::string(id) + ".png"}}}};
+    };
+    const auto tool_result = [](const char* id, Json content) {
+        return Json{{"type", "tool_result"}, {"tool_use_id", id}, {"content", content}};
+    };
+
+    const Json body = {
+        {"model", "m"},
+        {"max_tokens", 8},
+        {"tools", Json::array({Json{{"name", "read"},
+                                    {"input_schema", Json{{"type", "object"}}}}})},
+        {"messages",
+         Json::array(
+             {Json{{"role", "user"}, {"content", "inspect"}},
+              Json{{"role", "assistant"},
+                   {"content", Json::array(
+                                   {tool_use("call_A"), tool_use("call_B"), tool_use("call_C")})}},
+              Json{{"role", "user"},
+                   {"content",
+                    Json::array(
+                        {tool_result("call_C", Json::array({Json{{"type", "text"},
+                                                                  {"text", "text only"}}})),
+                         tool_result("call_B", Json::array({image})),
+                         tool_result("call_A",
+                                     Json::array({Json{{"type", "text"}, {"text", "first"}},
+                                                  image,
+                                                  Json{{"type", "text"}, {"text", "second"}},
+                                                  image}))})}}})}};
+
+    const GenerationRequest req = parse_messages_request(body, default_limits());
+    int failures = check(req.messages.size() == 5, "parallel tool results did not expand in place");
+    failures += check(req.messages[1].tool_calls.size() == 3 &&
+                          req.messages[1].tool_calls[0].id == "call_A" &&
+                          req.messages[1].tool_calls[1].id == "call_B" &&
+                          req.messages[1].tool_calls[2].id == "call_C",
+                      "assistant tool_use array order changed");
+    failures += check(req.messages[2].tool_call_id == "call_C" &&
+                          req.messages[3].tool_call_id == "call_B" &&
+                          req.messages[4].tool_call_id == "call_A",
+                      "tool_result blocks were reordered to tool_use order");
+    failures += check(req.messages[2].content.size() == 1 &&
+                          req.messages[2].content[0].kind == ContentKind::Text &&
+                          req.messages[3].content.size() == 1 &&
+                          req.messages[3].content[0].kind == ContentKind::Image &&
+                          req.messages[4].content.size() == 4 &&
+                          req.messages[4].content[0].kind == ContentKind::Text &&
+                          req.messages[4].content[1].kind == ContentKind::Image &&
+                          req.messages[4].content[2].kind == ContentKind::Text &&
+                          req.messages[4].content[3].kind == ContentKind::Image,
+                      "nested tool_result content order changed");
+
+    const ninfer::PromptInput prompt = translate(req);
+    failures += check(prompt.messages.size() == 5 &&
+                          prompt.messages[2].tool_call_id == "call_C" &&
+                          prompt.messages[3].tool_call_id == "call_B" &&
+                          prompt.messages[4].tool_call_id == "call_A" &&
+                          prompt.messages[4].parts.size() == 4 &&
+                          prompt.messages[4].parts[1].kind == ninfer::MessagePartKind::Media &&
+                          prompt.messages[4].parts[3].kind == ninfer::MessagePartKind::Media,
+                      "translation changed tool-result or nested media order");
+    return failures;
+}
+
 int test_thinking_and_sampling() {
     int failures                = 0;
     Json body                   = {{"model", "m"},
@@ -751,6 +823,7 @@ int main() {
     failures += test_parse_image();
     failures += test_tools_and_choice();
     failures += test_tool_use_result_roundtrip();
+    failures += test_parallel_tool_result_media_order();
     failures += test_thinking_and_sampling();
     failures += test_reasoning_effort();
     failures += test_stop_reason_mapping();


### PR DESCRIPTION
  A valid Anthropic Messages request containing parallel `tool_use` history and
  image-bearing `tool_result` blocks returned:

      400 chat media order does not match rendered placeholders

  The captured request returned tool results in completion order rather than the
  preceding invocation order. It also contained literal Qwen Vision control-token
  spellings inside system text that quoted a chat template.

  ## Root cause

  The Anthropic schema path already preserved both `tool_result` order and nested
  content order. Media collection followed that same order.

  The mismatch occurred later in the Qwen frontend. Media binding searched the
  complete rendered prompt for raw `<|image_pad|>` and `<|video_pad|>` strings.
  Literal occurrences in system text, reasoning, tool definitions, or tool
  arguments were therefore mistaken for structured media placeholders. This
  shifted binding away from the actual image blocks and produced the ordering
  error.

  ## Design

  The compiled chat renderer now neutralizes exact Qwen Vision control-token
  spellings in textual input by inserting U+2060 WORD JOINER after `<|`.

  This keeps the quoted text readable while preventing it from becoming an exact
  added token or media-binding marker. The rule is applied to:

  - text content;
  - explicit reasoning content;
  - serialized tool definitions; and
  - rendered tool-call arguments.

  Structured image and video parts continue to emit the original raw control
  tokens and remain the sole source of media placeholders.

  Tool results are not sorted or remapped to the original `tool_use` order.
  Message, block, and nested-content traversal remain in client-supplied order.

  ## Affected behavior

  - Image-bearing `tool_result` blocks may arrive in a different order from the
    preceding parallel `tool_use` blocks.
  - Mixed text/image results and multiple images within one result retain their
    nested order.
  - Literal Vision control tokens remain ordinary text.
  - Direct user images and text-only tool results are unchanged.

  The serving documentation now states these ordering and literal-token
  semantics.

  ## Verification

  Clean V100-port checkout, Tesla V100-SXM2-32GB, GCC 13.3, CUDA 12.8.61:

  ```bash
  cmake -S . -B build-cuda128 \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_TESTING=ON \
    -DCMAKE_CUDA_ARCHITECTURES=70 \
    -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.8/bin/nvcc

  cmake --build build-cuda128 -j \
    --target ninfer_anthropic_schema_test ninfer_qwen3_6_frontend_test

  ctest --test-dir build-cuda128 \
    -R '^ninfer_anthropic_schema_test$' \
    --output-on-failure

  Results:

  - both focused test executables built successfully;
  - ninfer_anthropic_schema_test: passed;
  - git diff --check origin/master...HEAD: passed;
  - captured 58,922-token Anthropic request, with max_tokens reduced to 1:
    HTTP 200, one output token, no media-order error;

  - ordinary direct-user image through /v1/messages/count_tokens:
    HTTP 200, 415 input tokens.

  The complete ninfer_qwen3_6_frontend_test executable could not run on this
  host because an existing test reads tokenizer resources from the maintainer’s
  hard-coded /home/neroued/... path, which is not present. The executable
  compiled successfully, and the affected frontend preparation path was exercised
  by the live captured request.

  The exact upstream sm_120a configuration was not built because this host does
  not have the required CUDA 13.1/RTX 5090 environment. No performance claim is
  made.

  ## Related work

  #71 adds multimodal tool outputs to the OpenAI Responses schema. This change is
  independent: it fixes shared Qwen frontend media binding and the reproduced
  Anthropic Messages failure.

  ## AI-assisted implementation disclosure

  The implementation and tests were generated and reviewed in OpenAI Codex using
  GPT-5. The session did not expose a more specific model revision.