### PR TITLE
fix(ops): size persistent grids from the active device SM count

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(ninfer_nvfp4_tma PRIVATE ninfer_core CUDA::cudart CUDA::cu
 # Shared mathematical Ops. The list is intentionally explicit: adding a
 # source is a build-boundary decision, not an accidental recursive-glob side effect.
 add_library(ninfer_ops STATIC
+  ops/common/device_info.cu
   ops/launcher/add_bias.cu
   ops/launcher/argmax.cu
   ops/launcher/cast.cu

--- a/src/ops/common/device_info.cu
+++ b/src/ops/common/device_info.cu
@@ -1,0 +1,30 @@
+#include "ops/common/device_info.h"
+
+#include <cstdio>
+#include <cuda_runtime.h>
+
+namespace ninfer::ops {
+namespace {
+
+constexpr int kReferenceSmCount = 170; // RTX 5090
+
+int query_sm_count() {
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess) { return kReferenceSmCount; }
+    int count = 0;
+    if (cudaDeviceGetAttribute(&count, cudaDevAttrMultiProcessorCount, device) != cudaSuccess) {
+        return kReferenceSmCount;
+    }
+    if (count <= 0) { return kReferenceSmCount; }
+    std::fprintf(stderr, "ninfer: persistent grids sized for %d SMs\n", count);
+    return count;
+}
+
+} // namespace
+
+int device_sm_count() {
+    static const int count = query_sm_count();
+    return count;
+}
+
+} // namespace ninfer::ops

--- a/src/ops/common/device_info.h
+++ b/src/ops/common/device_info.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace ninfer::ops {
+
+/**
+ * Multiprocessor count of the active CUDA device, queried once and cached.
+ *
+ * Persistent-grid launchers size one resident wave from this value. Sizing from
+ * a hardcoded reference-part count leaves multiprocessors idle on a device with
+ * a wider die (or oversubscribes a narrower one); both are sm_120a parts and
+ * differ only in enabled SM count.
+ *
+ * Returns the reference RTX 5090 count if the device query fails, so a launcher
+ * always receives a positive, usable value.
+ */
+int device_sm_count();
+
+} // namespace ninfer::ops

--- a/src/ops/linear_attention/gated_delta_net/chunked/output.cu
+++ b/src/ops/linear_attention/gated_delta_net/chunked/output.cu
@@ -1,14 +1,13 @@
 #include "ops/linear_attention/gated_delta_net/chunked/launch.h"
 #include "ops/linear_attention/gated_delta_net/chunked/output.cuh"
+#include "ops/common/device_info.h"
 
 namespace ninfer::ops::detail::gated_delta_net::chunked {
 namespace {
 
 namespace kernel = output;
 
-constexpr std::int64_t kRtx5090SmCount = 170;
-constexpr std::int64_t kCtasPerSm      = 4;
-constexpr std::int64_t kTargetCtas     = kRtx5090SmCount * kCtasPerSm;
+constexpr std::int64_t kCtasPerSm = 4;
 
 template <bool MULTI_JOB>
 cudaError_t launch_fixed(const chunk_output_config& cfg, dim3 grid, head_map qk_map, int chunks) {
@@ -40,10 +39,11 @@ cudaError_t launch_output(const chunk_output_config& cfg) {
     const auto qk_map     = head_map::of((int)cfg.H_qk, (int)cfg.H_v);
     const std::int64_t NT = cfg.L / BT;
 
-    // Keep at most one resident RTX 5090 wave and distribute chunks evenly
-    // across it. Small grids retain one logical job per CTA.
+    // Keep at most one resident wave for THIS device and distribute chunks
+    // evenly across it. Small grids retain one logical job per CTA.
+    const std::int64_t target_ctas    = static_cast<std::int64_t>(device_sm_count()) * kCtasPerSm;
     const std::int64_t logical_jobs   = NT * cfg.H_v;
-    const std::int64_t jobs_per_block = (logical_jobs + kTargetCtas - 1) / kTargetCtas;
+    const std::int64_t jobs_per_block = (logical_jobs + target_ctas - 1) / target_ctas;
     const std::int64_t grid_chunks    = (NT + jobs_per_block - 1) / jobs_per_block;
     NINFER_GATED_DELTA_NET_PROPAGATE(v.check_grid(grid_chunks, cfg.H_v));
 

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -20,6 +20,8 @@
 #include <cstdint>
 #include <stdexcept>
 
+#include "ops/common/device_info.h"
+
 namespace ninfer::ops::detail {
 namespace {
 
@@ -253,9 +255,7 @@ constexpr int kExpertBK                = 64;
 constexpr int kExpertStages            = 2;
 constexpr int kExpertWarps             = 8;
 constexpr int kExpertThreads           = 32 * kExpertWarps;
-constexpr int kRtx5090SmCount          = 170;
-constexpr int kPrefillBlocksPerSm      = 3;
-constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
+constexpr int kPrefillBlocksPerSm = 3;
 
 template <int ExpertWarps, int ExpertBN>
 __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
@@ -1087,6 +1087,9 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         throw std::invalid_argument("sparse_moe prefill: launch plan does not match tensors");
     }
 
+    // One resident persistent wave sized for THIS device, not a reference part.
+    const int prefill_persistent_blocks = kPrefillBlocksPerSm * device_sm_count();
+
     const auto* router = static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata);
     const auto* routed_gate_codes = static_cast<const std::uint8_t*>(weights.routed_gate_up.qdata);
     const auto* routed_gate_scales =
@@ -1168,12 +1171,12 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         if (weights.routed_gate_up.qtype == QType::Q4G64_F16S) {
             if (wide_plan) {
                 sparse_moe_prefill_q4_gate_up_kernel<8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 8 * 32, 0, stream>>>(
                         grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
                         routed_gate_codes, routed_gate_scales, routed_activation);
             } else {
                 sparse_moe_prefill_q4_gate_up_kernel<4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 4 * 32, 0, stream>>>(
                         grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
                         routed_gate_codes, routed_gate_scales, routed_activation);
             }
@@ -1207,13 +1210,13 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         case QType::Q5G64_F16S:
             if (wide_plan) {
                 sparse_moe_prefill_qx_down_kernel<Q5DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 8 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
             } else {
                 sparse_moe_prefill_qx_down_kernel<Q5DownMma, 4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 4 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
@@ -1222,13 +1225,13 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         case QType::Q6G64_F16S:
             if (wide_plan) {
                 sparse_moe_prefill_qx_down_kernel<Q6DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 8 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
             } else {
                 sparse_moe_prefill_qx_down_kernel<Q6DownMma, 4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                    <<<prefill_persistent_blocks, 4 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);


### PR DESCRIPTION
## Problem

`kRtx5090SmCount = 170` is hardcoded in two persistent-grid launchers (GDN chunked output, sparse-MoE prefill). Any sm_120a part with a different enabled-SM count sizes one resident wave incorrectly: wider dies leave SMs idle, narrower dies oversubscribe.

## Design

A cached one-time device query (`ninfer::ops::device_sm_count()`, `src/ops/common/device_info.{h,cu}`) via `cudaDeviceGetAttribute(cudaDevAttrMultiProcessorCount)`, consumed by both launchers. The query falls back to the 170-SM reference value on failure so a launcher always receives a positive count. No schedule, tiling, or kernel changes; only the wave-count multiplier source.

## Affected behavior / contract

None observable on the RTX 5090 (the query returns 170 there, reproducing the current constants exactly). On other sm_120a parts the persistent grids now match the device.

## Verification

- Built clean (CUDA 13.1.2 container toolchain, `sm_120a`).
- Runtime-verified on an RTX PRO 6000 Blackwell Workstation Edition (sm_120a, 188 SMs): startup log confirms grids sized for 188.
- End-to-end A/B on that card, Qwen3.8-27B NVFP4, six identical 57,598-token prefills per arm, prefix reuse disabled: 6321 tok/s median stock vs 6232 patched, within run-to-run noise. **This change is performance-neutral for that target on that card** (the patched kernels are not that workload's prefill bottleneck); it is submitted as portability correctness, not a speedup.

Not run: RTX 5090 A/B (no such card here; expected identical by construction), MoE-target (35B-A3B) measurements, the in-tree test suite (no operator semantics changed).

## Environment

RTX PRO 6000 Blackwell Workstation Edition, Docker (nvidia/cuda:13.1.2 build image) under WSL2, driver CUDA 13.3.

## Disclosure

Implementation generated by Claude Opus 5 (Anthropic, model id `claude-opus-5`), directed and reviewed by the submitter.
