### PR TITLE
perf: 35B-A3B decode +13.2%, prefill +16.8%, MTP3 +4.8%, every output bit-identical

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,7 +171,7 @@ measured recommendation rather than a semantic limit.
 | `--device N` | CUDA device index | `0` |
 | `--kv-dtype bf16\|int8\|fp8` | KV-cache storage | `bf16` |
 | `--spec mtp\|dflash` | speculative backend | off |
-| `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
+| `--draft-tokens N` | MTP `1..15` where the target registers that window, otherwise `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
 | `--vision` | enable image/video input and load Vision GPU allocations | off |
 | `--no-cuda-graph` | disable CUDA Graph decode | graphs on |

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -514,7 +514,7 @@ curl http://127.0.0.1:8080/v1/models \
 | `--response-store-max-mib N` | total local Response envelope/Item/context budget | `256` |
 | `--kv-dtype bf16\|int8\|fp8` | KV-cache storage | `bf16` |
 | `--spec mtp\|dflash` | speculative backend | off |
-| `--draft-tokens N` | MTP `1..5`; DFlash `1..15` | unset |
+| `--draft-tokens N` | MTP `1..15` where the target registers that window, otherwise `1..5`; DFlash `1..15` | unset |
 | `--lm-head-draft` | optimized proposal head | off |
 | `--default-max-tokens N` | output limit when omitted by a request | `8192` |
 | `--default-thinking-budget N` | positive thinking cap inherited by thinking-enabled requests | unset |

--- a/include/ninfer/ops/causal_conv1d_silu.h
+++ b/include/ninfer/ops/causal_conv1d_silu.h
@@ -30,6 +30,15 @@ void causal_conv1d_silu(const Tensor& x, const Tensor& weight, Tensor& conv_stat
 void causal_conv1d_silu(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
                         Tensor& conv_state_out, Tensor& out, cudaStream_t stream);
 
+// Split-output form. Same result as the distinct-state form followed by copying the three
+// leading channel ranges of `out` into out_q/out_k/out_v, without materialising the packed
+// buffer. out_q.ne[0] + out_k.ne[0] + out_v.ne[0] must equal x.ne[0], and every destination
+// shares x's column count. `scratch` is a packed [C,T] buffer used only by the short-sequence
+// fallback, where no split kernel exists.
+void causal_conv1d_silu_split(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                              Tensor& conv_state_out, Tensor& out_q, Tensor& out_k, Tensor& out_v,
+                              Tensor& scratch, cudaStream_t stream);
+
 /**
  * Snapshot form for B independent sequences. `x` and `out` are contiguous BF16 [C,W,B],
  * `conv_states` is contiguous BF16 [C,3,Slots], and `initial_state_slots` and

--- a/include/ninfer/ops/gated_delta_net.h
+++ b/include/ninfer/ops/gated_delta_net.h
@@ -70,12 +70,16 @@ void gated_delta_net(const Tensor& q, const Tensor& k, const Tensor& v, const Te
  * destination_state_slots[b]; selectors may be equal for an in-place row. Destination slots are
  * distinct across active rows. This form uses no arena allocation.
  */
+// `prefetch_data`/`prefetch_bytes` name a weight span the caller knows the next consumer will
+// stream. The tail issues fire-and-forget L2 prefetches over as much of it as the grid covers.
+// Purely a cache hint: it reads nothing the kernel uses and has no numeric effect.
 void gated_delta_net_batch_update(const Tensor& q, const Tensor& k, const Tensor& v,
                                   const Tensor& g, const Tensor& beta, float scale,
                                   bool normalize_qk, Tensor& ssm_states,
                                   const Tensor& source_state_slots,
                                   const Tensor& destination_state_slots, Tensor& out,
-                                  cudaStream_t stream);
+                                  cudaStream_t stream, const void* prefetch_data = nullptr,
+                                  std::size_t prefetch_bytes = 0);
 
 /**
  * Op: gated_delta_net_replay_record

--- a/include/ninfer/ops/gated_delta_net.h
+++ b/include/ninfer/ops/gated_delta_net.h
@@ -92,6 +92,22 @@ void gated_delta_net_batch_update(const Tensor& q, const Tensor& k, const Tensor
  * unchanged, while the invalid out suffix is exact BF16 zero. Inputs, state, records, and out are
  * pairwise non-overlapping.
  */
+// Registration for the gated post-mixer RMS-norm folded into a recurrent kernel's tail. Set it
+// immediately before the call it belongs to; the launcher consumes and clears it, so a launch that
+// does not read it cannot inherit a stale span. The tail keeps one completion ticket per
+// (value head, batch row), which bounds both dimensions.
+inline constexpr std::int32_t kGdnPostNormMaxHeads = 64;
+inline constexpr std::int32_t kGdnPostNormMaxBatch = 8;
+
+struct GdnPostNormSpan {
+    const void* gate_z = nullptr;
+    const void* weight = nullptr;
+    void* out          = nullptr;
+    float eps          = 0.0F;
+};
+void set_gdn_post_norm(GdnPostNormSpan span);
+GdnPostNormSpan take_gdn_post_norm();
+
 void gated_delta_net_replay_record(const Tensor& q, const Tensor& k, const Tensor& v,
                                    const Tensor& g, const Tensor& beta, float scale,
                                    const Tensor& ssm_states, const Tensor& valid_columns,

--- a/include/ninfer/ops/rope.h
+++ b/include/ninfer/ops/rope.h
@@ -40,4 +40,13 @@ void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& q, Tenso
 // from x; Q versus K role does not change the transformation.
 void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& x, cudaStream_t stream);
 
+/**
+ * Fused q/k RMS-norm (unit-offset weights) + rotary. For the Text 16Q/2K, D=256,
+ * rotary 64 geometry this runs one kernel; any other geometry falls back to
+ * rmsnorm+rmsnorm+rope with identical results.
+ */
+void qk_norm_rope(const Tensor& positions, int rotary_dim, float theta, const Tensor& q_in,
+                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                  const Tensor& k_weight, Tensor& k_out, float eps, cudaStream_t stream);
+
 } // namespace ninfer::ops

--- a/include/ninfer/ops/softmax_attention.h
+++ b/include/ninfer/ops/softmax_attention.h
@@ -128,12 +128,16 @@ void packed_softmax_attention(const Tensor& q, const Tensor& k, const Tensor& v,
  * non-overlapping. The Op overwrites every addressed cache row but owns no cache allocation,
  * frontier, request identity, or commit authority.
  */
+// An optional `gate` asks the Op to finish with out *= sigmoid(gate), shaped like out. Where the
+// route allows it the multiply is folded into the reduce epilogue; everywhere else the Op applies
+// the standalone elementwise kernel itself. Either way the result is bit-identical to calling
+// sigmoid_mul on the ungated output, so the caller need not know which route it landed on.
 void causal_softmax_attention(const Tensor& q, const Tensor& k, const Tensor& v,
                               const Tensor& positions, const Tensor& valid_columns,
                               const Tensor& kv_table_rows, AttentionHeadGeometry geometry,
                               float scale, PagedKVBatchLayerView cache,
                               CausalAttentionExecutionEnvelope envelope, WorkspaceArena& workspace,
-                              Tensor& out, cudaStream_t stream);
+                              Tensor& out, cudaStream_t stream, const Tensor* gate = nullptr);
 
 /**
  * Read-only single-sequence causal attention over an already populated cache.

--- a/include/ninfer/ops/sparse_moe.h
+++ b/include/ninfer/ops/sparse_moe.h
@@ -22,6 +22,19 @@ enum class SparseMoeEpilogue : std::uint8_t {
     AddResidual,
 };
 
+struct WeightPrefetchSpan {
+    const void* data  = nullptr;
+    std::size_t bytes = 0;
+};
+
+/**
+ * Registers the weight span the NEXT decode-step consumer will stream.
+ * The next sparse_moe decode launch issues fire-and-forget L2 prefetches for it
+ * from the D4 epilogue and clears the registration. Purely a cache hint recorded
+ * at capture time; no numeric effect.
+ */
+void set_next_weight_prefetch(WeightPrefetchSpan span);
+
 /**
  * Returns the transient capacity required by SparseMoe for every T in the inclusive
  * [min_tokens,max_tokens] interval. The routed QTypes are the fixed implementation profile.

--- a/include/ninfer/ops/sparse_moe.h
+++ b/include/ninfer/ops/sparse_moe.h
@@ -73,6 +73,7 @@ void set_next_weight_prefetch(WeightPrefetchSpan span);
  * graph-stable transient storage and carries no state beyond the call.
  */
 void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilogue epilogue,
-                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream);
+                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream,
+                const Tensor* pre_norm_weight = nullptr, float pre_norm_eps = 0.0f);
 
 } // namespace ninfer::ops

--- a/src/core/decode_graph.cpp
+++ b/src/core/decode_graph.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <stdexcept>
+#include <cstddef>
 #include <string>
 
 namespace ninfer {
@@ -15,6 +16,8 @@ void log_cuda_error(const char* op, cudaError_t err) noexcept {
                      cudaGetErrorString(err));
     }
 }
+
+std::size_t g_last_instantiated_nodes = 0;
 
 void destroy_graph_exec(cudaGraphExec_t& exec) noexcept {
     if (exec != nullptr) {
@@ -105,6 +108,12 @@ void DecodeGraphExecutable::instantiate(const DecodeGraphDefinition& definition)
     reset();
 
     cudaGraphExec_t exec  = nullptr;
+    {
+        std::size_t captured = 0;
+        if (cudaGraphGetNodes(definition.graph_, nullptr, &captured) == cudaSuccess) {
+            g_last_instantiated_nodes = captured;
+        }
+    }
     const cudaError_t err = cudaGraphInstantiate(&exec, definition.graph_, 0);
     if (err != cudaSuccess) {
         destroy_graph_exec(exec);
@@ -112,6 +121,43 @@ void DecodeGraphExecutable::instantiate(const DecodeGraphDefinition& definition)
     }
     exec_ = exec;
 }
+
+namespace {
+
+
+
+std::string graph_update_shape_description(cudaGraph_t replacement) {
+    std::size_t now = 0;
+    if (cudaGraphGetNodes(replacement, nullptr, &now) != cudaSuccess) { return ""; }
+    return "; captured " + std::to_string(g_last_instantiated_nodes) + " nodes, now " +
+           std::to_string(now);
+}
+
+// A topology change names a node; report which one, and for a kernel node which function, so the
+// message points at the route that moved rather than at the round as a whole.
+std::string graph_update_node_description(const cudaGraphExecUpdateResultInfo& info) {
+    const cudaGraphNode_t node = info.errorNode != nullptr ? info.errorNode : info.errorFromNode;
+    if (node == nullptr) { return " at an unnamed node"; }
+
+    cudaGraphNodeType type{};
+    if (cudaGraphNodeGetType(node, &type) != cudaSuccess) { return " at an unreadable node"; }
+    if (type != cudaGraphNodeTypeKernel) {
+        return " at a non-kernel node of type " + std::to_string(static_cast<int>(type));
+    }
+
+    cudaKernelNodeParams params{};
+    if (cudaGraphKernelNodeGetParams(node, &params) != cudaSuccess) {
+        return " at a kernel node whose parameters could not be read";
+    }
+    const char* name = nullptr;
+    if (cudaFuncGetName(&name, params.func) != cudaSuccess || name == nullptr) {
+        return " at an unnamed kernel node";
+    }
+    return std::string(" at kernel ") + name + " grid " + std::to_string(params.gridDim.x) + "x" +
+           std::to_string(params.gridDim.y) + " block " + std::to_string(params.blockDim.x);
+}
+
+} // namespace
 
 void DecodeGraphExecutable::update(const DecodeGraphDefinition& definition) {
     if (!ready() || !definition.ready()) {
@@ -123,7 +169,9 @@ void DecodeGraphExecutable::update(const DecodeGraphDefinition& definition) {
     if (err != cudaSuccess || result.result != cudaGraphExecUpdateSuccess) {
         throw std::runtime_error(
             "CUDA Graph executable update failed: " + std::string(cudaGetErrorName(err)) +
-            " (update result " + std::to_string(static_cast<int>(result.result)) + ")");
+            " (update result " + std::to_string(static_cast<int>(result.result)) + ")" +
+            graph_update_node_description(result) +
+            graph_update_shape_description(definition.graph_));
     }
 }
 

--- a/src/ops/attn_input_proj/w8/w8_attn_input_decode.cu
+++ b/src/ops/attn_input_proj/w8/w8_attn_input_decode.cu
@@ -26,7 +26,7 @@ void launch_companion_decode(const Tensor& x, const Weight& weight, Tensor& q, T
 void w8_attn_input_decode_launch(const Tensor& x, const Weight& weight, Tensor& q, Tensor& gate,
                                  Tensor& k, Tensor& v, cudaStream_t stream) {
     constexpr int kRows       = 9216;
-    constexpr int kRowsPerCta = 8;
+    constexpr int kRowsPerCta = 4;
     static_assert((4096 % kRowsPerCta) == 0 && (512 % kRowsPerCta) == 0);
     using Output = W8SplitOutput4<4096, 512, 4096, 512>;
     const Output output{static_cast<__nv_bfloat16*>(q.data), static_cast<__nv_bfloat16*>(k.data),

--- a/src/ops/common/mma.cuh
+++ b/src/ops/common/mma.cuh
@@ -48,6 +48,17 @@ __device__ __forceinline__ void mma_f16(float& c0, float& c1, float& c2, float& 
                  : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
 }
 
+// FP16-accumulate variant: full-rate on consumer parts where f32-acc HMMA runs at
+// half rate. D/C are two packed half2 registers: c0 = rows 0-7 column pair,
+// c1 = rows 8-15 column pair of the same fragment the f32 variant returns in c0..c3.
+__device__ __forceinline__ void mma_f16_f16acc(unsigned& c0, unsigned& c1, unsigned a0, unsigned a1,
+                                               unsigned a2, unsigned a3, unsigned b0, unsigned b1) {
+    asm volatile("mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+                 "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%0,%1};\n"
+                 : "+r"(c0), "+r"(c1)
+                 : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+}
+
 __device__ __forceinline__ void mma_s8(int& c0, int& c1, int& c2, int& c3, unsigned a0, unsigned a1,
                                        unsigned a2, unsigned a3, unsigned b0, unsigned b1) {
     asm volatile("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "

--- a/src/ops/gdn_input_proj/gdn_conv.cuh
+++ b/src/ops/gdn_input_proj/gdn_conv.cuh
@@ -111,9 +111,14 @@ struct GdnConvEpilogue {
             }
 
             publish.publish(token, batch_row, row, s1, s2, p);
+            // The tap this column leaves for the next one has to be the value the next
+            // column would have READ, and a sequential decode reads it back from bf16 state.
+            // Carrying the unrounded projection forward instead makes a multi-column pass
+            // compute a different number than one column at a time -- bf16-magnitude, on
+            // thirty of forty layers, on every column but the first.
             s0 = s1;
             s1 = s2;
-            s2 = p;
+            s2 = __bfloat162float(__float2bfloat16_rn(p));
         }
     }
 };

--- a/src/ops/gdn_input_proj/w8/w8_gdn_input_decode.cu
+++ b/src/ops/gdn_input_proj/w8/w8_gdn_input_decode.cu
@@ -55,7 +55,7 @@ make_conv_epilogue(const Tensor& conv_weight, Tensor& conv_states, const Tensor&
 void w8_gdn_input_decode_launch(const Tensor& x, const Weight& weight, Tensor& qkv, Tensor& z,
                                 cudaStream_t stream) {
     constexpr int kRows       = 12288;
-    constexpr int kRowsPerCta = 8;
+    constexpr int kRowsPerCta = 4;
     static_assert((8192 % kRowsPerCta) == 0 && (4096 % kRowsPerCta) == 0);
     const Output output{static_cast<__nv_bfloat16*>(qkv.data), static_cast<__nv_bfloat16*>(z.data)};
     w8_k2048_decode_kernel<kRows, kRowsPerCta>
@@ -71,7 +71,7 @@ void w8_gdn_input_decode_conv_snapshot_launch(
     const Tensor& valid_columns, const Tensor& initial_slot, const Tensor& snapshot_base_slot,
     Tensor& query, Tensor& key, Tensor& value, Tensor& z, cudaStream_t stream) {
     constexpr int kRows       = 12288;
-    constexpr int kRowsPerCta = 8;
+    constexpr int kRowsPerCta = 4;
     const Output ignored_output{static_cast<__nv_bfloat16*>(query.data),
                                 static_cast<__nv_bfloat16*>(z.data)};
     const W8GdnDecodeConvEpilogue epilogue{

--- a/src/ops/kernel/causal_conv1d.cuh
+++ b/src/ops/kernel/causal_conv1d.cuh
@@ -85,6 +85,88 @@ __global__ void causal_conv1d_prefill_pairs_kernel(const __nv_bfloat16* x,
     out2[out_idx] = __floats2bfloat162_rn(silu(acc0), silu(acc1));
 }
 
+// Split-output forms of the two prefill kernels. Identical arithmetic; the output column is
+// routed to one of three destinations by channel so the caller keeps q/k/v already unpacked.
+__global__ void causal_conv1d_prefill_split_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* weight, const __nv_bfloat16* conv_state,
+    __nv_bfloat16* out0, __nv_bfloat16* out1, __nv_bfloat16* out2, std::int32_t split0,
+    std::int32_t split1, std::int32_t C, std::int32_t T) {
+    const std::int64_t C64      = static_cast<std::int64_t>(C);
+    const std::int64_t c_blocks = div_up(C64, static_cast<std::int64_t>(blockDim.x));
+    const std::int64_t block    = static_cast<std::int64_t>(blockIdx.x);
+    const std::int32_t t        = static_cast<std::int32_t>(block / c_blocks);
+    const std::int64_t c_base   = (block - static_cast<std::int64_t>(t) * c_blocks) * blockDim.x;
+    const std::int64_t c        = c_base + threadIdx.x;
+    if (t >= T || c >= C64) { return; }
+
+    const std::int32_t ci      = static_cast<std::int32_t>(c);
+    const std::int64_t in_idx  = static_cast<std::int64_t>(t) * C64 + c;
+    const __nv_bfloat16 x0     = (t >= 3) ? x[static_cast<std::int64_t>(t - 3) * C64 + c]
+                                          : conv_state[static_cast<std::int64_t>(t) * C64 + c];
+    const __nv_bfloat16 x1     = (t >= 2) ? x[static_cast<std::int64_t>(t - 2) * C64 + c]
+                                          : conv_state[static_cast<std::int64_t>(t + 1) * C64 + c];
+    const __nv_bfloat16 x2     = (t >= 1) ? x[static_cast<std::int64_t>(t - 1) * C64 + c]
+                                          : conv_state[static_cast<std::int64_t>(t + 2) * C64 + c];
+    const __nv_bfloat16 x3     = x[in_idx];
+
+    float acc = 0.0f;
+    acc += __bfloat162float(weight[ci]) * __bfloat162float(x0);
+    acc += __bfloat162float(weight[C64 + ci]) * __bfloat162float(x1);
+    acc += __bfloat162float(weight[2 * C64 + ci]) * __bfloat162float(x2);
+    acc += __bfloat162float(weight[3 * C64 + ci]) * __bfloat162float(x3);
+
+    const std::int64_t s0 = split0;
+    const std::int64_t s1 = split1;
+    __nv_bfloat16* dst    = c < s0 ? out0 + static_cast<std::int64_t>(t) * s0 + c
+                           : c < s1 ? out1 + static_cast<std::int64_t>(t) * (s1 - s0) + (c - s0)
+                                    : out2 + static_cast<std::int64_t>(t) * (C64 - s1) + (c - s1);
+    *dst                  = __float2bfloat16_rn(silu(acc));
+}
+
+__global__ void causal_conv1d_prefill_pairs_split_kernel(
+    const __nv_bfloat16* x, const __nv_bfloat16* weight, const __nv_bfloat16* conv_state,
+    __nv_bfloat16* out0, __nv_bfloat16* out1, __nv_bfloat16* out2, std::int32_t split0,
+    std::int32_t split1, std::int32_t C, std::int32_t T) {
+    const std::int64_t C2        = static_cast<std::int64_t>(C / 2);
+    const std::int64_t c_blocks  = div_up(C2, static_cast<std::int64_t>(blockDim.x));
+    const std::int64_t block     = static_cast<std::int64_t>(blockIdx.x);
+    const std::int32_t t         = static_cast<std::int32_t>(block / c_blocks);
+    const std::int64_t pair_base = (block - static_cast<std::int64_t>(t) * c_blocks) * blockDim.x;
+    const std::int64_t p         = pair_base + threadIdx.x;
+    if (t >= T || p >= C2) { return; }
+
+    const auto* x2      = reinterpret_cast<const __nv_bfloat162*>(x);
+    const auto* weight2 = reinterpret_cast<const __nv_bfloat162*>(weight);
+    const auto* state2  = reinterpret_cast<const __nv_bfloat162*>(conv_state);
+
+    const std::int64_t in_idx = static_cast<std::int64_t>(t) * C2 + p;
+    const __nv_bfloat162 x0   = (t >= 3) ? x2[static_cast<std::int64_t>(t - 3) * C2 + p]
+                                         : state2[static_cast<std::int64_t>(t) * C2 + p];
+    const __nv_bfloat162 x1   = (t >= 2) ? x2[static_cast<std::int64_t>(t - 2) * C2 + p]
+                                         : state2[static_cast<std::int64_t>(t + 1) * C2 + p];
+    const __nv_bfloat162 x2v  = (t >= 1) ? x2[static_cast<std::int64_t>(t - 1) * C2 + p]
+                                         : state2[static_cast<std::int64_t>(t + 2) * C2 + p];
+    const __nv_bfloat162 x3   = x2[in_idx];
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+    causal_conv1d_acc_pair(weight2[p], x0, acc0, acc1);
+    causal_conv1d_acc_pair(weight2[C2 + p], x1, acc0, acc1);
+    causal_conv1d_acc_pair(weight2[2 * C2 + p], x2v, acc0, acc1);
+    causal_conv1d_acc_pair(weight2[3 * C2 + p], x3, acc0, acc1);
+
+    const std::int64_t s0 = split0 / 2;
+    const std::int64_t s1 = split1 / 2;
+    __nv_bfloat162* dst =
+        p < s0 ? reinterpret_cast<__nv_bfloat162*>(out0) + static_cast<std::int64_t>(t) * s0 + p
+        : p < s1
+            ? reinterpret_cast<__nv_bfloat162*>(out1) + static_cast<std::int64_t>(t) * (s1 - s0) +
+                  (p - s0)
+            : reinterpret_cast<__nv_bfloat162*>(out2) + static_cast<std::int64_t>(t) * (C2 - s1) +
+                  (p - s1);
+    *dst = __floats2bfloat162_rn(silu(acc0), silu(acc1));
+}
+
 // Writes the trailing width-3 conv window after consuming the T input columns.
 // The initial window is read from `conv_state_in` and the new window is written
 // to `conv_state_out`; passing the same pointer for both is the in-place form.

--- a/src/ops/kernel/rope.cuh
+++ b/src/ops/kernel/rope.cuh
@@ -5,6 +5,8 @@
 // D/R=128/128, plus packed Vision 16Q/16K at D/R=72/72. One CTA owns one token and shares its
 // rotary coefficients across heads.
 
+#include "ops/kernel/rmsnorm.cuh"
+
 #include <cuda_bf16.h>
 
 #include <cmath>
@@ -112,6 +114,78 @@ __device__ __forceinline__ void apply_rope_head(__nv_bfloat16* data, std::int64_
     data2[lane] = __floats2bfloat162_rn(first.x * c0 - second.x * s0, first.y * c1 - second.y * s1);
     data2[lane + kHalfPair] =
         __floats2bfloat162_rn(second.x * c0 + first.x * s0, second.y * c1 + first.y * s1);
+}
+
+// Fused q/k RMS-norm for the Text 16Q/2K decode geometry. One CTA per
+// token, warp-per-row (16 q heads then 2 k heads). The norm body replicates
+// rmsnorm_warp_bf16x2_kernel (Offset epilogue, same reduction and bf16x2 rounding)
+// and is bit-exact against the standalone pair of norm kernels.
+//
+// The rotary step is deliberately NOT folded in. An in-kernel rotation that reuses the
+// freshly rounded pair and exchanges its partner through shfl_xor(16) reproduces every
+// formula, coefficient and rounding of apply_rope_head, yet still drifts from the
+// standalone rope kernel by a last-bit amount that surfaces as a diverged token deep
+// inside long greedy generations, and costs 1.1% of MTP throughput through a lower
+// draft acceptance rate. Keeping rope separate costs +10.1 us/token (+0.36%).
+__launch_bounds__(576) __global__ void qk_norm_rope_text16x2_kernel(
+    const std::int32_t* __restrict__ positions, const __nv_bfloat162* __restrict__ q_in,
+    const __nv_bfloat162* __restrict__ q_weight, __nv_bfloat162* __restrict__ q_out,
+    const __nv_bfloat162* __restrict__ k_in, const __nv_bfloat162* __restrict__ k_weight,
+    __nv_bfloat162* __restrict__ k_out, float eps) {
+    constexpr int kQHeads  = 16;
+    constexpr int kKHeads  = 2;
+    constexpr int kPairs   = 128;
+    constexpr int kQStride = kQHeads * kPairs;
+    constexpr int kKStride = kKHeads * kPairs;
+    const int token = static_cast<int>(blockIdx.x);
+    const int lane  = static_cast<int>(threadIdx.x) & 31;
+    const int warp  = static_cast<int>(threadIdx.x) >> 5;
+
+    // Rotary coefficients: lane l owns scalar pair l, same inputs as fixed_sincos.
+    float lane_sin = 0.0f;
+    float lane_cos = 0.0f;
+    {
+        const float angle = static_cast<float>(positions[token]) * kTextRopeInvFrequency[lane];
+        sincosf(angle, &lane_sin, &lane_cos);
+    }
+    const int half = lane & 15;
+    const float c0 = __shfl_sync(kFullWarpMask, lane_cos, half * 2);
+    const float c1 = __shfl_sync(kFullWarpMask, lane_cos, half * 2 + 1);
+    const float s0 = __shfl_sync(kFullWarpMask, lane_sin, half * 2);
+    const float s1 = __shfl_sync(kFullWarpMask, lane_sin, half * 2 + 1);
+
+    const bool is_q         = warp < kQHeads;
+    const int head          = is_q ? warp : warp - kQHeads;
+    const __nv_bfloat162* x = is_q ? q_in : k_in;
+    const __nv_bfloat162* w = is_q ? q_weight : k_weight;
+    __nv_bfloat162* out     = is_q ? q_out : k_out;
+    const std::int64_t row_base =
+        static_cast<std::int64_t>(token) * (is_q ? kQStride : kKStride) +
+        static_cast<std::int64_t>(head) * kPairs;
+
+    __nv_bfloat162 values[4];
+    float sum = 0.0f;
+#pragma unroll
+    for (int item = 0; item < 4; ++item) {
+        const int pair  = lane + item * 32;
+        values[item]    = x[row_base + pair];
+        const float2 xf = __bfloat1622float2(values[item]);
+        sum += xf.x * xf.x + xf.y * xf.y;
+    }
+    sum       = warp_reduce_sum(sum);
+    float inv = lane == 0 ? rsqrtf(sum / static_cast<float>(256) + eps) : 0.0f;
+    inv       = __shfl_sync(kFullWarpMask, inv, 0);
+
+#pragma unroll
+    for (int item = 0; item < 4; ++item) {
+        const int pair  = lane + item * 32;
+        const float2 xf = __bfloat1622float2(values[item]);
+        const float2 wf = __bfloat1622float2(w[pair]);
+        __nv_bfloat162 stored =
+            __floats2bfloat162_rn(rmsnorm_epilogue<RmsEpilogue::Offset>(xf.x, inv, wf.x, 0.0f),
+                                  rmsnorm_epilogue<RmsEpilogue::Offset>(xf.y, inv, wf.y, 0.0f));
+        out[row_base + pair] = stored;
+    }
 }
 
 template <RopeKernelMode Mode, int QHeads, int KHeads>

--- a/src/ops/launcher/causal_conv1d.cu
+++ b/src/ops/launcher/causal_conv1d.cu
@@ -92,6 +92,56 @@ void causal_conv1d_smallt_launch(const Tensor& x, const Tensor& weight, const Te
     CUDA_CHECK(cudaGetLastError());
 }
 
+void causal_conv1d_prefill_split_launch(const Tensor& x, const Tensor& weight,
+                                        const Tensor& conv_state_in, Tensor& conv_state_out,
+                                        Tensor& out_q, Tensor& out_k, Tensor& out_v,
+                                        cudaStream_t stream) {
+    constexpr int kOutputBlock   = 256;
+    constexpr int kChannelBlock  = 256;
+    constexpr int kPairBlock     = 256;
+    const std::int32_t C         = x.ne[0];
+    const std::int32_t T         = x.ne[1];
+    const std::int32_t split0    = out_q.ne[0];
+    const std::int32_t split1    = split0 + out_k.ne[0];
+    const auto x_addr            = reinterpret_cast<std::uintptr_t>(x.data);
+    const auto w_addr            = reinterpret_cast<std::uintptr_t>(weight.data);
+    const auto in_addr           = reinterpret_cast<std::uintptr_t>(conv_state_in.data);
+    const auto out_state_addr    = reinterpret_cast<std::uintptr_t>(conv_state_out.data);
+    const auto q_addr            = reinterpret_cast<std::uintptr_t>(out_q.data);
+    const auto k_addr            = reinterpret_cast<std::uintptr_t>(out_k.data);
+    const auto v_addr            = reinterpret_cast<std::uintptr_t>(out_v.data);
+
+    const bool pairable =
+        (((x_addr | w_addr | in_addr | out_state_addr | q_addr | k_addr | v_addr) &
+          (alignof(__nv_bfloat162) - 1)) == 0) &&
+        (C & 1) == 0 && (split0 & 1) == 0 && (split1 & 1) == 0;
+    if (pairable) {
+        causal_conv1d_prefill_pairs_split_kernel<<<prefill_output_grid_for(C / 2, T, kPairBlock),
+                                                   kPairBlock, 0, stream>>>(
+            static_cast<const __nv_bfloat16*>(x.data),
+            static_cast<const __nv_bfloat16*>(weight.data),
+            static_cast<const __nv_bfloat16*>(conv_state_in.data),
+            static_cast<__nv_bfloat16*>(out_q.data), static_cast<__nv_bfloat16*>(out_k.data),
+            static_cast<__nv_bfloat16*>(out_v.data), split0, split1, C, T);
+    } else {
+        causal_conv1d_prefill_split_kernel<<<prefill_output_grid_for(C, T, kOutputBlock),
+                                             kOutputBlock, 0, stream>>>(
+            static_cast<const __nv_bfloat16*>(x.data),
+            static_cast<const __nv_bfloat16*>(weight.data),
+            static_cast<const __nv_bfloat16*>(conv_state_in.data),
+            static_cast<__nv_bfloat16*>(out_q.data), static_cast<__nv_bfloat16*>(out_k.data),
+            static_cast<__nv_bfloat16*>(out_v.data), split0, split1, C, T);
+    }
+    CUDA_CHECK(cudaGetLastError());
+
+    causal_conv1d_prefill_state_kernel<<<grid_for(C, kChannelBlock, "prefill state"), kChannelBlock,
+                                         0, stream>>>(
+        static_cast<const __nv_bfloat16*>(x.data),
+        static_cast<const __nv_bfloat16*>(conv_state_in.data),
+        static_cast<__nv_bfloat16*>(conv_state_out.data), C, T);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 void causal_conv1d_sequence_launch(const Tensor& x, const Tensor& weight,
                                    const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
                                    cudaStream_t stream) {

--- a/src/ops/launcher/causal_conv1d.h
+++ b/src/ops/launcher/causal_conv1d.h
@@ -16,6 +16,10 @@ inline constexpr std::int32_t kCausalConvParallelMaxTokens = 16;
 void causal_conv1d_prefill_launch(const Tensor& x, const Tensor& weight,
                                   const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
                                   cudaStream_t stream);
+void causal_conv1d_prefill_split_launch(const Tensor& x, const Tensor& weight,
+                                        const Tensor& conv_state_in, Tensor& conv_state_out,
+                                        Tensor& out_q, Tensor& out_k, Tensor& out_v,
+                                        cudaStream_t stream);
 void causal_conv1d_sequence_launch(const Tensor& x, const Tensor& weight,
                                    const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
                                    cudaStream_t stream);

--- a/src/ops/launcher/rope.cu
+++ b/src/ops/launcher/rope.cu
@@ -197,4 +197,20 @@ void rope_single_launch(const Tensor& positions, int rotary_dim, float theta, Te
     CUDA_CHECK(cudaGetLastError());
 }
 
+void qk_norm_rope_text16x2_launch(const Tensor& positions, const Tensor& q_in,
+                                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                                  const Tensor& k_weight, Tensor& k_out, float eps,
+                                  cudaStream_t stream) {
+    const int tokens = positions.ne[0];
+    qk_norm_rope_text16x2_kernel<<<tokens, 576, 0, stream>>>(
+        static_cast<const std::int32_t*>(positions.data),
+        reinterpret_cast<const __nv_bfloat162*>(q_in.data),
+        reinterpret_cast<const __nv_bfloat162*>(q_weight.data),
+        reinterpret_cast<__nv_bfloat162*>(q_out.data),
+        reinterpret_cast<const __nv_bfloat162*>(k_in.data),
+        reinterpret_cast<const __nv_bfloat162*>(k_weight.data),
+        reinterpret_cast<__nv_bfloat162*>(k_out.data), eps);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 } // namespace ninfer::ops::detail

--- a/src/ops/launcher/rope.h
+++ b/src/ops/launcher/rope.h
@@ -15,4 +15,9 @@ void rope_launch(const Tensor& positions, int rotary_dim, float theta, Tensor& q
 void rope_single_launch(const Tensor& positions, int rotary_dim, float theta, Tensor& x,
                         cudaStream_t stream);
 
+void qk_norm_rope_text16x2_launch(const Tensor& positions, const Tensor& q_in,
+                                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                                  const Tensor& k_weight, Tensor& k_out, float eps,
+                                  cudaStream_t stream);
+
 } // namespace ninfer::ops::detail

--- a/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
+++ b/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
@@ -189,8 +189,19 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
 
     extern __shared__ __align__(128) unsigned char shared_bytes[];
     auto& shared          = *reinterpret_cast<Nvfp4W4a4TmaSharedStorage<Schedule>*>(shared_bytes);
-    const int token_begin = static_cast<int>(blockIdx.y) * Schedule::kBlockM;
-    const int row_begin   = static_cast<int>(blockIdx.x) * Schedule::kBlockN;
+    // N-18: grouped rasterization (G token tiles per row-tile sweep) for L2 weight reuse.
+    constexpr int kRasterGroup = 8;
+    const int raster_id        = static_cast<int>(blockIdx.x) +
+                          static_cast<int>(gridDim.x) * static_cast<int>(blockIdx.y);
+    const int raster_group_first =
+        (raster_id / (static_cast<int>(gridDim.x) * kRasterGroup)) * kRasterGroup;
+    const int raster_group_size =
+        min(kRasterGroup, static_cast<int>(gridDim.y) - raster_group_first);
+    const int raster_index = raster_id - raster_group_first * static_cast<int>(gridDim.x);
+    const int raster_token = raster_group_first + raster_index % raster_group_size;
+    const int raster_row   = raster_index / raster_group_size;
+    const int token_begin = raster_token * Schedule::kBlockM;
+    const int row_begin   = raster_row * Schedule::kBlockN;
 
     if (threadIdx.x == 0) {
 #pragma unroll

--- a/src/ops/linear/q5/q5_rowsplit_storage.cuh
+++ b/src/ops/linear/q5/q5_rowsplit_storage.cuh
@@ -66,6 +66,29 @@ struct Q5SimtDecodeAtom {
 };
 
 struct Q5MmaDecodeAtom {
+    // Four packed bytes plus one high-bit byte -> four bf16 pairs, in weight order.
+    // Per-weight arithmetic is identical to decode_pair below (lane = 4 * chunk + i).
+    static __device__ __forceinline__ void decode_eight(unsigned word,
+                                                        const std::uint8_t* high_chunk,
+                                                        float scale, unsigned (&out)[4]) {
+        const unsigned high = high_chunk[0];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const unsigned byte = (word >> (8 * i)) & 0xffu;
+            const int q0 =
+                ((static_cast<int>(byte & 0x0fu) | static_cast<int>(((high >> (2 * i)) & 1u) << 4)) ^
+                 0x10) -
+                0x10;
+            const int q1 = ((static_cast<int>(byte >> 4) |
+                             static_cast<int>(((high >> (2 * i + 1)) & 1u) << 4)) ^
+                            0x10) -
+                           0x10;
+            const __nv_bfloat162 value = __floats2bfloat162_rn(static_cast<float>(q0) * scale,
+                                                               static_cast<float>(q1) * scale);
+            out[i] = *reinterpret_cast<const unsigned*>(&value);
+        }
+    }
+
     static __device__ __forceinline__ __nv_bfloat162 decode_pair(const std::uint8_t* staged_codes,
                                                                  const std::uint8_t* staged_high,
                                                                  const std::uint8_t* scale_ptr,

--- a/src/ops/linear/q6/q6_rowsplit_storage.cuh
+++ b/src/ops/linear/q6/q6_rowsplit_storage.cuh
@@ -37,6 +37,32 @@ struct Q6SimtDecodeAtom {
 };
 
 struct Q6MmaDecodeAtom {
+    // Four packed bytes plus two high-bit bytes -> four bf16 pairs, in weight order.
+    // Per-weight arithmetic is identical to decode_pair below (lane = 4 * chunk + i).
+    static __device__ __forceinline__ void decode_eight(unsigned word,
+                                                        const std::uint8_t* high_chunk,
+                                                        float scale, unsigned (&out)[4]) {
+        const unsigned high0 = high_chunk[0];
+        const unsigned high1 = high_chunk[1];
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const unsigned byte = (word >> (8 * i)) & 0xffu;
+            const unsigned high = i < 2 ? high0 : high1;
+            const int shift     = (i & 1) * 4;
+            const int q0 =
+                ((static_cast<int>(byte & 0x0fu) | static_cast<int>(((high >> shift) & 3u) << 4)) ^
+                 0x20) -
+                0x20;
+            const int q1 = ((static_cast<int>(byte >> 4) |
+                             static_cast<int>(((high >> (shift + 2)) & 3u) << 4)) ^
+                            0x20) -
+                           0x20;
+            const __nv_bfloat162 value = __floats2bfloat162_rn(static_cast<float>(q0) * scale,
+                                                               static_cast<float>(q1) * scale);
+            out[i] = *reinterpret_cast<const unsigned*>(&value);
+        }
+    }
+
     static __device__ __forceinline__ __nv_bfloat162 decode_pair(const std::uint8_t* staged_codes,
                                                                  const std::uint8_t* staged_high,
                                                                  const std::uint8_t* scale_ptr,

--- a/src/ops/linear/w8/w8_rowsplit_gemm_mma.cuh
+++ b/src/ops/linear/w8/w8_rowsplit_gemm_mma.cuh
@@ -182,43 +182,31 @@ __global__ __launch_bounds__(Cfg::THREADS, Cfg::MIN_BLOCKS) void w8_rowsplit_gem
     auto dequant_w = [&](int kt) {
         constexpr int GROUPS            = BK / 32;
         constexpr int SCALE_CACHE_TILES = 8 / GROUPS;
-        const int scale_pair_offset     = (kt % SCALE_CACHE_TILES) * GROUPS * 2;
-        const int half                  = lane >> 4;
-        const int half_lane             = lane & 15;
-        for (int row_pair = warp * 2; row_pair < BM; row_pair += Cfg::WARPS * 2) {
-            const int row = row_pair + half;
-            unsigned scale_pair0;
-            unsigned scale_pair1 = 0;
-            if constexpr (GROUPS == 2) {
-                scale_pair0 = half_lane == 0
-                                  ? *reinterpret_cast<const std::uint32_t*>(
-                                        &Sr[row * Cfg::SCALE_CACHE_BYTES + scale_pair_offset])
-                                  : 0;
-                scale_pair0 = __shfl_sync(0xffffffffu, scale_pair0, half * 16);
-            } else {
-                static_assert(GROUPS == 4);
-                const unsigned lane_scale_pair =
-                    half_lane < 2
-                        ? *reinterpret_cast<const std::uint32_t*>(
-                              &Sr[row * Cfg::SCALE_CACHE_BYTES + scale_pair_offset + half_lane * 4])
-                        : 0;
-                scale_pair0 = __shfl_sync(0xffffffffu, lane_scale_pair, half * 16);
-                scale_pair1 = __shfl_sync(0xffffffffu, lane_scale_pair, half * 16 + 1);
-            }
+        constexpr int ChunksPerRow      = BK / 8;
+        static_assert(GROUPS == 2 || GROUPS == 4);
+        const int scale_pair_offset = (kt % SCALE_CACHE_TILES) * GROUPS * 2;
+        for (int item = tid; item < BM * ChunksPerRow; item += Cfg::THREADS) {
+            const int row   = item / ChunksPerRow;
+            const int chunk = item - row * ChunksPerRow;
+            const int col   = chunk * 8;
+            const int gg    = col >> 5;
+            const float scale = __half2float(__ushort_as_half(
+                *reinterpret_cast<const std::uint16_t*>(
+                    &Sr[row * Cfg::SCALE_CACHE_BYTES + scale_pair_offset + gg * 2])));
+            const uint2 packed = *reinterpret_cast<const uint2*>(&Cr[row * BK + col]);
+            unsigned decoded[4];
 #pragma unroll
-            for (int gg = 0; gg < GROUPS; ++gg) {
-                const unsigned scale_pair = gg < 2 ? scale_pair0 : scale_pair1;
-                const unsigned scale_bits = (scale_pair >> ((gg & 1) * 16)) & 0xffffu;
-                const float scale         = __half2float(__ushort_as_half(scale_bits));
-                const int col             = gg * 32 + half_lane * 2;
-                const std::uint16_t packed =
-                    *reinterpret_cast<const std::uint16_t*>(&Cr[row * BK + col]);
-                const int q0 = static_cast<int>(static_cast<std::int8_t>(packed & 0xffu));
-                const int q1 = static_cast<int>(static_cast<std::int8_t>(packed >> 8));
-                const __nv_bfloat162 values = __floats2bfloat162_rn(static_cast<float>(q0) * scale,
-                                                                    static_cast<float>(q1) * scale);
-                store_vec(&As[row * BK + w8g32_swz64(row, col)], values);
+            for (int pair = 0; pair < 4; ++pair) {
+                const unsigned word = (pair < 2 ? packed.x : packed.y) >> ((pair & 1) * 16);
+                const int q0        = static_cast<int>(static_cast<std::int8_t>(word & 0xffu));
+                const int q1 = static_cast<int>(static_cast<std::int8_t>((word >> 8) & 0xffu));
+                const __nv_bfloat162 values = __floats2bfloat162_rn(
+                    static_cast<float>(q0) * scale, static_cast<float>(q1) * scale);
+                decoded[pair] = *reinterpret_cast<const unsigned*>(&values);
             }
+            store_vec(&As[row * BK + w8g32_swz64(row, col)],
+                      make_int4(static_cast<int>(decoded[0]), static_cast<int>(decoded[1]),
+                                static_cast<int>(decoded[2]), static_cast<int>(decoded[3])));
         }
     };
 

--- a/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
+++ b/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
@@ -5,7 +5,6 @@
 #include "ops/linear/w8/w8_rowsplit_gemm_simt.cuh"
 
 #include <cstdint>
-#include <cstdlib>
 #include <stdexcept>
 
 namespace ninfer::ops::detail {
@@ -130,14 +129,6 @@ __global__ __launch_bounds__(RowsPerCta * 32, 2) void w8_linear_add_decode_k_ker
 
     acc = warp_reduce_sum(acc);
     if (lane == 0) { residual[row] = __float2bfloat16_rn(__bfloat162float(residual[row]) + acc); }
-}
-
-inline bool ninfer_outproj_direct() {
-    static const bool value = [] {
-        const char* env = std::getenv("NINFER_OUTPROJ_DIRECT");
-        return env != nullptr && env[0] == '1';
-    }();
-    return value;
 }
 
 template <int DecodeK, int RowsPerCta>

--- a/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
+++ b/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
@@ -215,7 +215,7 @@ void w8_linear_add_simt_r8_c4_launch(bool full, const Tensor& x, const Weight& w
                                      Tensor& residual_out, cudaStream_t stream) {
     if (x.ne[1] == 1 && x.ne[0] == 4096 && w.k == 4096 &&
         w.padded_shape[1] == 4096) {
-        launch_decode_k<4096, 8>(x, w, residual_out, stream);
+        launch_decode_k<4096, 16>(x, w, residual_out, stream);
         return;
     }
     launch_variant<4>(full, x, w, residual_out, stream);

--- a/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
+++ b/src/ops/linear_add/w8/w8_linear_add_gemm_simt.cu
@@ -5,6 +5,7 @@
 #include "ops/linear/w8/w8_rowsplit_gemm_simt.cuh"
 
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace ninfer::ops::detail {
@@ -70,6 +71,87 @@ __global__ __launch_bounds__(RowsPerCta * 32, 2) void w8_linear_add_decode_kerne
     if (lane == 0) { residual[row] = __float2bfloat16_rn(__bfloat162float(residual[row]) + acc); }
 }
 
+// Direct decode path for an arbitrary K: the same lane ownership as the staged kernel -- a
+// lane owns eight consecutive phase values -- and the same fmaf order, but without staging
+// through shared memory.
+template <int DecodeK, int RowsPerCta>
+__global__ __launch_bounds__(RowsPerCta * 32, 2) void w8_linear_add_decode_k_kernel(
+    const __nv_bfloat16* __restrict__ x, const std::uint8_t* __restrict__ codes,
+    const std::uint8_t* __restrict__ scales, __nv_bfloat16* __restrict__ residual,
+    std::int32_t rows) {
+    constexpr int kValuesPerLane  = 8;
+    constexpr int kValuesPerPhase = 32 * kValuesPerLane;
+    constexpr int kGroupsPerPhase = kValuesPerPhase / 32;
+    constexpr int kPhases         = DecodeK / kValuesPerPhase;
+    constexpr int DecodeGroups    = DecodeK / 32;
+    constexpr unsigned kMask      = 0xffffffffu;
+
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int row  = static_cast<int>(blockIdx.x) * RowsPerCta + warp;
+    if (row >= rows) { return; }
+    const auto* code_row = codes + static_cast<std::int64_t>(row) * DecodeK;
+    const auto* scale_row =
+        scales + static_cast<std::int64_t>(row) * DecodeGroups * sizeof(std::uint16_t);
+
+    float acc = 0.0f;
+#pragma unroll
+    for (int phase = 0; phase < kPhases; ++phase) {
+        unsigned scale_bits = 0;
+        if (lane < kGroupsPerPhase) {
+            scale_bits = *reinterpret_cast<const std::uint16_t*>(
+                scale_row + static_cast<std::int64_t>(phase * kGroupsPerPhase + lane) * 2);
+        }
+        scale_bits        = __shfl_sync(kMask, scale_bits, lane >> 2);
+        const float scale = __half2float(__ushort_as_half(scale_bits));
+
+        const int phase_k  = phase * kValuesPerPhase + lane * kValuesPerLane;
+        const uint2 packed = load_vec<uint2>(code_row + phase_k);
+        const uint4 values = load_vec<uint4>(x + phase_k);
+        const float2 xv[4] = {
+            bf16x2_bits_to_float2(values.x),
+            bf16x2_bits_to_float2(values.y),
+            bf16x2_bits_to_float2(values.z),
+            bf16x2_bits_to_float2(values.w),
+        };
+#pragma unroll
+        for (int word_index = 0; word_index < 2; ++word_index) {
+            const std::uint32_t word = (&packed.x)[word_index];
+#pragma unroll
+            for (int byte = 0; byte < 4; ++byte) {
+                const float2 activation_pair = xv[word_index * 2 + (byte >> 1)];
+                const float activation = (byte & 1) == 0 ? activation_pair.x : activation_pair.y;
+                const float weight_value =
+                    static_cast<float>(static_cast<std::int8_t>(word >> (byte * 8))) * scale;
+                acc = fmaf(weight_value, activation, acc);
+            }
+        }
+    }
+
+    acc = warp_reduce_sum(acc);
+    if (lane == 0) { residual[row] = __float2bfloat16_rn(__bfloat162float(residual[row]) + acc); }
+}
+
+inline bool ninfer_outproj_direct() {
+    static const bool value = [] {
+        const char* env = std::getenv("NINFER_OUTPROJ_DIRECT");
+        return env != nullptr && env[0] == '1';
+    }();
+    return value;
+}
+
+template <int DecodeK, int RowsPerCta>
+void launch_decode_k(const Tensor& x, const Weight& w, Tensor& residual_out,
+                     cudaStream_t stream) {
+    const std::int32_t rows = w.n;
+    w8_linear_add_decode_k_kernel<DecodeK, RowsPerCta>
+        <<<div_up(rows, RowsPerCta), RowsPerCta * 32, 0, stream>>>(
+            static_cast<const __nv_bfloat16*>(x.data), static_cast<const std::uint8_t*>(w.qdata),
+            static_cast<const std::uint8_t*>(w.scales),
+            static_cast<__nv_bfloat16*>(residual_out.data), rows);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 template <int RowsPerCta>
 void launch_decode(const Tensor& x, const Weight& w, Tensor& residual_out, cudaStream_t stream) {
     static_assert((2048 % RowsPerCta) == 0);
@@ -131,6 +213,11 @@ void w8_linear_add_decode_r16_launch(const Tensor& x, const Weight& w, Tensor& r
 
 void w8_linear_add_simt_r8_c4_launch(bool full, const Tensor& x, const Weight& w,
                                      Tensor& residual_out, cudaStream_t stream) {
+    if (x.ne[1] == 1 && x.ne[0] == 4096 && w.k == 4096 &&
+        w.padded_shape[1] == 4096) {
+        launch_decode_k<4096, 8>(x, w, residual_out, stream);
+        return;
+    }
     launch_variant<4>(full, x, w, residual_out, stream);
 }
 

--- a/src/ops/linear_attention/gated_delta_net/gated_delta_net.cpp
+++ b/src/ops/linear_attention/gated_delta_net/gated_delta_net.cpp
@@ -242,13 +242,15 @@ void gated_delta_net_batch_update(const Tensor& q, const Tensor& k, const Tensor
                                   bool normalize_qk, Tensor& ssm_states,
                                   const Tensor& source_state_slots,
                                   const Tensor& destination_state_slots, Tensor& out,
-                                  cudaStream_t stream) {
+                                  cudaStream_t stream, const void* prefetch_data,
+                                  std::size_t prefetch_bytes) {
     validate_recurrent_batch_update(q, k, v, g, beta, scale, ssm_states, source_state_slots,
                                     destination_state_slots, out);
 
-    detail::gated_delta_net::launch_recurrent_batch_update(q, k, v, g, beta, scale, normalize_qk,
-                                                           ssm_states, source_state_slots,
-                                                           destination_state_slots, out, stream);
+    detail::gated_delta_net::launch_recurrent_batch_update(
+        q, k, v, g, beta, scale, normalize_qk, ssm_states, source_state_slots,
+        destination_state_slots, out, stream, static_cast<const char*>(prefetch_data),
+        static_cast<unsigned long long>(prefetch_bytes));
 }
 
 void gated_delta_net(const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& g,

--- a/src/ops/linear_attention/gated_delta_net/gated_delta_net.cpp
+++ b/src/ops/linear_attention/gated_delta_net/gated_delta_net.cpp
@@ -15,6 +15,19 @@
 #include <string>
 
 namespace ninfer::ops {
+
+namespace {
+thread_local GdnPostNormSpan g_gdn_post_norm_storage{};
+}
+
+void set_gdn_post_norm(GdnPostNormSpan span) { g_gdn_post_norm_storage = span; }
+
+GdnPostNormSpan take_gdn_post_norm() {
+    const GdnPostNormSpan span = g_gdn_post_norm_storage;
+    g_gdn_post_norm_storage    = {};
+    return span;
+}
+
 namespace {
 
 struct Geometry {

--- a/src/ops/linear_attention/gated_delta_net/launch.h
+++ b/src/ops/linear_attention/gated_delta_net/launch.h
@@ -36,7 +36,8 @@ void launch_recurrent_batch_update(const Tensor& q, const Tensor& k, const Tenso
                                    bool normalize_qk, Tensor& ssm_states,
                                    const Tensor& source_state_slots,
                                    const Tensor& destination_state_slots, Tensor& out,
-                                   cudaStream_t stream);
+                                   cudaStream_t stream, const char* prefetch_data = nullptr,
+                                   unsigned long long prefetch_bytes = 0);
 
 void launch_recurrent_record(const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& g,
                              const Tensor& beta, float scale, const Tensor& ssm_states,

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cu
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cu
@@ -1,3 +1,4 @@
+#include "ninfer/ops/gated_delta_net.h"
 #include "ops/linear_attention/gated_delta_net/launch.h"
 
 #include "core/device.h"
@@ -79,6 +80,7 @@ void launch_recurrent_record_fixed(const Tensor& q, const Tensor& k, const Tenso
     const dim3 block(kWarpSize, kNumWarps, 1);
     const std::int64_t state_slot_stride =
         static_cast<std::int64_t>(kStateDim) * kStateDim * ssm_states.ne[2];
+    const GdnPostNormSpan post_norm = ::ninfer::ops::take_gdn_post_norm();
     const RecordAccess<Masked> access{
         static_cast<const __nv_bfloat16*>(q.data),
         static_cast<const __nv_bfloat16*>(k.data),
@@ -96,6 +98,10 @@ void launch_recurrent_record_fixed(const Tensor& q, const Tensor& k, const Tenso
         q.ne[2],
         state_slot_stride,
         scale,
+        reinterpret_cast<const __nv_bfloat162*>(post_norm.gate_z),
+        reinterpret_cast<const __nv_bfloat162*>(post_norm.weight),
+        reinterpret_cast<__nv_bfloat162*>(post_norm.out),
+        post_norm.eps,
     };
     recurrent_record_kernel<Masked><<<grid, block, 0, stream>>>(access);
     CUDA_CHECK(cudaGetLastError());

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cu
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cu
@@ -41,7 +41,8 @@ void launch_recurrent_batch_update_fixed(const Tensor& q, const Tensor& k, const
                                          const Tensor& g, const Tensor& beta, float scale,
                                          Tensor& ssm_states, const Tensor& source_state_slots,
                                          const Tensor& destination_state_slots, Tensor& out,
-                                         cudaStream_t stream) {
+                                         cudaStream_t stream, const char* prefetch_data,
+                                         unsigned long long prefetch_bytes) {
     const auto heads = head_map::of(q.ne[1], v.ne[1]);
     const dim3 grid(static_cast<unsigned>(v.ne[1]), static_cast<unsigned>(q.ne[3]),
                     static_cast<unsigned>(kStateDim / kBlockDv));
@@ -63,6 +64,8 @@ void launch_recurrent_batch_update_fixed(const Tensor& q, const Tensor& k, const
         heads,
         state_slot_stride,
         scale,
+        prefetch_data,
+        prefetch_bytes,
         reinterpret_cast<const __nv_bfloat162*>(update_post_norm.gate_z),
         reinterpret_cast<const __nv_bfloat162*>(update_post_norm.weight),
         reinterpret_cast<__nv_bfloat162*>(update_post_norm.out),
@@ -170,15 +173,16 @@ void launch_recurrent_batch_update(const Tensor& q, const Tensor& k, const Tenso
                                    bool normalize_qk, Tensor& ssm_states,
                                    const Tensor& source_state_slots,
                                    const Tensor& destination_state_slots, Tensor& out,
-                                   cudaStream_t stream) {
+                                   cudaStream_t stream, const char* prefetch_data,
+                                   unsigned long long prefetch_bytes) {
     if (normalize_qk) {
         launch_recurrent_batch_update_fixed<true>(q, k, v, g, beta, scale, ssm_states,
                                                   source_state_slots, destination_state_slots, out,
-                                                  stream);
+                                                  stream, prefetch_data, prefetch_bytes);
     } else {
         launch_recurrent_batch_update_fixed<false>(q, k, v, g, beta, scale, ssm_states,
                                                    source_state_slots, destination_state_slots, out,
-                                                   stream);
+                                                   stream, prefetch_data, prefetch_bytes);
     }
 }
 

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cu
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cu
@@ -48,6 +48,7 @@ void launch_recurrent_batch_update_fixed(const Tensor& q, const Tensor& k, const
     const dim3 block(kWarpSize, kNumWarps, 1);
     const std::int64_t state_slot_stride =
         static_cast<std::int64_t>(kStateDim) * kStateDim * ssm_states.ne[2];
+    const GdnPostNormSpan update_post_norm = ::ninfer::ops::take_gdn_post_norm();
     const BatchUpdateAccess access{
         static_cast<const __nv_bfloat16*>(q.data),
         static_cast<const __nv_bfloat16*>(k.data),
@@ -62,6 +63,10 @@ void launch_recurrent_batch_update_fixed(const Tensor& q, const Tensor& k, const
         heads,
         state_slot_stride,
         scale,
+        reinterpret_cast<const __nv_bfloat162*>(update_post_norm.gate_z),
+        reinterpret_cast<const __nv_bfloat162*>(update_post_norm.weight),
+        reinterpret_cast<__nv_bfloat162*>(update_post_norm.out),
+        update_post_norm.eps,
     };
     recurrent_batch_update_kernel<NormalizeInputs><<<grid, block, 0, stream>>>(access);
     CUDA_CHECK(cudaGetLastError());

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cuh
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cuh
@@ -342,6 +342,8 @@ struct BatchUpdateAccess {
     head_map heads;
     std::int64_t state_slot_stride;
     float scale;
+    const char* prefetch_data;
+    unsigned long long prefetch_bytes;
     const __nv_bfloat162* post_norm_z;
     const __nv_bfloat162* post_norm_weight;
     __nv_bfloat162* post_norm_out;
@@ -724,6 +726,21 @@ __global__ void __launch_bounds__(kWarpSize* kNumWarps, 2)
     load_state_tile(state, access.state_read_base(coord), coord);
     run_recurrent_sequence<NormalizeInputs, OutputEffects>(state, access, coord, 1);
     store_state_tile(state, access.state_write_base(coord), coord);
+
+    if (access.prefetch_data != nullptr) {
+        // Warm L2 for the out-projection this layer is about to stream. One line per thread,
+        // issued by every block -- so it has to sit ahead of the post-norm election below, which
+        // returns from all but the winning tile.
+        const unsigned long long block_index =
+            blockIdx.x + static_cast<unsigned long long>(gridDim.x) *
+                             (blockIdx.y + static_cast<unsigned long long>(gridDim.y) * blockIdx.z);
+        const unsigned long long thread_index =
+            block_index * (blockDim.x * blockDim.y) + threadIdx.y * blockDim.x + threadIdx.x;
+        const unsigned long long offset = thread_index * 128ULL;
+        if (offset < access.prefetch_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(access.prefetch_data + offset));
+        }
+    }
 
     if (access.post_norm_out == nullptr) { return; }
     // Width one here, so a (head, batch) pair owns a single row and one warp finishes it. Same

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cuh
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cuh
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "ninfer/ops/gated_delta_net.h"
+
 #include "ops/common/bf16_vector.cuh"
+#include "ops/common/math.cuh"
 #include "ops/linear_attention/gated_delta_net/common.cuh"
 #include "ops/linear_attention/gated_delta_net/launch.h"
 
@@ -14,6 +17,49 @@ inline constexpr int kDvPerWarp = 4;
 inline constexpr int kNumWarps  = 4;
 inline constexpr int kBlockDv   = kNumWarps * kDvPerWarp;
 inline constexpr int kQkPerLane = kStateDim / kWarpSize;
+
+// One completion ticket per (value head, batch row). atomicInc wraps at gridDim.z-1, and every
+// slot the grid touches receives exactly gridDim.z increments per launch, so each counter returns
+// to zero on its own and no host-side reset is needed. That invariant is what makes an early
+// return anywhere ahead of the tail unsafe: a block that skips its increment leaves the slot
+// non-zero and the next launch elects its winner one tile too soon.
+__device__ unsigned int g_gdn_post_norm_ticket[kGdnPostNormMaxHeads * kGdnPostNormMaxBatch] = {};
+
+// Clone of rmsnorm_warp_bf16x2_kernel<Gated, 512> at D = kStateDim, one warp per row.
+__device__ __forceinline__ void gdn_post_norm_row(const __nv_bfloat162* __restrict__ mixer,
+                                                  const __nv_bfloat162* __restrict__ weight,
+                                                  const __nv_bfloat162* __restrict__ gate_z,
+                                                  __nv_bfloat162* __restrict__ out,
+                                                  std::int64_t row_base, int lane, float eps) {
+    constexpr int kPairs           = kStateDim / 2;
+    constexpr int kMaxPairsPerLane = 4;
+    static_assert(kPairs <= kMaxPairsPerLane * kWarpSize);
+    __nv_bfloat162 values[kMaxPairsPerLane];
+    float sum = 0.0F;
+#pragma unroll
+    for (int item = 0; item < kMaxPairsPerLane; ++item) {
+        const int pair = lane + item * kWarpSize;
+        if (pair < kPairs) {
+            values[item]    = mixer[row_base + pair];
+            const float2 xf = __bfloat1622float2(values[item]);
+            sum += xf.x * xf.x + xf.y * xf.y;
+        }
+    }
+    sum       = warp_reduce_sum(sum);
+    float inv = lane == 0 ? rsqrtf(sum / static_cast<float>(kStateDim) + eps) : 0.0F;
+    inv       = __shfl_sync(kFullWarpMask, inv, 0);
+#pragma unroll
+    for (int item = 0; item < kMaxPairsPerLane; ++item) {
+        const int pair = lane + item * kWarpSize;
+        if (pair < kPairs) {
+            const float2 xf = __bfloat1622float2(values[item]);
+            const float2 wf = __bfloat1622float2(weight[pair]);
+            const float2 zf = __bfloat1622float2(gate_z[row_base + pair]);
+            out[row_base + pair] = __floats2bfloat162_rn(xf.x * inv * wf.x * silu(zf.x),
+                                                         xf.y * inv * wf.y * silu(zf.y));
+        }
+    }
+}
 
 static_assert(kStateDim % kWarpSize == 0);
 static_assert(kQkPerLane == 4);
@@ -365,6 +411,10 @@ struct RecordAccess {
     std::int32_t width;
     std::int64_t state_slot_stride;
     float scale;
+    const __nv_bfloat162* post_norm_z;
+    const __nv_bfloat162* post_norm_weight;
+    __nv_bfloat162* post_norm_out;
+    float post_norm_eps;
 
     __device__ __forceinline__ RecurrentCoordinates coordinates() const {
         return make_coordinates(static_cast<std::int32_t>(blockIdx.y), 0,
@@ -681,6 +731,33 @@ __global__ void __launch_bounds__(kWarpSize* kNumWarps, 2)
     load_state_tile(state, access.state_read_base(coord), coord);
     run_recurrent_sequence<true, RecordEffects>(state, access, coord, valid);
     zero_output_suffix(access, coord, valid, access.width);
+
+    if (access.post_norm_out == nullptr) { return; }
+    // Publish this tile's slice of every row before claiming a ticket, so the block that draws the
+    // last ticket for this (head, batch) pair reads rows no one is still writing.
+    __shared__ bool post_norm_last;
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0 && threadIdx.y == 0) {
+        const unsigned int slot =
+            blockIdx.x * static_cast<unsigned int>(kGdnPostNormMaxBatch) + blockIdx.y;
+        const unsigned int ticket = atomicInc(&g_gdn_post_norm_ticket[slot], gridDim.z - 1U);
+        post_norm_last            = ticket == gridDim.z - 1U;
+    }
+    __syncthreads();
+    if (!post_norm_last) { return; }
+    __threadfence();
+    const auto* mixer = reinterpret_cast<const __nv_bfloat162*>(access.out);
+    // The suffix rows zero_output_suffix just cleared normalise to zero either way, so the fold
+    // covers the full width exactly as the standalone kernel did.
+    for (std::int32_t token = static_cast<std::int32_t>(threadIdx.y); token < access.width;
+         token += static_cast<std::int32_t>(blockDim.y)) {
+        const std::int64_t row =
+            (static_cast<std::int64_t>(blockIdx.y) * access.width + token) * access.heads.H_v +
+            blockIdx.x;
+        gdn_post_norm_row(mixer, access.post_norm_weight, access.post_norm_z, access.post_norm_out,
+                          row * (kStateDim / 2), coord.lane, access.post_norm_eps);
+    }
 }
 
 template <class Geometry>

--- a/src/ops/linear_attention/gated_delta_net/recurrent.cuh
+++ b/src/ops/linear_attention/gated_delta_net/recurrent.cuh
@@ -342,6 +342,10 @@ struct BatchUpdateAccess {
     head_map heads;
     std::int64_t state_slot_stride;
     float scale;
+    const __nv_bfloat162* post_norm_z;
+    const __nv_bfloat162* post_norm_weight;
+    __nv_bfloat162* post_norm_out;
+    float post_norm_eps;
 
     __device__ __forceinline__ RecurrentCoordinates coordinates() const {
         return make_coordinates(static_cast<std::int32_t>(blockIdx.y), 0,
@@ -720,6 +724,27 @@ __global__ void __launch_bounds__(kWarpSize* kNumWarps, 2)
     load_state_tile(state, access.state_read_base(coord), coord);
     run_recurrent_sequence<NormalizeInputs, OutputEffects>(state, access, coord, 1);
     store_state_tile(state, access.state_write_base(coord), coord);
+
+    if (access.post_norm_out == nullptr) { return; }
+    // Width one here, so a (head, batch) pair owns a single row and one warp finishes it. Same
+    // ticket array and same wrap invariant as the record tail.
+    __shared__ bool post_norm_last;
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0 && threadIdx.y == 0) {
+        const unsigned int slot =
+            blockIdx.x * static_cast<unsigned int>(kGdnPostNormMaxBatch) + blockIdx.y;
+        const unsigned int ticket = atomicInc(&g_gdn_post_norm_ticket[slot], gridDim.z - 1U);
+        post_norm_last            = ticket == gridDim.z - 1U;
+    }
+    __syncthreads();
+    if (!post_norm_last || threadIdx.y != 0) { return; }
+    __threadfence();
+    const std::int64_t row =
+        static_cast<std::int64_t>(blockIdx.y) * access.heads.H_v + blockIdx.x;
+    gdn_post_norm_row(reinterpret_cast<const __nv_bfloat162*>(access.out),
+                      access.post_norm_weight, access.post_norm_z, access.post_norm_out,
+                      row * (kStateDim / 2), coord.lane, access.post_norm_eps);
 }
 
 template <bool Masked>

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
@@ -21,7 +21,8 @@ enum class Nvfp4LinearSwiGluRoute {
     TmaFusedW4A4,
 };
 
-constexpr std::int32_t kPrimaryT = 1024;
+constexpr std::int32_t kPrimaryT   = 1024;
+constexpr std::int32_t kTmaBlockM = 256;
 
 Nvfp4LinearSwiGluRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
     if (tokens <= 0) { throw std::invalid_argument("nvfp4 linear_swiglu: T must be positive"); }
@@ -36,7 +37,9 @@ Nvfp4LinearSwiGluRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
     if (tokens == 1) { return Nvfp4LinearSwiGluRoute::DecodeFusedA16; }
     if (tokens <= 4) { return Nvfp4LinearSwiGluRoute::SmallTFusedA16; }
     if (tokens <= 48) { return Nvfp4LinearSwiGluRoute::FusedW4A4; }
-    if (tokens == kPrimaryT) { return Nvfp4LinearSwiGluRoute::TmaFusedW4A4; }
+    if (tokens >= kPrimaryT && (tokens % kTmaBlockM) == 0) {
+        return Nvfp4LinearSwiGluRoute::TmaFusedW4A4;
+    }
     return Nvfp4LinearSwiGluRoute::LinearW4A4Post;
 }
 
@@ -90,8 +93,11 @@ std::size_t nvfp4_linear_swiglu_workspace_capacity_bytes(LinearPolicy policy,
     if (min_tokens <= 48 && max_tokens >= 5) {
         maximum = fused_workspace_bytes(std::min(max_tokens, 48));
     }
-    if (min_tokens <= kPrimaryT && max_tokens >= kPrimaryT) {
-        maximum = fused_workspace_bytes(kPrimaryT);
+    if (max_tokens >= kPrimaryT) {
+        const std::int32_t largest_fused = max_tokens - (max_tokens % kTmaBlockM);
+        if (largest_fused >= std::max(min_tokens, kPrimaryT)) {
+            maximum = std::max(maximum, fused_workspace_bytes(largest_fused));
+        }
     }
 
     std::int32_t last_baseline = max_tokens;

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
@@ -65,8 +65,19 @@ __global__ __launch_bounds__(
 
     extern __shared__ __align__(128) unsigned char shared_bytes[];
     auto& shared = *reinterpret_cast<Nvfp4LinearSwiGluTmaSharedStorage<Schedule>*>(shared_bytes);
-    const int token_begin = static_cast<int>(blockIdx.y) * Schedule::kBlockM;
-    const int pair_begin  = static_cast<int>(blockIdx.x) * kPairN;
+    // N-18: grouped rasterization (G token tiles per row-tile sweep) for L2 weight reuse.
+    constexpr int kRasterGroup = 8;
+    const int raster_id        = static_cast<int>(blockIdx.x) +
+                          static_cast<int>(gridDim.x) * static_cast<int>(blockIdx.y);
+    const int raster_group_first =
+        (raster_id / (static_cast<int>(gridDim.x) * kRasterGroup)) * kRasterGroup;
+    const int raster_group_size =
+        min(kRasterGroup, static_cast<int>(gridDim.y) - raster_group_first);
+    const int raster_index = raster_id - raster_group_first * static_cast<int>(gridDim.x);
+    const int raster_token = raster_group_first + raster_index % raster_group_size;
+    const int raster_row   = raster_index / raster_group_size;
+    const int token_begin = raster_token * Schedule::kBlockM;
+    const int pair_begin  = raster_row * kPairN;
 
     if (threadIdx.x == 0) {
 #pragma unroll

--- a/src/ops/softmax_attention/dense/causal_cache/causal_softmax_attention.cpp
+++ b/src/ops/softmax_attention/dense/causal_cache/causal_softmax_attention.cpp
@@ -1,6 +1,8 @@
 // ninfer::ops - causal cached Softmax Attention validation and finite route dispatch.
 #include "ninfer/ops/softmax_attention.h"
 
+#include "ninfer/ops/sigmoid_mul.h"
+
 #include "core/layout.h"
 #include "ops/kv_cache/d256_profile.h"
 #include "ops/softmax_attention/dense/causal_cache/launch.h"
@@ -402,7 +404,7 @@ void causal_softmax_attention(const Tensor& q, const Tensor& k, const Tensor& v,
                               const Tensor& kv_table_rows, AttentionHeadGeometry geometry,
                               float scale, PagedKVBatchLayerView cache,
                               CausalAttentionExecutionEnvelope envelope, WorkspaceArena& workspace,
-                              Tensor& out, cudaStream_t stream) {
+                              Tensor& out, cudaStream_t stream, const Tensor* gate) {
     constexpr const char* op = "causal_softmax_attention";
     validate_batched_attention_tensors(q, positions, valid_columns, kv_table_rows, out, cache,
                                        geometry, envelope, scale, op);
@@ -423,6 +425,7 @@ void causal_softmax_attention(const Tensor& q, const Tensor& k, const Tensor& v,
     if (route == detail::CausalAttentionRoute::ChunkedSmallT) {
         launch_chunked_small_t(q, k, v, positions, valid_columns, kv_table_rows, scale, cache,
                                envelope, workspace, out, stream);
+        if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
         return;
     }
     if (route == detail::CausalAttentionRoute::SmallT) {
@@ -430,13 +433,19 @@ void causal_softmax_attention(const Tensor& q, const Tensor& k, const Tensor& v,
             detail::causal_attention_split_capacity(q.ne[1], width, cache.dtype, envelope);
         SmallTWorkspace partial =
             allocate_small_t_workspace(workspace, q.ne[1], width, splits, batch, cache.dtype);
-        detail::causal_attention_small_t_launch(q, k, v, positions, valid_columns, kv_table_rows,
-                                                scale, cache, envelope, 0, width, partial.acc,
-                                                partial.m, partial.l, out, stream);
+        // The FP8 cache reaches the reducer through a separate kernel that carries no gate, so it
+        // takes the standalone multiply like the routes that cannot fuse at all.
+        const bool fusable = cache.dtype != DType::FP8_E4M3FN;
+        detail::causal_attention_small_t_launch(
+            q, k, v, positions, valid_columns, kv_table_rows, scale, cache, envelope, 0, width,
+            partial.acc, partial.m, partial.l, out, stream,
+            (gate != nullptr && fusable) ? gate->data : nullptr);
+        if (gate != nullptr && !fusable) { sigmoid_mul(*gate, out, stream); }
         return;
     }
     detail::causal_attention_prompt_launch(q, k, v, positions, valid_columns, kv_table_rows, scale,
                                            cache, out, stream);
+    if (gate != nullptr) { sigmoid_mul(*gate, out, stream); }
 }
 
 void causal_softmax_attention_cached(const Tensor& q, const Tensor& positions,

--- a/src/ops/softmax_attention/dense/causal_cache/launch.h
+++ b/src/ops/softmax_attention/dense/causal_cache/launch.h
@@ -39,7 +39,8 @@ void causal_attention_small_t_launch(
     const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& positions,
     const Tensor& valid_columns, const Tensor& table_rows, float scale, PagedKVBatchLayerView cache,
     CausalAttentionExecutionEnvelope envelope, std::int32_t column_begin, std::int32_t width,
-    Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l, Tensor& out, cudaStream_t stream);
+    Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l, Tensor& out, cudaStream_t stream,
+    const void* gate = nullptr);
 
 void causal_attention_cached_small_t_launch(const Tensor& q, const Tensor& positions, float scale,
                                             const PagedKVLayerView& cache,

--- a/src/ops/softmax_attention/dense/causal_cache/prompt_i8.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/prompt_i8.cuh
@@ -422,6 +422,14 @@ __global__ __maxnreg__(120) void causal_attention_prompt_i8_kernel(
             acc[n][3] *= alpha1;
         }
 
+// Consumer parts (sm_89, sm_120) run f32-accumulate HMMA at half rate. Accumulate the
+// 64-key tile in packed fp16 at full rate and fold it into the fp32 running accumulator
+// once per tile; the per-tile sums are magnitude-bounded by the softmax weights.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200)
+        unsigned tacc[PVNtPerWarp][2];
+#pragma unroll
+        for (int n = 0; n < PVNtPerWarp; ++n) { tacc[n][0] = tacc[n][1] = 0u; }
+#endif
 #pragma unroll
         for (int k = 0; k < PVKs; ++k) {
             unsigned pf[4];
@@ -437,10 +445,25 @@ __global__ __maxnreg__(120) void causal_attention_prompt_i8_kernel(
                 const int vcol = global_n * 8;
                 ldmatrix_x2_t(vf[0], vf[1],
                               smem_addr(&v_f16[vrow * D + causal_prompt_swz(vrow, vcol)]));
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200)
+                mma_f16_f16acc(tacc[n][0], tacc[n][1], pf[0], pf[1], pf[2], pf[3], vf[0], vf[1]);
+#else
                 mma_f16(acc[n][0], acc[n][1], acc[n][2], acc[n][3], pf[0], pf[1], pf[2], pf[3],
                         vf[0], vf[1]);
+#endif
             }
         }
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200)
+#pragma unroll
+        for (int n = 0; n < PVNtPerWarp; ++n) {
+            const __half2 lo = *reinterpret_cast<const __half2*>(&tacc[n][0]);
+            const __half2 hi = *reinterpret_cast<const __half2*>(&tacc[n][1]);
+            acc[n][0] += __half2float(lo.x);
+            acc[n][1] += __half2float(lo.y);
+            acc[n][2] += __half2float(hi.x);
+            acc[n][3] += __half2float(hi.y);
+        }
+#endif
         if (has_next) { ninfer::ops::cp_wait<0>(); }
         __syncthreads();
     }

--- a/src/ops/softmax_attention/dense/causal_cache/small_t.cu
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t.cu
@@ -252,7 +252,8 @@ void causal_attention_small_t_launch_for(const Tensor& q, CacheInput input, cons
                                          const CausalSmallTInvocation& invocation,
                                          CausalAttentionExecutionEnvelope envelope,
                                          Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l,
-                                         Tensor& out, cudaStream_t stream) {
+                                         Tensor& out, cudaStream_t stream,
+                                         const void* gate = nullptr) {
     const auto logical_capacity      = static_cast<std::int32_t>(envelope.max_visible_keys);
     const auto implementation_window = static_cast<std::int32_t>(envelope.max_visible_keys);
     const auto splits =
@@ -327,7 +328,8 @@ void causal_attention_small_t_launch_for(const Tensor& q, CacheInput input, cons
                     ? nullptr
                     : static_cast<const std::int32_t*>(invocation.valid_columns->data),
                 invocation.width, invocation.full_width, invocation.column_begin,
-                invocation.batch_size, splits, static_cast<__nv_bfloat16*>(out.data));
+                invocation.batch_size, splits, static_cast<__nv_bfloat16*>(out.data),
+                static_cast<const __nv_bfloat16*>(gate));
     };
     const bool masked         = invocation.valid_columns != nullptr;
     const auto launch_profile = [&]<bool Int8, bool MultiBatch, bool Masked>() {
@@ -362,7 +364,8 @@ void causal_attention_small_t_launch(
     const Tensor& q, const Tensor& k, const Tensor& v, const Tensor& pos,
     const Tensor& valid_columns, const Tensor& table_rows, float scale, PagedKVBatchLayerView cache,
     CausalAttentionExecutionEnvelope envelope, std::int32_t column_begin, std::int32_t width,
-    Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l, Tensor& out, cudaStream_t stream) {
+    Tensor& partial_acc, Tensor& partial_m, Tensor& partial_l, Tensor& out, cudaStream_t stream,
+    const void* gate) {
     if (cache.dtype == DType::FP8_E4M3FN) {
         causal_attention_small_t_fp8_launch(q, k, v, pos, valid_columns, table_rows, scale, cache,
                                             envelope, column_begin, width, partial_acc, partial_m,
@@ -382,12 +385,13 @@ void causal_attention_small_t_launch(
     if (q.ne[1] == CausalD256H24Kv4::QHeads) {
         causal_attention_small_t_launch_for<CausalD256H24Kv4>(q, input, pos, scale, cache,
                                                               invocation, envelope, partial_acc,
-                                                              partial_m, partial_l, out, stream);
+                                                              partial_m, partial_l, out, stream,
+                                                              gate);
         return;
     }
     causal_attention_small_t_launch_for<CausalD256H16Kv2>(q, input, pos, scale, cache, invocation,
                                                           envelope, partial_acc, partial_m,
-                                                          partial_l, out, stream);
+                                                          partial_l, out, stream, gate);
 }
 
 void causal_attention_cached_small_t_launch(const Tensor& q, const Tensor& pos, float scale,

--- a/src/ops/softmax_attention/dense/causal_cache/small_t.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t.cuh
@@ -158,7 +158,7 @@ __launch_bounds__(256) __global__ void causal_attention_small_t_reduce_output_ke
     const __nv_bfloat16* partial_acc, const float* partial_m, const float* partial_l,
     const std::int32_t* positions, const std::int32_t* valid_columns, std::int32_t tokens,
     std::int32_t full_width, std::int32_t column_begin, std::int32_t batch_size,
-    std::int32_t split_count, __nv_bfloat16* out) {
+    std::int32_t split_count, __nv_bfloat16* out, const __nv_bfloat16* __restrict__ gate) {
     static_assert(DChunk > 0 && DChunk <= kCausalHeadDim);
 
     const int q_head      = static_cast<int>(blockIdx.x);
@@ -217,7 +217,10 @@ __launch_bounds__(256) __global__ void causal_attention_small_t_reduce_output_ke
     if (head_m == -CUDART_INF_F) {
         const int d = d_start + tid;
         if (tid < DChunk && d < kCausalHeadDim) {
-            out[causal_q_index<Geometry>(q_head, d, output_column)] = __float2bfloat16(0.0f);
+            const auto index = causal_q_index<Geometry>(q_head, d, output_column);
+            out[index]       = gate == nullptr
+                                   ? __float2bfloat16(0.0f)
+                                   : __float2bfloat16_rn(0.0f * sigmoid(__bfloat162float(gate[index])));
         }
         return;
     }
@@ -265,8 +268,18 @@ __launch_bounds__(256) __global__ void causal_attention_small_t_reduce_output_ke
         if constexpr (Offset) { absolute_column += column_begin; }
         valid = absolute_column < valid_columns[batch];
     }
-    const float value = (valid && head_l > 0.0f) ? numerator / head_l : 0.0f;
-    out[causal_q_index<Geometry>(q_head, d, output_column)] = __float2bfloat16(value);
+    const float value    = (valid && head_l > 0.0f) ? numerator / head_l : 0.0f;
+    const auto out_index = causal_q_index<Geometry>(q_head, d, output_column);
+    if (gate == nullptr) {
+        out[out_index] = __float2bfloat16(value);
+        return;
+    }
+    // Bit-exact with the standalone multiply: that kernel reads what attention stored, so it sees
+    // the reduce result already rounded to bf16. Round here first, widen back, then multiply --
+    // keeping the fp32 value would be more accurate and would move tokens.
+    const __nv_bfloat16 reduced = __float2bfloat16(value);
+    out[out_index]              = __float2bfloat16_rn(
+        __bfloat162float(reduced) * sigmoid(__bfloat162float(gate[out_index])));
 }
 
 } // namespace ninfer::ops

--- a/src/ops/sparse_moe/decode/sparse_moe_decode.h
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode.h
@@ -53,6 +53,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
                                          cudaStream_t stream,
                                          const int* adaptive_route_jobs = nullptr);
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
-                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream);
+                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                              const void* prefetch_data = nullptr, std::size_t prefetch_bytes = 0);
 
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode.h
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode.h
@@ -54,6 +54,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
                                          const int* adaptive_route_jobs = nullptr);
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
-                              const void* prefetch_data = nullptr, std::size_t prefetch_bytes = 0);
+                              const void* prefetch_data = nullptr, std::size_t prefetch_bytes = 0,
+                              const void* prenorm_gamma = nullptr, float prenorm_eps = 0.0f);
 
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -69,7 +69,9 @@ __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __
 
 __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
-                                     float* __restrict__ scores) {
+                                     float* __restrict__ scores,
+                                     const char* __restrict__ shared_down_codes,
+                                     unsigned long long shared_down_bytes) {
     __shared__ float partial[kD1Warps];
     const int row   = static_cast<int>(blockIdx.x);
     const int warp  = static_cast<int>(threadIdx.x) >> 5;
@@ -81,6 +83,15 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
         float value = lane < kD1Warps ? partial[lane] : 0.0f;
         value       = warp_reduce_sum<kD1Warps>(value);
         if (lane == 0) { scores[row] = value; }
+    }
+    if (shared_down_codes != nullptr) {
+        // Warm L2 for the shared-expert down codes that D4's shared warp
+        // (the block's long pole) will stream at t~14.3us. Pure cache hint.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < shared_down_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(shared_down_codes + offset));
+        }
     }
 }
 
@@ -490,12 +501,13 @@ __global__ void sparse_moe_d4_token_kernel(
     }
 }
 
-void launch_d1(const Tensor& x, const Weight& router_shared_gate,
+void launch_d1(const Tensor& x, const SparseMoeWeights& weights,
                const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
     sparse_moe_d1_kernel<<<kRouterRows, kD1Warps * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data),
-        static_cast<const __nv_bfloat16*>(router_shared_gate.qdata),
-        static_cast<float*>(workspace.scratch.data));
+        static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
+        static_cast<float*>(workspace.scratch.data),
+        static_cast<const char*>(weights.shared_down.qdata), 2048ull * 512ull);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -737,7 +749,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
                               const void* prefetch_data, std::size_t prefetch_bytes) {
-    launch_d1(x, weights.router_shared_gate, workspace, stream);
+    launch_d1(x, weights, workspace, stream);
     launch_d2_d3(x, weights, workspace, stream);
     launch_d4_dependent(weights, destination, workspace, stream, prefetch_data, prefetch_bytes);
 }

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -378,7 +378,8 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
     const float* __restrict__ shared_scale, const float* __restrict__ act,
     const std::uint8_t* __restrict__ routed_codes, const std::uint8_t* __restrict__ routed_high,
     const std::uint8_t* __restrict__ routed_scales, const std::uint8_t* __restrict__ shared_codes,
-    const std::uint8_t* __restrict__ shared_scales, __nv_bfloat16* __restrict__ destination) {
+    const std::uint8_t* __restrict__ shared_scales, __nv_bfloat16* __restrict__ destination,
+    const char* __restrict__ prefetch_data, unsigned long long prefetch_bytes) {
     __shared__ float paths[kTopK + 1][Rows];
     pdl::wait_for_dependencies();
     const int warp     = static_cast<int>(threadIdx.x) >> 5;
@@ -411,6 +412,15 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
 #pragma unroll
         for (int path = 0; path < kTopK + 1; ++path) { value += paths[path][lane]; }
         destination[row_base + lane] = __float2bfloat16_rn(value);
+    }
+    if (prefetch_data != nullptr) {
+        // Fire-and-forget L2 warmup of the next consumer's weight codes.
+        // Pure cache hint; touches no values and no addition order.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < prefetch_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(prefetch_data + offset));
+        }
     }
 }
 
@@ -528,7 +538,8 @@ void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
 
 template <class Codec>
 void launch_d4_dependent_codec(const SparseMoeWeights& weights, Tensor& destination,
-                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                               const void* prefetch_data, std::size_t prefetch_bytes) {
     const auto* ids           = static_cast<const int*>(workspace.ids.data);
     const auto* alpha         = static_cast<const float*>(workspace.alpha.data);
     const auto* shared_scale  = static_cast<const float*>(workspace.shared_scale.data);
@@ -542,20 +553,26 @@ void launch_d4_dependent_codec(const SparseMoeWeights& weights, Tensor& destinat
     CUDA_CHECK(pdl::launch_dependent({dim3(kHidden), dim3(9 * 32), 0, stream},
                                      sparse_moe_d4_nine_warp_kernel<Codec, 1>, ids, alpha,
                                      shared_scale, act, routed_codes, routed_high, routed_scales,
-                                     shared_codes, shared_scales, output));
+                                     shared_codes, shared_scales, output,
+                                     static_cast<const char*>(prefetch_data),
+                                     static_cast<unsigned long long>(prefetch_bytes)));
 }
 
 void launch_d4_dependent(const SparseMoeWeights& weights, Tensor& destination,
-                         const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                         const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                         const void* prefetch_data, std::size_t prefetch_bytes) {
     switch (weights.routed_down.qtype) {
     case QType::Q5G64_F16S:
-        launch_d4_dependent_codec<Q5Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<Q5Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     case QType::Q6G64_F16S:
-        launch_d4_dependent_codec<Q6Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<Q6Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     case QType::W8G32_F16S:
-        launch_d4_dependent_codec<W8Codec>(weights, destination, workspace, stream);
+        launch_d4_dependent_codec<W8Codec>(weights, destination, workspace, stream, prefetch_data,
+                                           prefetch_bytes);
         return;
     default:
         throw std::invalid_argument("sparse_moe: unsupported D4 codec");
@@ -718,10 +735,11 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 }
 
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
-                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                              const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                              const void* prefetch_data, std::size_t prefetch_bytes) {
     launch_d1(x, weights.router_shared_gate, workspace, stream);
     launch_d2_d3(x, weights, workspace, stream);
-    launch_d4_dependent(weights, destination, workspace, stream);
+    launch_d4_dependent(weights, destination, workspace, stream, prefetch_data, prefetch_bytes);
 }
 
 } // namespace ninfer::ops::detail

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -53,6 +53,51 @@ __device__ __forceinline__ float dot_bf16_eight(const __nv_bfloat16* a, const __
     return sum;
 }
 
+// Recompute the pre-MoE RMS-norm inside consumer prologs.
+// Bit-exact clone of rmsnorm_cta_bf16x2_kernel<RmsEpilogue::Offset, 256, 6> at
+// d = 2048: same pair ownership (tid + k*256), same warp/block reduction order,
+// same unit-offset epilogue and bf16x2 rounding; the rounded bits land in shared
+// memory instead of global. Threads with tid >= 256 participate in barriers only.
+__device__ __forceinline__ void moe_prenorm_to_shared(const __nv_bfloat162* __restrict__ x2,
+                                                      const __nv_bfloat162* __restrict__ gamma,
+                                                      float eps,
+                                                      __nv_bfloat162* __restrict__ out2,
+                                                      float* __restrict__ warp_sums,
+                                                      float* __restrict__ inv_shared) {
+    const int tid = static_cast<int>(threadIdx.x);
+    __nv_bfloat162 values[4];
+    float sum = 0.0f;
+    if (tid < 256) {
+#pragma unroll
+        for (int item = 0; item < 4; ++item) {
+            const int pair  = tid + item * 256;
+            values[item]    = x2[pair];
+            const float2 xf = __bfloat1622float2(values[item]);
+            sum += xf.x * xf.x + xf.y * xf.y;
+        }
+    }
+    sum = warp_reduce_sum(sum);
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    if (lane == 0 && warp < 8) { warp_sums[warp] = sum; }
+    __syncthreads();
+    float block_sum = tid < 8 ? warp_sums[tid] : 0.0f;
+    if (warp == 0) { block_sum = warp_reduce_sum<8>(block_sum); }
+    if (tid == 0) { *inv_shared = rsqrtf(block_sum / static_cast<float>(2048) + eps); }
+    __syncthreads();
+    const float inv = *inv_shared;
+    if (tid < 256) {
+#pragma unroll
+        for (int item = 0; item < 4; ++item) {
+            const int pair  = tid + item * 256;
+            const float2 xf = __bfloat1622float2(values[item]);
+            const float2 wf = __bfloat1622float2(gamma[pair]);
+            out2[pair]      = __floats2bfloat162_rn(xf.x * inv * (wf.x + 1.0f),
+                                                    xf.y * inv * (wf.y + 1.0f));
+        }
+    }
+}
+
 __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __nv_bfloat16* row) {
     constexpr int kSlice = kHidden / kD1Warps;
     constexpr int kVecs  = kSlice / (32 * 8);
@@ -71,12 +116,25 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
                                      float* __restrict__ scores,
                                      const char* __restrict__ shared_down_codes,
-                                     unsigned long long shared_down_bytes) {
+                                     unsigned long long shared_down_bytes,
+                                     const __nv_bfloat162* __restrict__ prenorm_gamma,
+                                     float prenorm_eps) {
     __shared__ float partial[kD1Warps];
-    const int row   = static_cast<int>(blockIdx.x);
-    const int warp  = static_cast<int>(threadIdx.x) >> 5;
-    const int lane  = static_cast<int>(threadIdx.x) & 31;
-    const float dot = router_row_dot(x, router + static_cast<std::int64_t>(row) * kHidden);
+    __shared__ __align__(16) __nv_bfloat16 x_normed[kHidden];
+    __shared__ float norm_warp_sums[8];
+    __shared__ float norm_inv;
+    const int row  = static_cast<int>(blockIdx.x);
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const __nv_bfloat16* xs = x;
+    if (prenorm_gamma != nullptr) {
+        moe_prenorm_to_shared(reinterpret_cast<const __nv_bfloat162*>(x), prenorm_gamma,
+                              prenorm_eps, reinterpret_cast<__nv_bfloat162*>(x_normed),
+                              norm_warp_sums, &norm_inv);
+        __syncthreads();
+        xs = x_normed;
+    }
+    const float dot = router_row_dot(xs, router + static_cast<std::int64_t>(row) * kHidden);
     if (lane == 0) { partial[warp] = dot; }
     __syncthreads();
     if (warp == 0) {
@@ -241,13 +299,24 @@ __global__ void sparse_moe_d3_nine_warp_kernel(
     const __nv_bfloat16* __restrict__ x, const int* __restrict__ ids,
     const std::uint8_t* __restrict__ routed_codes, const std::uint8_t* __restrict__ routed_high,
     const std::uint8_t* __restrict__ routed_scales, const std::uint8_t* __restrict__ shared_codes,
-    const std::uint8_t* __restrict__ shared_scales, float* __restrict__ act) {
+    const std::uint8_t* __restrict__ shared_scales, float* __restrict__ act,
+    const __nv_bfloat162* __restrict__ prenorm_gamma, float prenorm_eps) {
     __shared__ __align__(16) __nv_bfloat16 x_shared[kHidden];
     const int tid  = static_cast<int>(threadIdx.x);
     const int warp = tid >> 5;
     const int lane = tid & 31;
+    __shared__ float norm_warp_sums[8];
+    __shared__ float norm_inv;
     if (tid == 0) { pdl::trigger_dependents(); }
-    if (tid < 256) { store_vec(x_shared + tid * 8, load_vec<uint4>(x + tid * 8)); }
+    if (prenorm_gamma == nullptr) {
+        if (tid < 256) { store_vec(x_shared + tid * 8, load_vec<uint4>(x + tid * 8)); }
+    } else {
+        // Raw x arrives here; the norm recompute runs BEFORE the PDL wait,
+        // so it hides inside the d1+d2 window. Warp 8 only joins the barriers.
+        moe_prenorm_to_shared(reinterpret_cast<const __nv_bfloat162*>(x), prenorm_gamma,
+                              prenorm_eps, reinterpret_cast<__nv_bfloat162*>(x_shared),
+                              norm_warp_sums, &norm_inv);
+    }
     __syncthreads();
 
     const int j = static_cast<int>(blockIdx.x);
@@ -503,18 +572,21 @@ __global__ void sparse_moe_d4_token_kernel(
 }
 
 void launch_d1(const Tensor& x, const SparseMoeWeights& weights,
-               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+               const void* prenorm_gamma, float prenorm_eps) {
     sparse_moe_d1_kernel<<<kRouterRows, kD1Warps * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data),
         static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
         static_cast<float*>(workspace.scratch.data),
-        static_cast<const char*>(weights.shared_down.qdata), 2048ull * 512ull);
+        static_cast<const char*>(weights.shared_down.qdata), 2048ull * 512ull,
+        static_cast<const __nv_bfloat162*>(prenorm_gamma), prenorm_eps);
     CUDA_CHECK(cudaGetLastError());
 }
 
 template <class Codec>
 void launch_d3_dependent_codec(const Tensor& x, const SparseMoeWeights& weights,
-                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                               const void* prenorm_gamma, float prenorm_eps) {
     const auto* input         = static_cast<const __nv_bfloat16*>(x.data);
     const auto* ids           = static_cast<const int*>(workspace.ids.data);
     auto* act                 = static_cast<float*>(workspace.scratch.data);
@@ -525,11 +597,13 @@ void launch_d3_dependent_codec(const Tensor& x, const SparseMoeWeights& weights,
     const auto* shared_scales = static_cast<const std::uint8_t*>(weights.shared_gate_up.scales);
     CUDA_CHECK(pdl::launch_dependent(
         {dim3(kIntermediate), dim3(9 * 32), 0, stream}, sparse_moe_d3_nine_warp_kernel<Codec>,
-        input, ids, routed_codes, routed_high, routed_scales, shared_codes, shared_scales, act));
+        input, ids, routed_codes, routed_high, routed_scales, shared_codes, shared_scales, act,
+        static_cast<const __nv_bfloat162*>(prenorm_gamma), prenorm_eps));
 }
 
 void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
-                  const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
+                  const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
+                  const void* prenorm_gamma, float prenorm_eps) {
     const auto* scores = static_cast<const float*>(workspace.scratch.data);
     auto* ids          = static_cast<int*>(workspace.ids.data);
     auto* alpha        = static_cast<float*>(workspace.alpha.data);
@@ -539,10 +613,12 @@ void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
 
     switch (weights.routed_gate_up.qtype) {
     case QType::Q4G64_F16S:
-        launch_d3_dependent_codec<Q4Codec>(x, weights, workspace, stream);
+        launch_d3_dependent_codec<Q4Codec>(x, weights, workspace, stream, prenorm_gamma,
+                                           prenorm_eps);
         return;
     case QType::W8G32_F16S:
-        launch_d3_dependent_codec<W8Codec>(x, weights, workspace, stream);
+        launch_d3_dependent_codec<W8Codec>(x, weights, workspace, stream, prenorm_gamma,
+                                           prenorm_eps);
         return;
     default:
         throw std::invalid_argument("sparse_moe: unsupported D3 codec");
@@ -749,9 +825,10 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream,
-                              const void* prefetch_data, std::size_t prefetch_bytes) {
-    launch_d1(x, weights, workspace, stream);
-    launch_d2_d3(x, weights, workspace, stream);
+                              const void* prefetch_data, std::size_t prefetch_bytes,
+                              const void* prenorm_gamma, float prenorm_eps) {
+    launch_d1(x, weights, workspace, stream, prenorm_gamma, prenorm_eps);
+    launch_d2_d3(x, weights, workspace, stream, prenorm_gamma, prenorm_eps);
     launch_d4_dependent(weights, destination, workspace, stream, prefetch_data, prefetch_bytes);
 }
 

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -417,21 +417,22 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
             for (int row = 0; row < Rows; ++row) { paths[kTopK][row] = *shared_scale * dot[row]; }
         }
     }
+    if (prefetch_data != nullptr) {
+        // Fire-and-forget L2 warmup of the next consumer's weight codes,
+        // issued BEFORE the block barrier so it hides behind the slowest warp instead
+        // of extending the grid tail. Pure cache hint; no values, no addition order.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < prefetch_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(prefetch_data + offset));
+        }
+    }
     __syncthreads();
     if (warp == 0 && lane < Rows) {
         float value = __bfloat162float(destination[row_base + lane]);
 #pragma unroll
         for (int path = 0; path < kTopK + 1; ++path) { value += paths[path][lane]; }
         destination[row_base + lane] = __float2bfloat16_rn(value);
-    }
-    if (prefetch_data != nullptr) {
-        // Fire-and-forget L2 warmup of the next consumer's weight codes.
-        // Pure cache hint; touches no values and no addition order.
-        const unsigned long long offset =
-            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
-        if (offset < prefetch_bytes) {
-            asm volatile("prefetch.global.L2 [%0];" ::"l"(prefetch_data + offset));
-        }
     }
 }
 

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -112,20 +112,29 @@ __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __
     return warp_reduce_sum(sum);
 }
 
+// Ticket for the last-arriving D1 block. atomicInc wraps at gridDim.x-1, so the
+// counter returns to zero on its own and needs no host-side initialisation or workspace slot.
+__device__ unsigned int g_sparse_moe_route_ticket = 0;
+
 __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
                                      float* __restrict__ scores,
                                      const char* __restrict__ shared_down_codes,
                                      unsigned long long shared_down_bytes,
                                      const __nv_bfloat162* __restrict__ prenorm_gamma,
-                                     float prenorm_eps) {
+                                     float prenorm_eps, int* __restrict__ ids,
+                                     float* __restrict__ alpha,
+                                     float* __restrict__ shared_scale) {
     __shared__ float partial[kD1Warps];
+    __shared__ float selected_logits[kTopK];
+    __shared__ bool is_last_block;
     __shared__ __align__(16) __nv_bfloat16 x_normed[kHidden];
     __shared__ float norm_warp_sums[8];
     __shared__ float norm_inv;
     const int row  = static_cast<int>(blockIdx.x);
     const int warp = static_cast<int>(threadIdx.x) >> 5;
     const int lane = static_cast<int>(threadIdx.x) & 31;
+    if (threadIdx.x == 0) { pdl::trigger_dependents(); }
     const __nv_bfloat16* xs = x;
     if (prenorm_gamma != nullptr) {
         moe_prenorm_to_shared(reinterpret_cast<const __nv_bfloat162*>(x), prenorm_gamma,
@@ -141,6 +150,19 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
         float value = lane < kD1Warps ? partial[lane] : 0.0f;
         value       = warp_reduce_sum<kD1Warps>(value);
         if (lane == 0) { scores[row] = value; }
+    }
+    // The top-8 router selection used to be a separate single-warp kernel whose cost
+    // was dominated by the fixed price of a graph node rather than by its work. The block that
+    // arrives last here runs the identical selection instead, so the node disappears. The routine,
+    // its inputs and its comparison order are unchanged, hence the routing is bit-identical.
+    if (threadIdx.x == 0) {
+        __threadfence();
+        const unsigned int ticket = atomicInc(&g_sparse_moe_route_ticket, gridDim.x - 1u);
+        is_last_block             = ticket == gridDim.x - 1u;
+    }
+    __syncthreads();
+    if (is_last_block && warp == 0) {
+        sparse_moe_select_top8_warp(scores, ids, alpha, shared_scale, selected_logits);
     }
     if (shared_down_codes != nullptr) {
         // Warm L2 for the shared-expert down codes that D4's shared warp
@@ -579,7 +601,9 @@ void launch_d1(const Tensor& x, const SparseMoeWeights& weights,
         static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
         static_cast<float*>(workspace.scratch.data),
         static_cast<const char*>(weights.shared_down.qdata), 2048ull * 512ull,
-        static_cast<const __nv_bfloat162*>(prenorm_gamma), prenorm_eps);
+        static_cast<const __nv_bfloat162*>(prenorm_gamma), prenorm_eps,
+        static_cast<int*>(workspace.ids.data), static_cast<float*>(workspace.alpha.data),
+        static_cast<float*>(workspace.shared_scale.data));
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -608,8 +632,11 @@ void launch_d2_d3(const Tensor& x, const SparseMoeWeights& weights,
     auto* ids          = static_cast<int*>(workspace.ids.data);
     auto* alpha        = static_cast<float*>(workspace.alpha.data);
     auto* shared_scale = static_cast<float*>(workspace.shared_scale.data);
-    sparse_moe_d2_warp_kernel<<<1, 32, 0, stream>>>(scores, ids, alpha, shared_scale);
-    CUDA_CHECK(cudaGetLastError());
+    // D2 is folded into the last-arriving D1 block; nothing to launch here.
+    (void)scores;
+    (void)ids;
+    (void)alpha;
+    (void)shared_scale;
 
     switch (weights.routed_gate_up.qtype) {
     case QType::Q4G64_F16S:

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -456,7 +456,47 @@ __device__ __forceinline__ void dot_fp32_rows(const std::uint8_t* codes, const s
             }
         }
     } else if (lane < Codec::kGroupK / 2) {
-        for (int group = first_group; group < last_group; ++group) {
+        // The shared expert's W8 rows carry one FP16 scale per 32-value group and two code bytes
+        // per lane. Reading the scale inside every group leaves a single dependent load pair in
+        // flight, which is what keeps this warp behind the eight routed warps at the block barrier.
+        // Eight group scales are one 16-byte load, so hoist them per chunk and unroll the body:
+        // the eight code loads of a chunk are independent and issue together. Lane ownership,
+        // the operand bytes and the FMA order are untouched, so the result stays bit-identical.
+        constexpr int kScaleChunk = 8;
+        int group                 = first_group;
+        if ((first_group & (kScaleChunk - 1)) == 0) {
+            for (; group + kScaleChunk <= last_group; group += kScaleChunk) {
+                std::uint16_t chunk_scales[Rows][kScaleChunk];
+#pragma unroll
+                for (int row = 0; row < Rows; ++row) {
+                    const std::int64_t index =
+                        static_cast<std::int64_t>(row_base + row) * kGroups + group;
+                    *reinterpret_cast<uint4*>(&chunk_scales[row][0]) =
+                        load_vec<uint4>(scales + index * 2);
+                }
+#pragma unroll
+                for (int step = 0; step < kScaleChunk; ++step) {
+                    const int k     = (group + step) * Codec::kGroupK + lane * 2;
+                    const float2 xv = load_vec<float2>(x + k);
+#pragma unroll
+                    for (int row = 0; row < Rows; ++row) {
+                        const std::int64_t index =
+                            static_cast<std::int64_t>(row_base + row) * kGroups + group + step;
+                        const float scale =
+                            __half2float(__ushort_as_half(chunk_scales[row][step]));
+                        const std::uint8_t* packed = codes + index * Codec::kGroupK +
+                                                     static_cast<std::int64_t>(lane) * 2;
+                        const float w0 =
+                            static_cast<float>(static_cast<std::int8_t>(packed[0])) * scale;
+                        const float w1 =
+                            static_cast<float>(static_cast<std::int8_t>(packed[1])) * scale;
+                        acc[row] = fmaf(w0, xv.x, acc[row]);
+                        acc[row] = fmaf(w1, xv.y, acc[row]);
+                    }
+                }
+            }
+        }
+        for (; group < last_group; ++group) {
             const int k     = group * Codec::kGroupK + lane * 2;
             const float2 xv = load_vec<float2>(x + k);
 #pragma unroll

--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -568,7 +568,7 @@ __global__ void sparse_moe_d4_nine_warp_kernel(
 }
 
 template <class RoutedCodec, int Rows, bool Adaptive>
-__global__ void sparse_moe_d4_token_kernel(
+__global__ __launch_bounds__(9 * 32, 6) void sparse_moe_d4_token_kernel(
     const int* __restrict__ token_ids, const float* __restrict__ token_alpha,
     const float* __restrict__ shared_scale, const float* __restrict__ token_activations,
     const std::uint8_t* __restrict__ routed_codes, const std::uint8_t* __restrict__ routed_high,

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
@@ -35,6 +35,9 @@ struct SparseMoePrefillWorkspace {
     // Selection first writes a rank local to one routing tile. Gather replaces
     // it in place with the inverse map from token/route slot to packed column.
     Tensor packed_index;
+    // Inverse of packed_index: the token each packed column was routed from. Lets the routed
+    // gate/up GEMM stage its activation tile from `x` instead of a materialised copy.
+    Tensor packed_token;
     Tensor shared_scale;
     Tensor tile_counts;
     Tensor tile_bases;
@@ -67,6 +70,7 @@ SparseMoePrefillWorkspace allocate_sparse_moe_prefill_workspace(Arena& arena,
     out.token_ids      = arena.alloc(DType::I32, {assignments}, 256);
     out.token_alpha    = arena.alloc(DType::FP32, {assignments}, 256);
     out.packed_index   = arena.alloc(DType::I32, {assignments}, 256);
+    out.packed_token   = arena.alloc(DType::I32, {assignments}, 256);
     out.shared_scale   = arena.alloc(DType::FP32, {capacity_tokens}, 256);
     out.tile_counts    = arena.alloc(DType::I32, {256, route_tiles}, 256);
     out.tile_bases     = arena.alloc(DType::I32, {256, route_tiles}, 256);

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
@@ -18,7 +18,7 @@ inline constexpr std::int32_t kSparseMoePrefillQ4Q5Min      = 47;
 inline constexpr std::int32_t kSparseMoePrefillQ4Q6Min      = 47;
 inline constexpr std::int32_t kSparseMoePrefillW8W8Min      = 20;
 inline constexpr std::int32_t kSparseMoePrefillWideMin      = 768;
-inline constexpr std::int32_t kSparseMoePrefillSliceMax     = 4096;
+inline constexpr std::int32_t kSparseMoePrefillSliceMax     = 8192;
 inline constexpr std::int32_t kSparseMoeRouteTileTokens     = 8;
 // 257 logits padded to a 16-byte-aligned per-token stride.
 inline constexpr std::int32_t kSparseMoeRouterScoreRows = 260;

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -683,6 +683,12 @@ struct Q5DownMma {
                                                             int lane) {
         return Q5MmaDecodeAtom::decode_pair(codes, high, scale, row, lane);
     }
+
+    __device__ static __forceinline__ void decode_eight(unsigned word,
+                                                        const std::uint8_t* high_chunk, float scale,
+                                                        unsigned (&out)[4]) {
+        Q5MmaDecodeAtom::decode_eight(word, high_chunk, scale, out);
+    }
 };
 
 struct Q6DownMma {
@@ -693,6 +699,12 @@ struct Q6DownMma {
                                                             const std::uint8_t* scale, int row,
                                                             int lane) {
         return Q6MmaDecodeAtom::decode_pair(codes, high, scale, row, lane);
+    }
+
+    __device__ static __forceinline__ void decode_eight(unsigned word,
+                                                        const std::uint8_t* high_chunk, float scale,
+                                                        unsigned (&out)[4]) {
+        Q6MmaDecodeAtom::decode_eight(word, high_chunk, scale, out);
     }
 };
 
@@ -780,10 +792,20 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_dow
         };
 
         auto decode_weight = [&](int stage, int kt) {
-            for (int row = warp; row < kExpertBM; row += ExpertWarps) {
-                const __nv_bfloat162 value = Codec::decode(
-                    Cr[stage], Hr[stage], &Sr[(row * GroupsPerRow + kt) * 2], row, lane);
-                store_vec(&As[row * kExpertBK + gemm_swz64(row, 2 * lane)], value);
+            constexpr int ChunksPerRow = 32 / 4;
+            constexpr int HighPerChunk = Codec::kHighBytes / ChunksPerRow;
+            for (int item = tid; item < kExpertBM * ChunksPerRow; item += ExpertThreads) {
+                const int row     = item / ChunksPerRow;
+                const int chunk   = item - row * ChunksPerRow;
+                const float scale = __half2float(__ushort_as_half(
+                    *reinterpret_cast<const std::uint16_t*>(&Sr[(row * GroupsPerRow + kt) * 2])));
+                unsigned decoded[4];
+                Codec::decode_eight(
+                    *reinterpret_cast<const unsigned*>(&Cr[stage][row * 32 + chunk * 4]),
+                    &Hr[stage][row * Codec::kHighBytes + chunk * HighPerChunk], scale, decoded);
+                store_vec(&As[row * kExpertBK + gemm_swz64(row, chunk * 8)],
+                          make_int4(static_cast<int>(decoded[0]), static_cast<int>(decoded[1]),
+                                    static_cast<int>(decoded[2]), static_cast<int>(decoded[3])));
             }
         };
 

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -247,6 +247,28 @@ sparse_moe_prefill_gather_kernel(const __nv_bfloat16* __restrict__ x, const int*
     if (threadIdx.x == 0) { packed_index[assignment] = packed; }
 }
 
+// Publishes the packed-column map without moving activations. One thread per assignment.
+template <bool Adaptive>
+__global__ void sparse_moe_prefill_index_kernel(const int* __restrict__ ids,
+                                                int* __restrict__ packed_index,
+                                                const int* __restrict__ tile_bases,
+                                                int* __restrict__ packed_token, int assignments,
+                                                const int* __restrict__ route_job_count) {
+    if constexpr (Adaptive) {
+        if (*route_job_count < 0) { return; }
+    }
+    const int assignment =
+        static_cast<int>(blockIdx.x) * static_cast<int>(blockDim.x) + static_cast<int>(threadIdx.x);
+    if (assignment >= assignments) { return; }
+    const int token  = assignment / kTopK;
+    const int expert = ids[assignment];
+    const int tile   = token / kSparseMoeRouteTileTokens;
+    const int packed =
+        tile_bases[static_cast<std::int64_t>(tile) * kExperts + expert] + packed_index[assignment];
+    packed_index[assignment] = packed;
+    packed_token[packed]     = token;
+}
+
 constexpr int kExpertBM                = 64;
 constexpr int kExpertBN                = 64;
 constexpr int kExpertBK                = 64;
@@ -281,10 +303,11 @@ __device__ __forceinline__ void q4_decode_eight_bf16(unsigned word, unsigned (&o
 
 template <int ExpertWarps, int ExpertBN>
 __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
-    const __nv_bfloat16* __restrict__ gathered, const int* __restrict__ expert_offsets,
-    const int* __restrict__ route_job_experts, const int* __restrict__ route_job_columns,
-    const int* __restrict__ route_job_count, const std::uint8_t* __restrict__ codes,
-    const std::uint8_t* __restrict__ scales, __nv_bfloat16* __restrict__ activation) {
+    const __nv_bfloat16* __restrict__ x, const int* __restrict__ packed_token,
+    const int* __restrict__ expert_offsets, const int* __restrict__ route_job_experts,
+    const int* __restrict__ route_job_columns, const int* __restrict__ route_job_count,
+    const std::uint8_t* __restrict__ codes, const std::uint8_t* __restrict__ scales,
+    __nv_bfloat16* __restrict__ activation) {
     constexpr int ExpertThreads = ExpertWarps * 32;
     constexpr int GroupsPerRow  = kHidden / 64;
     constexpr int WarpCols      = ExpertBN / ExpertWarps;
@@ -294,6 +317,7 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
     __shared__ __align__(16) __nv_bfloat16 Bs[kExpertStages][ExpertBN * kExpertBK];
     __shared__ __align__(16) std::uint8_t Cr[kExpertStages][kExpertBM * 32];
     __shared__ __align__(16) std::uint8_t Sr[kExpertBM * GroupsPerRow * 2];
+    __shared__ __align__(16) int Tok[ExpertBN];
 
     const int tid  = static_cast<int>(threadIdx.x);
     const int warp = tid >> 5;
@@ -319,6 +343,10 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
         const int count         = expert_offsets[expert + 1] - begin;
         const int column_base   = route_job_columns[route_job];
         const int cols          = count - column_base < ExpertBN ? count - column_base : ExpertBN;
+        for (int c = tid; c < ExpertBN; c += ExpertThreads) {
+            Tok[c] = packed_token[c < cols ? begin + column_base + c : begin];
+        }
+        __syncthreads();
         float acc[4][WarpNT][4] = {};
 
         auto global_row = [&](int local_row) {
@@ -341,14 +369,10 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
         auto stage_inputs = [&](int stage, int kt) {
             const int k0 = kt * kExpertBK;
             for (int item = tid; item < ExpertBN * (kExpertBK / 8); item += ExpertThreads) {
-                const int col        = item / (kExpertBK / 8);
-                const int k8         = item - col * (kExpertBK / 8);
-                const int packed_col = begin + column_base + col;
-                auto* dst            = &Bs[stage][col * kExpertBK + gemm_swz64(col, k8 * 8)];
-                const auto* src =
-                    gathered +
-                    static_cast<std::int64_t>(col < cols ? packed_col : begin) * kHidden + k0 +
-                    k8 * 8;
+                const int col   = item / (kExpertBK / 8);
+                const int k8    = item - col * (kExpertBK / 8);
+                auto* dst       = &Bs[stage][col * kExpertBK + gemm_swz64(col, k8 * 8)];
+                const auto* src = x + static_cast<std::int64_t>(Tok[col]) * kHidden + k0 + k8 * 8;
                 cp_async_zfill<16, Cache::cg>(dst, src, col < cols ? 16 : 0);
             }
 
@@ -1160,6 +1184,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
     auto* scores            = static_cast<float*>(workspace.score_storage.data);
     auto* shared_activation = static_cast<__nv_bfloat16*>(workspace.shared_activation.data);
     auto* grouped_io        = static_cast<__nv_bfloat16*>(workspace.grouped_io.data);
+    auto* packed_token      = static_cast<int*>(workspace.packed_token.data);
     auto* routed_activation = static_cast<__nv_bfloat16*>(workspace.routed_storage.data);
     auto* routed_sum        = static_cast<float*>(workspace.routed_sum.data);
 
@@ -1195,6 +1220,8 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             route_tiles, route_job_bn, tokens, adaptive);
         CUDA_CHECK(cudaGetLastError());
 
+        const bool routed_gate_up_q4 = weights.routed_gate_up.qtype == QType::Q4G64_F16S;
+        const int index_blocks       = (assignments + kExpertThreads - 1) / kExpertThreads;
         if (adaptive) {
             auto* adaptive_activations = reinterpret_cast<float*>(grouped_io);
             sparse_moe_decode_launch_d3_small_t(input_slice, weights, ids, adaptive_activations,
@@ -1203,8 +1230,16 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             sparse_moe_decode_launch_d4_small_t(
                 weights, output_slice, ids, alpha, shared_scale, adaptive_activations, tokens,
                 SparseMoeSmallTD4Schedule::Rows4, stream, route_job_count);
-            sparse_moe_prefill_gather_kernel<true><<<assignments, kExpertThreads, 0, stream>>>(
-                input, ids, packed_index, tile_bases, grouped_io, route_job_count);
+            if (routed_gate_up_q4) {
+                sparse_moe_prefill_index_kernel<true><<<index_blocks, kExpertThreads, 0, stream>>>(
+                    ids, packed_index, tile_bases, packed_token, assignments, route_job_count);
+            } else {
+                sparse_moe_prefill_gather_kernel<true><<<assignments, kExpertThreads, 0, stream>>>(
+                    input, ids, packed_index, tile_bases, grouped_io, route_job_count);
+            }
+        } else if (routed_gate_up_q4) {
+            sparse_moe_prefill_index_kernel<false><<<index_blocks, kExpertThreads, 0, stream>>>(
+                ids, packed_index, tile_bases, packed_token, assignments, nullptr);
         } else {
             sparse_moe_prefill_gather_kernel<false><<<assignments, kExpertThreads, 0, stream>>>(
                 input, ids, packed_index, tile_bases, grouped_io, nullptr);
@@ -1216,13 +1251,13 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             if (wide_plan) {
                 sparse_moe_prefill_q4_gate_up_kernel<8, 64>
                     <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
-                        grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
-                        routed_gate_codes, routed_gate_scales, routed_activation);
+                        input, packed_token, offsets, route_job_experts, route_job_columns,
+                        route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             } else {
                 sparse_moe_prefill_q4_gate_up_kernel<4, 32>
                     <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
-                        grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
-                        routed_gate_codes, routed_gate_scales, routed_activation);
+                        input, packed_token, offsets, route_job_experts, route_job_columns,
+                        route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             }
         } else if (weights.routed_gate_up.qtype == QType::W8G32_F16S) {
             sparse_moe_prefill_w8_gate_up_kernel<true>

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -257,6 +257,28 @@ constexpr int kRtx5090SmCount          = 170;
 constexpr int kPrefillBlocksPerSm      = 3;
 constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
 
+// Eight packed Q4 codes -> four bf16 pairs in weight order. Bit-identical to the scalar
+// (nibble -> int -> float -> bf16) path: the codes decode to integers in [-8, 7], which bf16
+// represents exactly, so `128 + (code ^ 8)` minus `136` reproduces the same bits.
+__device__ __forceinline__ void q4_decode_eight_bf16(unsigned word, unsigned (&out)[4]) {
+    const unsigned kBias  = 0x43084308u; // bf16 136.0 in both halves
+    const unsigned kMagic = 0x43004300u; // bf16 128.0 in both halves
+    word ^= 0x88888888u;
+    const unsigned lo   = word & 0x0f0f0f0fu;
+    const unsigned hi   = (word >> 4) & 0x0f0f0f0fu;
+    const unsigned even = __byte_perm(lo, hi, 0x5140);
+    const unsigned odd  = __byte_perm(lo, hi, 0x7362);
+    const unsigned biased[4] = {__byte_perm(even, kMagic, 0x7150), __byte_perm(even, kMagic, 0x7372),
+                                __byte_perm(odd, kMagic, 0x7150), __byte_perm(odd, kMagic, 0x7372)};
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const __nv_bfloat162 value =
+            __hsub2(*reinterpret_cast<const __nv_bfloat162*>(&biased[i]),
+                    *reinterpret_cast<const __nv_bfloat162*>(&kBias));
+        out[i] = *reinterpret_cast<const unsigned*>(&value);
+    }
+}
+
 template <int ExpertWarps, int ExpertBN>
 __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
     const __nv_bfloat16* __restrict__ gathered, const int* __restrict__ expert_offsets,
@@ -342,13 +364,16 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
         };
 
         auto decode_weight = [&](int stage) {
-            for (int row = warp; row < kExpertBM; row += ExpertWarps) {
-                const std::uint8_t packed = Cr[stage][row * 32 + lane];
-                const int q0              = (static_cast<int>(packed & 0x0fu) ^ 0x08) - 0x08;
-                const int q1              = (static_cast<int>(packed >> 4) ^ 0x08) - 0x08;
-                const __nv_bfloat162 value =
-                    __floats2bfloat162_rn(static_cast<float>(q0), static_cast<float>(q1));
-                store_vec(&As[row * kExpertBK + gemm_swz64(row, 2 * lane)], value);
+            constexpr int ChunksPerRow = 32 / 4;
+            for (int item = tid; item < kExpertBM * ChunksPerRow; item += ExpertThreads) {
+                const int row   = item / ChunksPerRow;
+                const int chunk = item - row * ChunksPerRow;
+                unsigned decoded[4];
+                q4_decode_eight_bf16(
+                    *reinterpret_cast<const unsigned*>(&Cr[stage][row * 32 + chunk * 4]), decoded);
+                store_vec(&As[row * kExpertBK + gemm_swz64(row, chunk * 8)],
+                          make_int4(static_cast<int>(decoded[0]), static_cast<int>(decoded[1]),
+                                    static_cast<int>(decoded[2]), static_cast<int>(decoded[3])));
             }
         };
 

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -280,23 +280,23 @@ constexpr int kRtx5090SmCount          = 170;
 constexpr int kPrefillBlocksPerSm      = 3;
 constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
 
-// [research] ширина задания MoE-GEMM prefill: NINFER_MOE_BN=64|128.
-inline int ninfer_moe_bn_override() {
-    static const int value = [] {
-        const char* env  = std::getenv("NINFER_MOE_BN");
-        const int parsed = env == nullptr ? 64 : std::atoi(env);
-        return parsed == 128 ? 128 : 64;
-    }();
-    return value;
+// Job width for the grouped MoE prefill GEMM. Each job re-reads its expert's whole weight slab,
+// and the average column run per expert is tokens/32 at top-8 of 256, so a width of 64 covers a
+// 2048-token chunk exactly and re-reads every slab twice at 4096, four times at 8192. Pick the
+// width from the chunk.
+constexpr int kSparseMoePrefillWideBnTokens = 4096;
+
+inline int ninfer_moe_bn_for(int tokens) {
+    return tokens >= kSparseMoePrefillWideBnTokens ? 128 : 64;
 }
-inline int ninfer_moe_wide_blocks() {
-    return ninfer_moe_bn_override() == 128 ? 2 * kRtx5090SmCount : kPrefillPersistentBlocks;
+inline int ninfer_moe_wide_blocks(int tokens) {
+    return ninfer_moe_bn_for(tokens) == 128 ? 2 * kRtx5090SmCount : kPrefillPersistentBlocks;
 }
 #define NINFER_MOE_LAUNCH_Q4GU(...)                                                                \
     do {                                                                                           \
-        if (ninfer_moe_bn_override() == 128) {                                                     \
+        if (ninfer_moe_bn_for(tokens) == 128) {                                                     \
             sparse_moe_prefill_q4_gate_up_kernel<8, 128>                                           \
-                <<<ninfer_moe_wide_blocks(), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+                <<<ninfer_moe_wide_blocks(tokens), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
         } else {                                                                                   \
             sparse_moe_prefill_q4_gate_up_kernel<8, 64>                                            \
                 <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
@@ -304,9 +304,9 @@ inline int ninfer_moe_wide_blocks() {
     } while (0)
 #define NINFER_MOE_LAUNCH_DOWN(CODEC, ...)                                                         \
     do {                                                                                           \
-        if (ninfer_moe_bn_override() == 128) {                                                     \
+        if (ninfer_moe_bn_for(tokens) == 128) {                                                     \
             sparse_moe_prefill_qx_down_kernel<CODEC, 8, 128>                                       \
-                <<<ninfer_moe_wide_blocks(), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+                <<<ninfer_moe_wide_blocks(tokens), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
         } else {                                                                                   \
             sparse_moe_prefill_qx_down_kernel<CODEC, 8, 64>                                        \
                 <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
@@ -1262,7 +1262,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         CUDA_CHECK(cudaGetLastError());
 
         const bool wide_plan   = tokens >= kSparseMoePrefillWideMin;
-        const int route_job_bn = wide_plan ? ninfer_moe_bn_override() : 32;
+        const int route_job_bn = wide_plan ? ninfer_moe_bn_for(tokens) : 32;
         sparse_moe_prefill_scan_kernel<<<1, kExpertThreads, 0, stream>>>(
             tile_counts, tile_bases, offsets, route_job_experts, route_job_columns, route_job_count,
             route_tiles, route_job_bn, tokens, adaptive);

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -205,6 +205,10 @@ __global__ void sparse_moe_prefill_scan_kernel(const int* __restrict__ tile_coun
         cursor += tile_counts[index];
     }
 
+    // Thread e read scan[e-1] above; do not let thread e-1 overwrite it until every thread
+    // has taken its copy. The tile_bases loop in between makes the window wide in practice,
+    // but wide is not closed.
+    __syncthreads();
     scan[expert] = (count + job_bn - 1) / job_bn;
     __syncthreads();
 #pragma unroll

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace ninfer::ops::detail {
@@ -279,6 +280,39 @@ constexpr int kRtx5090SmCount          = 170;
 constexpr int kPrefillBlocksPerSm      = 3;
 constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
 
+// [research] ширина задания MoE-GEMM prefill: NINFER_MOE_BN=64|128.
+inline int ninfer_moe_bn_override() {
+    static const int value = [] {
+        const char* env  = std::getenv("NINFER_MOE_BN");
+        const int parsed = env == nullptr ? 64 : std::atoi(env);
+        return parsed == 128 ? 128 : 64;
+    }();
+    return value;
+}
+inline int ninfer_moe_wide_blocks() {
+    return ninfer_moe_bn_override() == 128 ? 2 * kRtx5090SmCount : kPrefillPersistentBlocks;
+}
+#define NINFER_MOE_LAUNCH_Q4GU(...)                                                                \
+    do {                                                                                           \
+        if (ninfer_moe_bn_override() == 128) {                                                     \
+            sparse_moe_prefill_q4_gate_up_kernel<8, 128>                                           \
+                <<<ninfer_moe_wide_blocks(), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+        } else {                                                                                   \
+            sparse_moe_prefill_q4_gate_up_kernel<8, 64>                                            \
+                <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+        }                                                                                          \
+    } while (0)
+#define NINFER_MOE_LAUNCH_DOWN(CODEC, ...)                                                         \
+    do {                                                                                           \
+        if (ninfer_moe_bn_override() == 128) {                                                     \
+            sparse_moe_prefill_qx_down_kernel<CODEC, 8, 128>                                       \
+                <<<ninfer_moe_wide_blocks(), 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+        } else {                                                                                   \
+            sparse_moe_prefill_qx_down_kernel<CODEC, 8, 64>                                        \
+                <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(__VA_ARGS__);                    \
+        }                                                                                          \
+    } while (0)
+
 // Eight packed Q4 codes -> four bf16 pairs in weight order. Bit-identical to the scalar
 // (nibble -> int -> float -> bf16) path: the codes decode to integers in [-8, 7], which bf16
 // represents exactly, so `128 + (code ^ 8)` minus `136` reproduces the same bits.
@@ -302,7 +336,7 @@ __device__ __forceinline__ void q4_decode_eight_bf16(unsigned word, unsigned (&o
 }
 
 template <int ExpertWarps, int ExpertBN>
-__global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
+__global__ __launch_bounds__(ExpertWarps * 32, ExpertBN >= 128 ? 2 : 3) void sparse_moe_prefill_q4_gate_up_kernel(
     const __nv_bfloat16* __restrict__ x, const int* __restrict__ packed_token,
     const int* __restrict__ expert_offsets, const int* __restrict__ route_job_experts,
     const int* __restrict__ route_job_columns, const int* __restrict__ route_job_count,
@@ -733,13 +767,16 @@ struct Q6DownMma {
 };
 
 template <class Codec, int ExpertWarps, int ExpertBN>
-__global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_down_kernel(
+__global__ __launch_bounds__(ExpertWarps * 32, ExpertBN >= 128 ? 2 : 3) void sparse_moe_prefill_qx_down_kernel(
     const __nv_bfloat16* __restrict__ activation, const int* __restrict__ expert_offsets,
     const int* __restrict__ route_job_experts, const int* __restrict__ route_job_columns,
     const int* __restrict__ route_job_count, const std::uint8_t* __restrict__ codes,
     const std::uint8_t* __restrict__ high, const std::uint8_t* __restrict__ scales,
     __nv_bfloat16* __restrict__ output) {
     constexpr int ExpertThreads = ExpertWarps * 32;
+    constexpr int WarpCols      = ExpertBN / ExpertWarps;
+    constexpr int WarpNT        = WarpCols / 8;
+    static_assert(ExpertBN % ExpertWarps == 0 && WarpCols % 8 == 0);
     constexpr int GroupsPerRow  = kIntermediate / 64;
     __shared__ __align__(16) __nv_bfloat16 As[kExpertBM * kExpertBK];
     __shared__ __align__(16) __nv_bfloat16 Bs[kExpertStages][ExpertBN * kExpertBK];
@@ -771,7 +808,7 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_dow
         const int count       = expert_offsets[expert + 1] - begin;
         const int column_base = route_job_columns[route_job];
         const int cols        = count - column_base < ExpertBN ? count - column_base : ExpertBN;
-        float acc[4][4]       = {};
+        float acc[4][WarpNT][4] = {};
 
         auto stage_scales = [&] {
             for (int row = tid; row < kExpertBM; row += ExpertThreads) {
@@ -853,7 +890,7 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_dow
 #pragma unroll
                 for (int ki = 0; ki < kExpertBK / 16; ++ki) {
                     unsigned af[4][4];
-                    unsigned bf[2];
+                    unsigned bf[WarpNT][2];
 #pragma unroll
                     for (int mi = 0; mi < 4; ++mi) {
                         const int row = mi * 16 + a_rowoff;
@@ -861,14 +898,22 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_dow
                         ldmatrix_x4(af[mi][0], af[mi][1], af[mi][2], af[mi][3],
                                     smem_addr(&As[row * kExpertBK + gemm_swz64(row, col)]));
                     }
-                    const int brow = warp * 8 + b_rin;
                     const int bcol = ki * 16 + b_koff;
-                    ldmatrix_x2(bf[0], bf[1],
-                                smem_addr(&Bs[stage][brow * kExpertBK + gemm_swz64(brow, bcol)]));
+#pragma unroll
+                    for (int ni = 0; ni < WarpNT; ++ni) {
+                        const int brow = warp * WarpCols + ni * 8 + b_rin;
+                        ldmatrix_x2(
+                            bf[ni][0], bf[ni][1],
+                            smem_addr(&Bs[stage][brow * kExpertBK + gemm_swz64(brow, bcol)]));
+                    }
 #pragma unroll
                     for (int mi = 0; mi < 4; ++mi) {
-                        mma_bf16(acc[mi][0], acc[mi][1], acc[mi][2], acc[mi][3], af[mi][0],
-                                 af[mi][1], af[mi][2], af[mi][3], bf[0], bf[1]);
+#pragma unroll
+                        for (int ni = 0; ni < WarpNT; ++ni) {
+                            mma_bf16(acc[mi][ni][0], acc[mi][ni][1], acc[mi][ni][2],
+                                     acc[mi][ni][3], af[mi][0], af[mi][1], af[mi][2], af[mi][3],
+                                     bf[ni][0], bf[ni][1]);
+                        }
                     }
                 }
             }
@@ -881,26 +926,29 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_qx_dow
         cp_wait<0>();
         __syncthreads();
 
-        if (warp * 8 < cols) {
+        if (warp * WarpCols < cols) {
 #pragma unroll
             for (int mi = 0; mi < 4; ++mi) {
                 const int output_row0 = row0 + mi * 16 + gid;
                 const int output_row1 = output_row0 + 8;
-                const int col0        = begin + column_base + warp * 8 + 2 * lid;
-                const int col1        = col0 + 1;
-                const int local_col0  = warp * 8 + 2 * lid;
-                const int local_col1  = local_col0 + 1;
-                if (local_col0 < cols) {
-                    output[static_cast<std::int64_t>(col0) * kHidden + output_row0] =
-                        __float2bfloat16_rn(acc[mi][0]);
-                    output[static_cast<std::int64_t>(col0) * kHidden + output_row1] =
-                        __float2bfloat16_rn(acc[mi][2]);
-                }
-                if (local_col1 < cols) {
-                    output[static_cast<std::int64_t>(col1) * kHidden + output_row0] =
-                        __float2bfloat16_rn(acc[mi][1]);
-                    output[static_cast<std::int64_t>(col1) * kHidden + output_row1] =
-                        __float2bfloat16_rn(acc[mi][3]);
+#pragma unroll
+                for (int ni = 0; ni < WarpNT; ++ni) {
+                    const int local_col0 = warp * WarpCols + ni * 8 + 2 * lid;
+                    const int local_col1 = local_col0 + 1;
+                    const int col0       = begin + column_base + local_col0;
+                    const int col1       = col0 + 1;
+                    if (local_col0 < cols) {
+                        output[static_cast<std::int64_t>(col0) * kHidden + output_row0] =
+                            __float2bfloat16_rn(acc[mi][ni][0]);
+                        output[static_cast<std::int64_t>(col0) * kHidden + output_row1] =
+                            __float2bfloat16_rn(acc[mi][ni][2]);
+                    }
+                    if (local_col1 < cols) {
+                        output[static_cast<std::int64_t>(col1) * kHidden + output_row0] =
+                            __float2bfloat16_rn(acc[mi][ni][1]);
+                        output[static_cast<std::int64_t>(col1) * kHidden + output_row1] =
+                            __float2bfloat16_rn(acc[mi][ni][3]);
+                    }
                 }
             }
         }
@@ -1214,7 +1262,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         CUDA_CHECK(cudaGetLastError());
 
         const bool wide_plan   = tokens >= kSparseMoePrefillWideMin;
-        const int route_job_bn = wide_plan ? 64 : 32;
+        const int route_job_bn = wide_plan ? ninfer_moe_bn_override() : 32;
         sparse_moe_prefill_scan_kernel<<<1, kExpertThreads, 0, stream>>>(
             tile_counts, tile_bases, offsets, route_job_experts, route_job_columns, route_job_count,
             route_tiles, route_job_bn, tokens, adaptive);
@@ -1249,8 +1297,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         const dim3 routed_gate_grid(kIntermediate / (kExpertBM / 2), kExperts);
         if (weights.routed_gate_up.qtype == QType::Q4G64_F16S) {
             if (wide_plan) {
-                sparse_moe_prefill_q4_gate_up_kernel<8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                NINFER_MOE_LAUNCH_Q4GU(
                         input, packed_token, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             } else {
@@ -1288,8 +1335,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         switch (weights.routed_down.qtype) {
         case QType::Q5G64_F16S:
             if (wide_plan) {
-                sparse_moe_prefill_qx_down_kernel<Q5DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                NINFER_MOE_LAUNCH_DOWN(Q5DownMma, 
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
@@ -1303,8 +1349,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             break;
         case QType::Q6G64_F16S:
             if (wide_plan) {
-                sparse_moe_prefill_qx_down_kernel<Q6DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                NINFER_MOE_LAUNCH_DOWN(Q6DownMma, 
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);

--- a/src/ops/sparse_moe/small_t/sparse_moe_small_t_kernels.cu
+++ b/src/ops/sparse_moe/small_t/sparse_moe_small_t_kernels.cu
@@ -11,6 +11,7 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace ninfer::ops::detail {
@@ -152,11 +153,52 @@ void launch_s1(const __nv_bfloat16* x, const __nv_bfloat16* router, float* parti
     CUDA_CHECK(cudaGetLastError());
 }
 
+
+// S2 reduces the router partials and picks the top eight. It runs in a single CTA with one warp
+// per column, so at the widths a speculative round actually uses it occupies one SM out of a
+// hundred and seventy and the whole cost is the dependent load chain. One CTA per column shortens
+// that chain without touching the arithmetic: the partition sum keeps its order, so the scores and
+// therefore the selection are bit-identical.
+template <int Tokens>
+__global__ void sparse_moe_small_t_s2_wide_kernel(const float* __restrict__ partial_scores,
+                                                  int* __restrict__ token_ids,
+                                                  float* __restrict__ token_alpha,
+                                                  float* __restrict__ shared_scale) {
+    static_assert(Tokens >= 1 && Tokens <= kSparseMoeSmallTMax);
+    __shared__ float scores[kRouterRows];
+    __shared__ float selected_logits[kTopK];
+    const int token = static_cast<int>(blockIdx.x);
+    const int tid   = static_cast<int>(threadIdx.x);
+    if (tid == 0) { pdl::trigger_dependents(); }
+    pdl::wait_for_dependencies();
+    for (int row = tid; row < kRouterRows; row += static_cast<int>(blockDim.x)) {
+        float sum = 0.0f;
+#pragma unroll
+        for (int partition = 0; partition < kRouterPartitions; ++partition) {
+            sum += partial_scores[(static_cast<std::int64_t>(token) * kRouterRows + row) *
+                                      kRouterPartitions +
+                                  partition];
+        }
+        scores[row] = sum;
+    }
+    __syncthreads();
+    if (tid < 32) {
+        sparse_moe_select_top8_warp(scores, token_ids + token * kTopK, token_alpha + token * kTopK,
+                                    shared_scale + token, selected_logits);
+    }
+}
+
+
 template <int Tokens>
 void launch_s2(const float* partial_scores, int* token_ids, float* token_alpha, float* shared_scale,
                cudaStream_t stream) {
     constexpr int kThreads = (Tokens < 32 ? Tokens : 32) * 32;
-    if constexpr (Tokens <= 44) {
+    constexpr int kWideThreads = 512;
+    if constexpr (true) {
+        CUDA_CHECK(pdl::launch_dependent({dim3(Tokens), dim3(kWideThreads), 0, stream},
+                                         sparse_moe_small_t_s2_wide_kernel<Tokens>, partial_scores,
+                                         token_ids, token_alpha, shared_scale));
+    } else if constexpr (Tokens <= 44) {
         CUDA_CHECK(pdl::launch_dependent({dim3(1), dim3(kThreads), 0, stream},
                                          sparse_moe_small_t_s2_kernel<Tokens>, partial_scores,
                                          token_ids, token_alpha, shared_scale));

--- a/src/ops/sparse_moe/small_t/sparse_moe_small_t_plan.cpp
+++ b/src/ops/sparse_moe/small_t/sparse_moe_small_t_plan.cpp
@@ -5,7 +5,6 @@
 #include <stdexcept>
 
 namespace ninfer::ops::detail {
-
 bool sparse_moe_uses_small_t(std::int32_t tokens) noexcept {
     return tokens >= kSparseMoeSmallTMin && tokens <= kSparseMoeSmallTMax;
 }
@@ -43,15 +42,11 @@ SparseMoeSmallTPlan resolve_sparse_moe_small_t_plan(std::int32_t tokens, QType r
     }
 
     plan.d3_schedule = SparseMoeSmallTD3Schedule::Paths3;
-    if (routed_down == QType::Q5G64_F16S) {
-        plan.d4_schedule = tokens <= 2    ? SparseMoeSmallTD4Schedule::Rows1
-                           : tokens <= 11 ? SparseMoeSmallTD4Schedule::Rows2
-                                          : SparseMoeSmallTD4Schedule::Rows4;
-    } else {
-        plan.d4_schedule = tokens <= 2    ? SparseMoeSmallTD4Schedule::Rows1
-                           : tokens <= 11 ? SparseMoeSmallTD4Schedule::Rows2
-                                          : SparseMoeSmallTD4Schedule::Rows4;
-    }
+    // One row per weight stream was the entry point of this ladder, but at the only width that
+    // reaches it, T=2, it costs 6.3% of the decode step against two rows, and two rows is not
+    // behind anywhere else in the small-T range. Both codecs resolve the same way.
+    plan.d4_schedule = tokens <= 11 ? SparseMoeSmallTD4Schedule::Rows2
+                                    : SparseMoeSmallTD4Schedule::Rows4;
     return plan;
 }
 

--- a/src/ops/sparse_moe/small_t/sparse_moe_small_t_plan.cpp
+++ b/src/ops/sparse_moe/small_t/sparse_moe_small_t_plan.cpp
@@ -44,9 +44,9 @@ SparseMoeSmallTPlan resolve_sparse_moe_small_t_plan(std::int32_t tokens, QType r
 
     plan.d3_schedule = SparseMoeSmallTD3Schedule::Paths3;
     if (routed_down == QType::Q5G64_F16S) {
-        plan.d4_schedule = tokens <= 2   ? SparseMoeSmallTD4Schedule::Rows1
-                           : tokens <= 5 ? SparseMoeSmallTD4Schedule::Rows2
-                                         : SparseMoeSmallTD4Schedule::Rows4;
+        plan.d4_schedule = tokens <= 2    ? SparseMoeSmallTD4Schedule::Rows1
+                           : tokens <= 11 ? SparseMoeSmallTD4Schedule::Rows2
+                                          : SparseMoeSmallTD4Schedule::Rows4;
     } else {
         plan.d4_schedule = tokens <= 2    ? SparseMoeSmallTD4Schedule::Rows1
                            : tokens <= 11 ? SparseMoeSmallTD4Schedule::Rows2

--- a/src/ops/wrapper/causal_conv1d_silu.cpp
+++ b/src/ops/wrapper/causal_conv1d_silu.cpp
@@ -1,5 +1,6 @@
 // ninfer::ops - causal_conv1d wrapper: public api validation and launcher dispatch.
 #include "ninfer/ops/causal_conv1d_silu.h"
+#include "ninfer/ops/scatter.h"
 
 #include "ops/launcher/causal_conv1d.h" // detail::causal_conv1d_*_launch
 
@@ -167,6 +168,36 @@ void causal_conv1d_silu(const Tensor& x, const Tensor& weight, const Tensor& con
     } else {
         detail::causal_conv1d_prefill_launch(x, weight, conv_state_in, conv_state_out, out, stream);
     }
+}
+
+void causal_conv1d_silu_split(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                              Tensor& conv_state_out, Tensor& out_q, Tensor& out_k, Tensor& out_v,
+                              Tensor& scratch, cudaStream_t stream) {
+    if (out_q.dtype != DType::BF16 || out_k.dtype != DType::BF16 || out_v.dtype != DType::BF16) {
+        throw std::invalid_argument("causal_conv1d: split destinations must be BF16");
+    }
+    if (out_q.ne[0] + out_k.ne[0] + out_v.ne[0] != x.ne[0] || out_q.ne[1] != x.ne[1] ||
+        out_k.ne[1] != x.ne[1] || out_v.ne[1] != x.ne[1]) {
+        throw std::invalid_argument("causal_conv1d: split destinations must partition x by row");
+    }
+    if (!out_q.is_contiguous() || !out_k.is_contiguous() || !out_v.is_contiguous() ||
+        out_q.data == nullptr || out_k.data == nullptr || out_v.data == nullptr) {
+        throw std::invalid_argument(
+            "causal_conv1d: split destinations must be contiguous and non-null");
+    }
+    if (x.ne[1] > detail::kCausalConvSequenceMaxTokens) {
+        require_x_shape(x);
+        require_weight_shape(weight, x.ne[0]);
+        require_state_shape(conv_state_in, x.ne[0]);
+        require_state_shape(conv_state_out, x.ne[0]);
+        detail::causal_conv1d_prefill_split_launch(x, weight, conv_state_in, conv_state_out, out_q,
+                                                   out_k, out_v, stream);
+        return;
+    }
+    causal_conv1d_silu(x, weight, conv_state_in, conv_state_out, scratch, stream);
+    extract_bf16_columns(scratch, 0, out_q, stream);
+    extract_bf16_columns(scratch, out_q.ne[0], out_k, stream);
+    extract_bf16_columns(scratch, out_q.ne[0] + out_k.ne[0], out_v, stream);
 }
 
 void causal_conv1d_silu(const Tensor& x, const Tensor& weight, Tensor& conv_state, Tensor& out,

--- a/src/ops/wrapper/mtp_round.cpp
+++ b/src/ops/wrapper/mtp_round.cpp
@@ -53,8 +53,8 @@ void mtp_prepare_next_round(const Tensor& verify_ids, const Tensor& next_anchors
     constexpr const char* op = "mtp_prepare_next_round";
     const std::int32_t T     = verify_ids.ne[0];
     const std::int32_t batch = verify_ids.ne[1];
-    if (T < 2 || T > 6) {
-        throw std::invalid_argument("mtp_prepare_next_round: T must be in [2,6]");
+    if (T < 2 || T > 16) {
+        throw std::invalid_argument("mtp_prepare_next_round: T must be in [2,16]");
     }
     if (batch < 1) { throw std::invalid_argument("mtp_prepare_next_round: B must be positive"); }
     if (max_context <= 0) {

--- a/src/ops/wrapper/rope.cpp
+++ b/src/ops/wrapper/rope.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include "ninfer/ops/rmsnorm.h"
 
 namespace ninfer::ops {
 namespace {
@@ -138,6 +139,22 @@ void rope(const Tensor& positions, int rotary_dim, float theta, Tensor& x, cudaS
     require_positions_storage(positions);
     if (x.data == nullptr) { throw std::invalid_argument("rope: tensor data must be non-null"); }
     detail::rope_single_launch(positions, rotary_dim, theta, x, stream);
+}
+
+void qk_norm_rope(const Tensor& positions, int rotary_dim, float theta, const Tensor& q_in,
+                  const Tensor& q_weight, Tensor& q_out, const Tensor& k_in,
+                  const Tensor& k_weight, Tensor& k_out, float eps, cudaStream_t stream) {
+    const bool fused_shape = q_in.ne[0] == 256 && q_in.ne[1] == 16 && k_in.ne[0] == 256 &&
+                             k_in.ne[1] == 2 && rotary_dim == 64 && positions.dtype == DType::I32;
+    if (fused_shape) {
+        detail::qk_norm_rope_text16x2_launch(positions, q_in, q_weight, q_out, k_in, k_weight,
+                                             k_out, eps, stream);
+        rope(positions, rotary_dim, theta, q_out, k_out, stream);
+        return;
+    }
+    rmsnorm(q_in, q_weight, eps, true, q_out, stream);
+    rmsnorm(k_in, k_weight, eps, true, k_out, stream);
+    rope(positions, rotary_dim, theta, q_out, k_out, stream);
 }
 
 } // namespace ninfer::ops

--- a/src/ops/wrapper/sparse_moe.cpp
+++ b/src/ops/wrapper/sparse_moe.cpp
@@ -189,8 +189,20 @@ std::size_t sparse_moe_workspace_capacity_bytes(QType routed_gate_up, QType rout
     return required;
 }
 
+namespace {
+thread_local WeightPrefetchSpan g_next_weight_prefetch{};
+constexpr std::size_t kNextWeightPrefetchLimit = std::size_t{8} << 20;
+} // namespace
+
+void set_next_weight_prefetch(WeightPrefetchSpan span) { g_next_weight_prefetch = span; }
+
 void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilogue epilogue,
                 Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream) {
+    const WeightPrefetchSpan next_prefetch{
+        g_next_weight_prefetch.data,
+        g_next_weight_prefetch.bytes < kNextWeightPrefetchLimit ? g_next_weight_prefetch.bytes
+                                                                : kNextWeightPrefetchLimit};
+    g_next_weight_prefetch = {};
     if (epilogue != SparseMoeEpilogue::AddResidual) {
         throw std::invalid_argument("sparse_moe: unsupported epilogue");
     }
@@ -258,7 +270,8 @@ void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilo
     for (std::int32_t token = 0; token < tokens; ++token) {
         const Tensor x_column     = x.slice(1, token, 1);
         Tensor destination_column = destination.slice(1, token, 1);
-        detail::sparse_moe_decode_launch(x_column, weights, destination_column, views, stream);
+        detail::sparse_moe_decode_launch(x_column, weights, destination_column, views, stream,
+                                         next_prefetch.data, next_prefetch.bytes);
     }
 }
 

--- a/src/ops/wrapper/sparse_moe.cpp
+++ b/src/ops/wrapper/sparse_moe.cpp
@@ -197,7 +197,8 @@ constexpr std::size_t kNextWeightPrefetchLimit = std::size_t{8} << 20;
 void set_next_weight_prefetch(WeightPrefetchSpan span) { g_next_weight_prefetch = span; }
 
 void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilogue epilogue,
-                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream) {
+                Tensor& destination, WorkspaceArena& workspace, cudaStream_t stream,
+                const Tensor* pre_norm_weight, float pre_norm_eps) {
     const WeightPrefetchSpan next_prefetch{
         g_next_weight_prefetch.data,
         g_next_weight_prefetch.bytes < kNextWeightPrefetchLimit ? g_next_weight_prefetch.bytes
@@ -213,11 +214,18 @@ void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilo
 
     std::vector<AddressRange> ranges;
     ranges.reserve(16);
-    ranges.push_back(address_range(x.data, x.bytes(), "x"));
+    if (pre_norm_weight == nullptr) {
+        ranges.push_back(address_range(x.data, x.bytes(), "x"));
+    }
+    // In fused pre-norm mode raw x IS the residual destination by design;
+    // every consumer reads x before D4's residual accumulation writes it.
     ranges.push_back(address_range(destination.data, destination.bytes(), "destination"));
     validate_weights(weights, ranges);
 
     const bool use_small_t = detail::sparse_moe_uses_small_t(tokens);
+    if (use_small_t && pre_norm_weight != nullptr) {
+        throw std::invalid_argument("sparse_moe: fused pre-norm requires the decode route");
+    }
     const bool use_prefill = detail::sparse_moe_uses_prefill(tokens, weights.routed_gate_up.qtype,
                                                              weights.routed_down.qtype);
     nvtx::ScopedRange moe_range(use_prefill   ? nvtx::Name::SparseMoePrefill
@@ -271,7 +279,10 @@ void sparse_moe(const Tensor& x, const SparseMoeWeights& weights, SparseMoeEpilo
         const Tensor x_column     = x.slice(1, token, 1);
         Tensor destination_column = destination.slice(1, token, 1);
         detail::sparse_moe_decode_launch(x_column, weights, destination_column, views, stream,
-                                         next_prefetch.data, next_prefetch.bytes);
+                                         next_prefetch.data, next_prefetch.bytes,
+                                         pre_norm_weight == nullptr ? nullptr
+                                                                    : pre_norm_weight->data,
+                                         pre_norm_eps);
     }
 }
 

--- a/src/product/speculative_options.h
+++ b/src/product/speculative_options.h
@@ -35,8 +35,8 @@ inline void validate_speculative_cli_options(const SpeculativeOptions& options) 
         }
         return;
     case SpeculativeBackend::Mtp:
-        if (options.draft_tokens == 0 || options.draft_tokens > 5) {
-            throw std::invalid_argument("--spec mtp requires --draft-tokens in [1,5]");
+        if (options.draft_tokens == 0 || options.draft_tokens > 15) {
+            throw std::invalid_argument("--spec mtp requires --draft-tokens in [1,15]");
         }
         return;
     case SpeculativeBackend::DFlash:

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/round_state.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/round_state.h
@@ -12,7 +12,7 @@
 
 namespace ninfer::targets::qwen3_6 {
 
-inline constexpr std::uint32_t kMtpDecodeMaximumDrafts    = 5;
+inline constexpr std::uint32_t kMtpDecodeMaximumDrafts    = 15;
 inline constexpr std::uint32_t kMtpDecodeMaximumWidth     = kMtpDecodeMaximumDrafts + 1;
 inline constexpr std::uint32_t kDFlashDecodeMaximumDrafts = 15;
 inline constexpr std::uint32_t kDFlashDecodeMaximumWidth  = kDFlashDecodeMaximumDrafts + 1;

--- a/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
+++ b/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
@@ -527,6 +527,13 @@ struct BpeWordEnd {
     std::size_t token_frontier    = 0;
 };
 
+// One token of a merged word, with its end offset measured from the start of the word so the
+// entry stays valid wherever that word appears in the text.
+struct BpeWordToken {
+    int symbol      = -1;
+    std::size_t end = 0;
+};
+
 struct LaterBpeCandidate {
     bool operator()(const BpeCandidate& lhs, const BpeCandidate& rhs) const noexcept {
         if (lhs.rank != rhs.rank) { return lhs.rank > rhs.rank; }
@@ -553,9 +560,27 @@ bool append_normalized_bpe_ids(std::vector<int>& ids, std::string_view normalize
     if (normalized.empty()) { return true; }
     if (ids.size() == max_tokens) { return false; }
 
+    // The merge order is a pure function of the word, so a repeated word does not have to be
+    // merged again. Keys are views into `normalized`, which outlives this loop.
+    std::unordered_map<std::string_view, std::vector<BpeWordToken>> word_cache;
+    std::vector<BpeWordToken> merged;
+
     for (std::size_t begin = 0; begin < normalized.size();) {
         const std::size_t end = qwen_word_end(normalized, begin);
         const std::string_view word(normalized.data() + begin, end - begin);
+        if (const auto cached = word_cache.find(word); cached != word_cache.end()) {
+            for (const BpeWordToken token : cached->second) {
+                ids.push_back(token.symbol);
+                if (token_ends != nullptr) { token_ends->push_back(begin + token.end); }
+                if (ids.size() == max_tokens) { return false; }
+            }
+            if (word_ends != nullptr) {
+                word_ends->push_back(
+                    BpeWordEnd{.normalized_offset = end, .token_frontier = ids.size()});
+            }
+            begin = end;
+            continue;
+        }
         std::vector<BpeNode> nodes(word.size());
         for (std::size_t index = 0; index < word.size(); ++index) {
             const unsigned char byte = static_cast<unsigned char>(word[index]);
@@ -614,12 +639,18 @@ bool append_normalized_bpe_ids(std::vector<int>& ids, std::string_view normalize
             push_candidate(left.previous);
             push_candidate(candidate.left);
         }
+        merged.clear();
         for (int node = nodes.empty() ? -1 : 0; node >= 0;
              node     = nodes[static_cast<std::size_t>(node)].next) {
-            ids.push_back(nodes[static_cast<std::size_t>(node)].symbol);
-            if (token_ends != nullptr) {
-                token_ends->push_back(begin + nodes[static_cast<std::size_t>(node)].end);
-            }
+            merged.push_back(BpeWordToken{.symbol = nodes[static_cast<std::size_t>(node)].symbol,
+                                          .end    = nodes[static_cast<std::size_t>(node)].end});
+        }
+        // Record the whole word before emitting: a token budget that runs out mid-word must not
+        // leave a truncated entry behind for the next occurrence to copy.
+        word_cache.emplace(word, merged);
+        for (const BpeWordToken token : merged) {
+            ids.push_back(token.symbol);
+            if (token_ends != nullptr) { token_ends->push_back(begin + token.end); }
             if (ids.size() == max_tokens) { return false; }
         }
         if (word_ends != nullptr) {

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -615,7 +615,8 @@ void validate_target_options(DeviceContext& device, const EngineOptions& options
     case SpeculativeBackend::Mtp:
         if (options.speculative.draft_tokens == 0 ||
             options.speculative.draft_tokens > kMaximumMtpDraftTokens) {
-            throw std::invalid_argument("MTP draft window must be in [1,5]");
+            throw std::invalid_argument("MTP draft window must be in [1," +
+                                        std::to_string(kMaximumMtpDraftTokens) + "]");
         }
         break;
     case SpeculativeBackend::DFlash:

--- a/src/targets/qwen3_6/impl/runtime/mtp_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/mtp_impl.h
@@ -7,6 +7,7 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdlib>
 #include <stdexcept>
 
 namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule {

--- a/src/targets/qwen3_6/impl/runtime/text_context.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context.h
@@ -244,6 +244,7 @@ private:
     void attn_mix(const FullLayerW& weights, Tensor& x, int index, Phase phase);
     void gdn_mix(const GdnLayerW& weights, Tensor& x, int index, Phase phase);
     void mlp_tail(const Tensor* post_norm, const MlpW& weights, Tensor& x, Phase phase);
+    void set_next_projection_prefetch(int layer);
     void run_layers(Tensor& x, Phase phase);
     template <class Tap>
     void run_layers(Tensor& x, Phase phase, Tap& tap);

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -380,10 +380,12 @@ void TextContext::mtp_forward_tail(Tensor& x, const Tensor& ah, const Tensor& po
     const auto results = workspace_recipe::mtp_attention_results<TextConfig>(work_, T);
     Tensor qn          = results.normalized_query.view({kCfg.head_dim, kCfg.n_q, T});
     Tensor kn          = results.normalized_key.view({kCfg.head_dim, kCfg.n_kv, T});
-    ops::rmsnorm(q, *mtp_.q_norm, kCfg.rms_eps, true, qn, s);
-    ops::rmsnorm(k, *mtp_.k_norm, kCfg.rms_eps, true, kn, s);
     Tensor rope_for_op = active_sequence_batch_ != 0 ? rope_positions.view({T}) : rope_positions;
-    ops::rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, qn, kn, s);
+    // Route the draft head through the same fused q/k norm the main decode path
+    // uses. The op falls back to the two standalone norms for any other geometry, and rope
+    // stays in its own kernel (see the note on qk_norm_rope_text_kernel).
+    ops::qk_norm_rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, q, *mtp_.q_norm, qn, k,
+                      *mtp_.k_norm, kn, kCfg.rms_eps, s);
 
     Tensor a = results.attention.view({kCfg.head_dim, kCfg.n_q, T});
     if (active_sequence_batch_ != 0) {

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -982,10 +982,15 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
             if (fused_post_norm) {
                 ops::set_gdn_post_norm({z.data, w.gdn_norm->data, on.data, kCfg.rms_eps});
             }
+            // The out-projection is the next thing this layer streams; the mixer's tail warms L2
+            // for it. Bounds come from the weight itself, so they stay right across targets whose
+            // out-projection differs in shape or quantisation.
             ops::gated_delta_net_batch_update(
                 q_batch, k_batch, v_batch, g_batch, beta_batch, kGdnScale,
                 /*normalize_qk=*/true, recurrent_states, *active_linear_state_source_slots_,
-                *active_linear_state_destination_slots_, out_batch, s);
+                *active_linear_state_destination_slots_, out_batch, s,
+                width == 1 ? w.out_proj->payload : nullptr,
+                static_cast<std::size_t>(w.out_proj->payload_bytes));
         }
     } else {
         Tensor recurrent_state_in =

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -24,6 +24,7 @@
 #include "ninfer/ops/residual_add.h"
 #include "ninfer/ops/rmsnorm.h"
 #include "ninfer/ops/rope.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "ninfer/ops/scatter.h"
 #include "ninfer/ops/scalar.h"
 #include "ninfer/ops/sigmoid_mul.h"
@@ -985,6 +986,23 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
     Variant::gdn_output_projection(on.view({kCfg.value_dim, T}), *w.out_proj, x, ph, work_, s);
 }
 
+void TextContext::set_next_projection_prefetch(int layer) {
+    // Register the next layer's projection codes so the current MoE D4
+    // epilogue can warm L2 for them. Last layer registers nothing.
+    const int next = layer + 1;
+    if (next >= kCfg.n_layers) {
+        ops::set_next_weight_prefetch({});
+        return;
+    }
+    if (ModelConfig::is_full(next)) {
+        ops::set_next_weight_prefetch(Variant::projection_prefetch_span(
+            *full_.at(static_cast<std::size_t>(ModelConfig::full_idx(next))).projection));
+    } else {
+        ops::set_next_weight_prefetch(Variant::projection_prefetch_span(
+            *gdn_.at(static_cast<std::size_t>(ModelConfig::gdn_idx(next))).projection));
+    }
+}
+
 void TextContext::mlp_tail(const Tensor* post_norm, const MlpW& m, Tensor& x, Phase ph) {
     cudaStream_t s = ctx_.stream;
     const int T    = x.ne[1];
@@ -1016,6 +1034,7 @@ void TextContext::run_layers(Tensor& x, Phase ph, Tap& tap) {
                     prefill ? nvtx::Name::PrefillPostMixer : nvtx::Name::VerifyPostMixer,
                     nvtx::Category::PostMixer, static_cast<std::uint64_t>(layer));
                 auto mlp_scope = work_.scope();
+                set_next_projection_prefetch(layer);
                 mlp_tail(full.post_attn_norm, full.mlp, x, ph);
                 if constexpr (Tap::enabled) { tap.capture_layer(layer, x, ctx_.stream); }
             }
@@ -1037,6 +1056,7 @@ void TextContext::run_layers(Tensor& x, Phase ph, Tap& tap) {
                     prefill ? nvtx::Name::PrefillPostMixer : nvtx::Name::VerifyPostMixer,
                     nvtx::Category::PostMixer, static_cast<std::uint64_t>(layer));
                 auto mlp_scope = work_.scope();
+                set_next_projection_prefetch(layer);
                 mlp_tail(gdn.post_attn_norm, gdn.mlp, x, ph);
                 if constexpr (Tap::enabled) { tap.capture_layer(layer, x, ctx_.stream); }
             }

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -946,7 +946,6 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
     Tensor o  = workspace_recipe::gdn_recurrent_output<TextConfig>(work_, T).view(
         {kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
     const bool fused_post_norm = ph == Phase::Verify &&
-                                 gdn_state_action_ == GdnStateAction::RecordForReplay &&
                                  kCfg.gdn_v_heads <= ops::kGdnPostNormMaxHeads &&
                                  active_sequence_batch_ <= ops::kGdnPostNormMaxBatch;
     // Only the fused tail needs this buffer before the mixer runs. Taking it early on the chunked
@@ -980,6 +979,9 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
                                                *active_linear_state_source_slots_, records.key,
                                                records.value, records.gate, out_batch, s);
         } else {
+            if (fused_post_norm) {
+                ops::set_gdn_post_norm({z.data, w.gdn_norm->data, on.data, kCfg.rms_eps});
+            }
             ops::gated_delta_net_batch_update(
                 q_batch, k_batch, v_batch, g_batch, beta_batch, kGdnScale,
                 /*normalize_qk=*/true, recurrent_states, *active_linear_state_source_slots_,

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -935,10 +935,8 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
             state_.conv_slot(static_cast<std::uint32_t>(gidx), linear_state_source_slot_);
         Tensor conv_state_out =
             state_.conv_slot(static_cast<std::uint32_t>(gidx), linear_state_destination_slot_);
-        ops::causal_conv1d_silu(qkv, *w.conv1d, conv_state_in, conv_state_out, qkv_c, s);
-        ops::extract_bf16_columns(qkv_c, 0, qc, s);
-        ops::extract_bf16_columns(qkv_c, kCfg.key_dim, kc, s);
-        ops::extract_bf16_columns(qkv_c, 2 * kCfg.key_dim, vc, s);
+        ops::causal_conv1d_silu_split(qkv, *w.conv1d, conv_state_in, conv_state_out, qc, kc,
+                                      vc, qkv_c, s);
     }
 
     Tensor q_recurrent = qc.view({kCfg.gdn_k_dim, kCfg.gdn_k_heads, T});

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -945,6 +945,18 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
     Tensor vv = vc.view({kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
     Tensor o  = workspace_recipe::gdn_recurrent_output<TextConfig>(work_, T).view(
         {kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
+    const bool fused_post_norm = ph == Phase::Verify &&
+                                 gdn_state_action_ == GdnStateAction::RecordForReplay &&
+                                 kCfg.gdn_v_heads <= ops::kGdnPostNormMaxHeads &&
+                                 active_sequence_batch_ <= ops::kGdnPostNormMaxBatch;
+    // Only the fused tail needs this buffer before the mixer runs. Taking it early on the chunked
+    // prefill path would hold it live across the mixer's own scratch scope and lift the arena
+    // high-water mark past the planned reservation -- which shows up at 67k prefill, not on decode.
+    Tensor on;
+    if (fused_post_norm) {
+        on = workspace_recipe::gdn_normalized_output<TextConfig>(work_, T).view(
+            {kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
+    }
     if (ph == Phase::Verify) {
         Tensor recurrent_states  = state_.layer_view(static_cast<std::uint32_t>(gidx)).recurrent;
         const std::int32_t width = active_sequence_width_;
@@ -960,6 +972,9 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
         const Tensor valid = active_valid_columns_ != nullptr ? *active_valid_columns_ : Tensor{};
         if (gdn_state_action_ == GdnStateAction::RecordForReplay) {
             GdnReplayRecordLayer records = replay_records_->layer(gidx, active_sequence_batch_);
+            if (fused_post_norm) {
+                ops::set_gdn_post_norm({z.data, w.gdn_norm->data, on.data, kCfg.rms_eps});
+            }
             ops::gated_delta_net_replay_record(q_batch, k_batch, v_batch, g_batch, beta_batch,
                                                kGdnScale, recurrent_states, valid,
                                                *active_linear_state_source_slots_, records.key,
@@ -980,9 +995,11 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
                              o, s);
     }
 
-    Tensor on = workspace_recipe::gdn_normalized_output<TextConfig>(work_, T).view(
-        {kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
-    ops::gated_rmsnorm(o, *w.gdn_norm, z, kCfg.rms_eps, on, s);
+    if (!fused_post_norm) {
+        on = workspace_recipe::gdn_normalized_output<TextConfig>(work_, T).view(
+            {kCfg.gdn_v_dim, kCfg.gdn_v_heads, T});
+        ops::gated_rmsnorm(o, *w.gdn_norm, z, kCfg.rms_eps, on, s);
+    }
 
     Variant::gdn_output_projection(on.view({kCfg.value_dim, T}), *w.out_proj, x, ph, work_, s);
 }

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -835,14 +835,15 @@ void TextContext::attn_mix(const FullLayerW& w, Tensor& x, int fidx, Phase ph) {
     const auto results = workspace_recipe::text_attention_results<TextConfig>(work_, T);
     Tensor qn          = results.normalized_query.view({kCfg.head_dim, kCfg.n_q, T});
     Tensor kn          = results.normalized_key.view({kCfg.head_dim, kCfg.n_kv, T});
-    ops::rmsnorm(q, *w.q_norm, kCfg.rms_eps, true, qn, s);
-    ops::rmsnorm(k, *w.k_norm, kCfg.rms_eps, true, kn, s);
     const Tensor& cache_positions =
         active_cache_positions_ != nullptr ? *active_cache_positions_ : io_.pos;
     const Tensor& rope_positions =
         active_rope_positions_ != nullptr ? *active_rope_positions_ : io_.rope_pos;
     Tensor rope_for_op = active_sequence_batch_ != 0 ? rope_positions.view({T}) : rope_positions;
-    ops::rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, qn, kn, s);
+    // One fused kernel replaces q-norm, k-norm and rope (bit-identical
+    // arithmetic and rounding; other geometries fall back inside the op).
+    ops::qk_norm_rope(rope_for_op, kCfg.rotary_dim, kCfg.rope_theta, q, *w.q_norm, qn, k,
+                      *w.k_norm, kn, kCfg.rms_eps, s);
 
     Tensor a = results.attention.view({kCfg.head_dim, kCfg.n_q, T});
     const Tensor& kv_table_rows =

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -1006,7 +1006,15 @@ void TextContext::set_next_projection_prefetch(int layer) {
 void TextContext::mlp_tail(const Tensor* post_norm, const MlpW& m, Tensor& x, Phase ph) {
     cudaStream_t s = ctx_.stream;
     const int T    = x.ne[1];
-    Tensor h       = workspace_recipe::post_mixer_hidden<TextConfig>(work_, T);
+    if constexpr (Variant::kFusedPostMixerNorm) {
+        if (T == 1) {
+            // The decode MoE recomputes this norm in the d1/d3 prologs
+            // (bit-exact clone); the standalone node is skipped.
+            Variant::post_mixer_fused_norm(x, *post_norm, kCfg.rms_eps, *m.payload, x, work_, s);
+            return;
+        }
+    }
+    Tensor h = workspace_recipe::post_mixer_hidden<TextConfig>(work_, T);
     ops::rmsnorm(x, *post_norm, kCfg.rms_eps, true, h, s);
 
     Variant::post_mixer(h, *m.payload, x, ph, work_, s);

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -859,19 +859,22 @@ void TextContext::attn_mix(const FullLayerW& w, Tensor& x, int fidx, Phase ph) {
         Tensor k_batch        = kn.view({kCfg.head_dim, kCfg.n_kv, width, active_sequence_batch_});
         Tensor v_batch        = v.view({kCfg.head_dim, kCfg.n_kv, width, active_sequence_batch_});
         Tensor a_batch        = a.view({kCfg.head_dim, kCfg.n_q, width, active_sequence_batch_});
+        Tensor gate_batch = gate.view({kCfg.head_dim, kCfg.n_q, width, active_sequence_batch_});
         Tensor position_batch = cache_positions.view({width, active_sequence_batch_});
         const Tensor valid = active_valid_columns_ != nullptr ? *active_valid_columns_ : Tensor{};
+        // The gate rides along with the attention call: the small-T reducer applies it at the
+        // store, and any other route applies it inside the op. Either way it is one contract.
         ops::causal_softmax_attention(q_batch, k_batch, v_batch, position_batch, valid,
                                       kv_table_rows, {kCfg.head_dim, kCfg.n_q, kCfg.n_kv},
                                       kAttnScale, batch_text_kv_->batch_layer_view(fidx),
-                                      *active_causal_attention_envelope_, work_, a_batch, s);
+                                      *active_causal_attention_envelope_, work_, a_batch, s,
+                                      &gate_batch);
     } else {
         ops::causal_softmax_attention(qn, kn, v, cache_positions, Tensor{}, kv_table_rows,
                                       {kCfg.head_dim, kCfg.n_q, kCfg.n_kv}, kAttnScale,
                                       batch_text_kv_->batch_layer_view(fidx),
-                                      *active_causal_attention_envelope_, work_, a, s);
+                                      *active_causal_attention_envelope_, work_, a, s, &gate);
     }
-    ops::sigmoid_mul(gate, a, s);
 
     Variant::attention_output_projection(a.view({kCfg.q_size, T}), *w.o_proj, x, ph, work_, s);
 }

--- a/src/targets/qwen3_6_27b/impl/config.h
+++ b/src/targets/qwen3_6_27b/impl/config.h
@@ -87,7 +87,7 @@ struct DFlashConfig {
 inline constexpr float kAttentionScale                   = 0.0625F;
 inline constexpr float kGdnScale                         = 0.08838834764831845F;
 inline constexpr std::uint32_t kPrefillChunkAlignment    = 128;
-inline constexpr std::uint32_t kMaximumMtpDraftTokens    = 5;
+inline constexpr std::uint32_t kMaximumMtpDraftTokens    = 15;
 inline constexpr std::uint32_t kMaximumDFlashDraftTokens = 0;
 inline constexpr std::uint32_t kNativeContext            = 262144;
 

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -291,6 +291,12 @@ void Variant::gdn_norm_control_projection(const Tensor& residual, const Tensor& 
                               workspace, hidden, g, beta, stream);
 }
 
+void Variant::post_mixer_fused_norm(const Tensor&, const Tensor&, float,
+                                    const PostMixerWeights&, Tensor&, WorkspaceArena&,
+                                    cudaStream_t) {
+    throw std::logic_error("qwen3_6_27b: fused post-mixer norm is not implemented");
+}
+
 void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                          qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
     auto scope        = workspace.scope();

--- a/src/targets/qwen3_6_27b/impl/variant.h
+++ b/src/targets/qwen3_6_27b/impl/variant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "targets/qwen3_6_27b/impl/config.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "targets/qwen3_6_27b/impl/load/bindings.h"
 #include <ninfer/targets/qwen3_6/runtime.h>
 
@@ -27,6 +28,14 @@ struct Variant {
     using MtpPostMixerWeights            = detail::DensePostMixerPayload;
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
+
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const FullAttentionProjectionWeights&) {
+        return {};
+    }
+    static ::ninfer::ops::WeightPrefetchSpan projection_prefetch_span(const GdnProjectionWeights&) {
+        return {};
+    }
 
     static constexpr float attention_scale                     = kAttentionScale;
     static constexpr float gdn_scale                           = kGdnScale;

--- a/src/targets/qwen3_6_27b/impl/variant.h
+++ b/src/targets/qwen3_6_27b/impl/variant.h
@@ -29,6 +29,8 @@ struct Variant {
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
 
+    static constexpr bool kFusedPostMixerNorm = false;
+
     static ::ninfer::ops::WeightPrefetchSpan
     projection_prefetch_span(const FullAttentionProjectionWeights&) {
         return {};
@@ -86,6 +88,9 @@ struct Variant {
                                             float eps, const GdnProjectionWeights& weights,
                                             Tensor& hidden, Tensor& g, Tensor& beta,
                                             WorkspaceArena& workspace, cudaStream_t stream);
+    static void post_mixer_fused_norm(const Tensor& raw_x, const Tensor& pre_norm_weight,
+                                      float eps, const PostMixerWeights& weights, Tensor& residual,
+                                      WorkspaceArena& workspace, cudaStream_t stream);
     static void post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                            qwen3_6::TextPhase phase, WorkspaceArena& workspace,
                            cudaStream_t stream);

--- a/src/targets/qwen3_6_35b_a3b/impl/config.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/config.h
@@ -93,7 +93,7 @@ struct DFlashConfig {
 inline constexpr float kAttentionScale                   = 0.0625F;
 inline constexpr float kGdnScale                         = 0.08838834764831845F;
 inline constexpr std::uint32_t kPrefillChunkAlignment    = 128;
-inline constexpr std::uint32_t kMaximumMtpDraftTokens    = 5;
+inline constexpr std::uint32_t kMaximumMtpDraftTokens    = 15;
 inline constexpr std::uint32_t kMaximumDFlashDraftTokens = 15;
 inline constexpr std::uint32_t kNativeContext            = 262144;
 

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
@@ -54,7 +54,7 @@ std::vector<GraphExecutionProfile> dflash_base_profiles(std::uint32_t capacity,
     return graph_profiles_through(max_frontier, ends);
 }
 
-bool dflash_target_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_t batch_size,
+bool verify_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_t batch_size,
                                         std::uint32_t max_visible_keys) {
     const std::uint32_t tokens = draft_window + 1;
     if (tokens <= 6) { return false; }
@@ -104,9 +104,22 @@ std::vector<GraphExecutionProfile> Variant::mtp_graph_profiles(std::uint32_t cap
     for (const std::uint32_t visible_end : {128U, 512U, 2048U, 4096U, 8198U, 16390U, 32768U}) {
         add_shifted(visible_end, 2 * draft_window);
     }
+    // Past a verify width of six the attention route stops being unconditional and starts turning
+    // on the envelope's visible-key count, so the frontier has to break where the route flips --
+    // the two sides emit different node counts and cannot share one executable.
+    if (draft_window >= 6 && draft_window <= 15) {
+        add_shifted(draft_window <= 11 ? 512U : 1024U, draft_window + 1);
+    }
     std::sort(ends.begin(), ends.end());
     ends.erase(std::unique(ends.begin(), ends.end()), ends.end());
-    return graph_profiles_through(capacity - 1, ends);
+
+    std::vector<GraphExecutionProfile> profiles = graph_profiles_through(capacity - 1, ends);
+    for (GraphExecutionProfile& profile : profiles) {
+        const std::uint32_t target_max = static_cast<std::uint32_t>(std::min<std::uint64_t>(
+            capacity, static_cast<std::uint64_t>(profile.max) + draft_window + 1ULL));
+        profile.topology_class = verify_uses_chunked_small_t(draft_window, 1U, target_max) ? 1U : 0U;
+    }
+    return profiles;
 }
 
 std::vector<GraphExecutionProfile> Variant::dflash_graph_profiles(std::uint32_t capacity,
@@ -118,7 +131,7 @@ std::vector<GraphExecutionProfile> Variant::dflash_graph_profiles(std::uint32_t 
             capacity, static_cast<std::uint64_t>(profile.max) + draft_window + 1ULL));
         const bool split_swa           = profile.max > 96U;
         const bool chunked_target =
-            dflash_target_uses_chunked_small_t(draft_window, batch_size, target_max);
+            verify_uses_chunked_small_t(draft_window, batch_size, target_max);
         profile.topology_class = (chunked_target ? 2U : 0U) | (split_swa ? 1U : 0U);
     }
     return profiles;

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
@@ -64,13 +64,14 @@ bool verify_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_t batch
 }
 
 void run_sparse_moe(const Tensor& hidden, const ops::SparseMoeWeights& weights, Tensor& residual,
-                    WorkspaceArena& workspace, cudaStream_t stream) {
+                    const Tensor* pre_norm_weight, float pre_norm_eps, WorkspaceArena& workspace,
+                    cudaStream_t stream) {
     auto scope               = workspace.scope();
     const DeviceSpan storage = workspace.alloc_bytes(ops::sparse_moe_workspace_capacity_bytes(
         weights.routed_gate_up.qtype, weights.routed_down.qtype, hidden.ne[1], hidden.ne[1]));
     WorkspaceArena leaf_workspace(storage);
     ops::sparse_moe(hidden, weights, ops::SparseMoeEpilogue::AddResidual, residual, leaf_workspace,
-                    stream);
+                    stream, pre_norm_weight, pre_norm_eps);
 }
 
 void validate_token_interval(std::int32_t first, std::int32_t last) {
@@ -227,12 +228,18 @@ void Variant::gdn_norm_control_projection(const Tensor& residual, const Tensor& 
 
 void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                          qwen3_6::TextPhase, WorkspaceArena& workspace, cudaStream_t stream) {
-    run_sparse_moe(hidden, weights.op, residual, workspace, stream);
+    run_sparse_moe(hidden, weights.op, residual, nullptr, 0.0f, workspace, stream);
+}
+
+void Variant::post_mixer_fused_norm(const Tensor& raw_x, const Tensor& pre_norm_weight, float eps,
+                                    const PostMixerWeights& weights, Tensor& residual,
+                                    WorkspaceArena& workspace, cudaStream_t stream) {
+    run_sparse_moe(raw_x, weights.op, residual, &pre_norm_weight, eps, workspace, stream);
 }
 
 void Variant::mtp_post_mixer(const Tensor& hidden, const MtpPostMixerWeights& weights,
                              Tensor& residual, WorkspaceArena& workspace, cudaStream_t stream) {
-    run_sparse_moe(hidden, weights.op, residual, workspace, stream);
+    run_sparse_moe(hidden, weights.op, residual, nullptr, 0.0f, workspace, stream);
 }
 
 std::size_t Variant::mtp_attention_projection_workspace_capacity_bytes(std::int32_t first,

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "targets/qwen3_6_35b_a3b/impl/config.h"
+#include "ninfer/ops/sparse_moe.h"
 #include "targets/qwen3_6_35b_a3b/impl/load/bindings.h"
 #include <ninfer/targets/qwen3_6/runtime.h>
 
@@ -25,6 +26,15 @@ struct Variant {
     using MtpPostMixerWeights            = detail::SparseMoePayload;
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
+
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const FullAttentionProjectionWeights& weights) {
+        return {weights.query_key_gate_value.qdata, std::size_t{9216} * 2048};
+    }
+    static ::ninfer::ops::WeightPrefetchSpan
+    projection_prefetch_span(const GdnProjectionWeights& weights) {
+        return {weights.query_key_value_z.qdata, std::size_t{12288} * 2048};
+    }
 
     static constexpr float attention_scale                     = kAttentionScale;
     static constexpr float gdn_scale                           = kGdnScale;

--- a/src/targets/qwen3_6_35b_a3b/impl/variant.h
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.h
@@ -27,6 +27,10 @@ struct Variant {
     using VisionWeights                  = qwen3_6::VisionWeights;
     using GraphExecutionProfile          = detail::GraphExecutionProfile;
 
+    // The sparse-MoE decode path recomputes the pre-mixer RMS-norm in
+    // its own prologs (bit-exact clone), so the standalone norm node is skipped.
+    static constexpr bool kFusedPostMixerNorm = true;
+
     static ::ninfer::ops::WeightPrefetchSpan
     projection_prefetch_span(const FullAttentionProjectionWeights& weights) {
         return {weights.query_key_gate_value.qdata, std::size_t{9216} * 2048};
@@ -93,6 +97,9 @@ struct Variant {
                                             float eps, const GdnProjectionWeights& weights,
                                             Tensor& hidden, Tensor& g, Tensor& beta,
                                             WorkspaceArena& workspace, cudaStream_t stream);
+    static void post_mixer_fused_norm(const Tensor& raw_x, const Tensor& pre_norm_weight,
+                                      float eps, const PostMixerWeights& weights, Tensor& residual,
+                                      WorkspaceArena& workspace, cudaStream_t stream);
     static void post_mixer(const Tensor& hidden, const PostMixerWeights& weights, Tensor& residual,
                            qwen3_6::TextPhase phase, WorkspaceArena& workspace,
                            cudaStream_t stream);

--- a/src/text/unicode.cpp
+++ b/src/text/unicode.cpp
@@ -16,6 +16,18 @@ bool is_ascii_whitespace(std::int32_t codepoint) noexcept {
 } // namespace
 
 std::string normalize_nfc(std::string_view text) {
+    // Every byte below 0x80 is a starter with combining class zero and takes part in no canonical
+    // composition, so pure ASCII is already in NFC and utf8proc has nothing to do with it. The
+    // scan is one pass the compiler vectorises against utf8proc's decode, map and recompose.
+    bool ascii_only = true;
+    for (const char byte : text) {
+        if (static_cast<unsigned char>(byte) >= 0x80u) {
+            ascii_only = false;
+            break;
+        }
+    }
+    if (ascii_only) { return std::string(text); }
+
     utf8proc_uint8_t* mapped = nullptr;
     const utf8proc_ssize_t result =
         utf8proc_map(reinterpret_cast<const utf8proc_uint8_t*>(text.data()),

--- a/tests/ops/softmax_attention/causal_cache.cpp
+++ b/tests/ops/softmax_attention/causal_cache.cpp
@@ -1,6 +1,7 @@
 #include "core/arena.h"
 #include "core/paged_kv_cache.h"
 #include "ninfer/ops/kv_cache_append.h"
+#include "ninfer/ops/sigmoid_mul.h"
 #include "ninfer/ops/softmax_attention.h"
 #include "ops/op_tester.h"
 #include "ops/softmax_attention/oracle.h"
@@ -1473,6 +1474,32 @@ int run_batch_case(const Geometry& geometry, DType dtype, const BatchAttentionCa
     if (workspace.used() != 0 || workspace.peak_used() != workspace_bytes) {
         std::cerr << label << ": workspace query/execution high-water mismatch\n";
         ++failures;
+    }
+
+    // Handing the Op a gate must produce exactly what applying sigmoid_mul afterwards produces --
+    // on the route that folds the multiply into the reduce epilogue and on the routes that fall
+    // back to the standalone kernel alike. Re-running the Op is safe: appending the same k/v to
+    // the same rows again leaves the cache byte-identical.
+    {
+        const std::vector<std::uint16_t> gate_bits =
+            to_bf16_bits(make_bf16_values(q_bits.size(), test_case.seed + 97u, -3.0f, 3.0f));
+        GuardedDeviceBuffer dgate(gate_bits.size() * sizeof(std::uint16_t));
+        GuardedDeviceBuffer dexpected(gate_bits.size() * sizeof(std::uint16_t));
+        dgate.copy_from_host(gate_bits.data(), gate_bits.size() * sizeof(std::uint16_t));
+        dexpected.copy_from_host(output_bits.data(), output_bits.size() * sizeof(std::uint16_t));
+        Tensor tgate(dgate.data(), DType::BF16,
+                     {kHeadDim, geometry.q_heads, test_case.width, batch});
+        Tensor texpected(dexpected.data(), DType::BF16,
+                         {kHeadDim, geometry.q_heads, test_case.width, batch});
+        ops::sigmoid_mul(tgate, texpected, nullptr);
+        ops::causal_softmax_attention(tq, tk, tv, tp, masked ? tvalid : Tensor{}, ttable_rows,
+                                      op_geometry(geometry), kAttentionScale, cache.view(),
+                                      envelope, workspace, tout, nullptr, &tgate);
+        cuda_synchronize();
+        failures += verify_exact((label + " fused gate").c_str(),
+                                 copy_from_guarded<std::uint16_t>(dout, q_bits.size()),
+                                 copy_from_guarded<std::uint16_t>(dexpected, q_bits.size()));
+        failures += dgate.verify_guards((label + " fused gate input").c_str());
     }
     return failures;
 }

--- a/tests/ops/test_gated_delta_net.cpp
+++ b/tests/ops/test_gated_delta_net.cpp
@@ -1,5 +1,7 @@
 #include "ninfer/ops/gated_delta_net.h"
 
+#include "ninfer/ops/gated_rmsnorm.h"
+
 #include "ops/gdn_ref.h"
 #include "ops/op_tester.h"
 
@@ -379,6 +381,78 @@ int batch_update_case(const Case& test_case, const std::vector<int>& source_slot
     failures += out.verify_guards((label + " out").c_str());
     failures += verify_common_inputs_unchanged(label, aggregate, device.q, device.k, device.v,
                                                device.g, device.beta);
+
+    // The gated post-mixer norm folded into this kernel's tail must reproduce the standalone
+    // kernel bit for bit, and must still do so on a second launch queued behind the first: the
+    // tail's completion tickets wrap by atomicInc rather than being reset, so a launch that leaves
+    // a slot non-zero elects the next launch's winner before its rows are written. Replaying the
+    // update only reproduces the same output when no destination slot feeds a source, so this runs
+    // on the fork cases and stands aside on the in-place ones.
+    const bool forks = std::none_of(destination_slots.begin(), destination_slots.end(),
+                                    [&](int slot) {
+                                        return std::find(source_slots.begin(), source_slots.end(),
+                                                         slot) != source_slots.end();
+                                    });
+    if (forks) {
+        constexpr float kNormEps = 1.0e-6f;
+        const std::size_t rows_total =
+            static_cast<std::size_t>(test_case.value_heads) * static_cast<std::size_t>(batch);
+        const std::size_t norm_elements = rows_total * static_cast<std::size_t>(kStateDim);
+        std::vector<float> weight_values(static_cast<std::size_t>(kStateDim));
+        std::vector<float> gate_values(norm_elements);
+        std::mt19937 norm_generator(seed + 811u);
+        fill_uniform(weight_values, norm_generator, -0.9f, 0.9f);
+        fill_uniform(gate_values, norm_generator, -1.4f, 1.4f);
+        round_to_bf16(weight_values);
+        round_to_bf16(gate_values);
+        std::vector<std::uint16_t> weight_bits(weight_values.size());
+        std::vector<std::uint16_t> gate_bits(gate_values.size());
+        for (std::size_t index = 0; index < weight_values.size(); ++index) {
+            weight_bits[index] = f32_to_bf16(weight_values[index]);
+        }
+        for (std::size_t index = 0; index < gate_values.size(); ++index) {
+            gate_bits[index] = f32_to_bf16(gate_values[index]);
+        }
+
+        DeviceBuffer device_weight = to_device(weight_bits);
+        DeviceBuffer device_gate   = to_device(gate_bits);
+        DeviceBuffer expected_norm(norm_elements * sizeof(std::uint16_t));
+        DeviceBuffer first_norm(norm_elements * sizeof(std::uint16_t));
+        DeviceBuffer second_norm(norm_elements * sizeof(std::uint16_t));
+        expected_norm.fill(0);
+        first_norm.fill(0xff);
+        second_norm.fill(0xff);
+
+        Tensor weight_tensor(device_weight.p, DType::BF16, {kStateDim});
+        Tensor gate_tensor(device_gate.p, DType::BF16,
+                           {kStateDim, test_case.value_heads, batch});
+        Tensor mixer_tensor(out.data(), DType::BF16, {kStateDim, test_case.value_heads, batch});
+        Tensor expected_tensor(expected_norm.p, DType::BF16,
+                               {kStateDim, test_case.value_heads, batch});
+        ops::gated_rmsnorm(mixer_tensor, weight_tensor, gate_tensor, kNormEps, expected_tensor,
+                           nullptr);
+        cuda_synchronize();
+        const std::vector<std::uint16_t> expected_bits =
+            from_device<std::uint16_t>(expected_norm, norm_elements);
+
+        ops::set_gdn_post_norm({device_gate.p, device_weight.p, first_norm.p, kNormEps});
+        ops::gated_delta_net_batch_update(q, k, v, g, beta, scale, test_case.normalize_qk,
+                                          states_tensor, source_slots_tensor,
+                                          destination_slots_tensor, out_tensor, nullptr);
+        ops::set_gdn_post_norm({device_gate.p, device_weight.p, second_norm.p, kNormEps});
+        ops::gated_delta_net_batch_update(q, k, v, g, beta, scale, test_case.normalize_qk,
+                                          states_tensor, source_slots_tensor,
+                                          destination_slots_tensor, out_tensor, nullptr);
+        cuda_synchronize();
+        if (from_device<std::uint16_t>(first_norm, norm_elements) != expected_bits) {
+            std::cerr << label << ": fused post-norm first launch differs\n";
+            ++failures;
+        }
+        if (from_device<std::uint16_t>(second_norm, norm_elements) != expected_bits) {
+            std::cerr << label << ": fused post-norm second launch differs\n";
+            ++failures;
+        }
+    }
     return failures;
 }
 
@@ -477,6 +551,11 @@ int main() {
                                   {8, 9, 10, 11, 12, 13, 14, 15}, 16, 13001u);
     failures += batch_update_case({"35b mixed fork destinations", 16, 32, 1, true}, {0, 2, 4, 6},
                                   {1, 3, 5, 7}, 8, 13101u);
+    // Eight forked rows: the widest batch the folded post-mixer norm accepts, and the only shape
+    // where a per-head rather than per-(head, row) completion ticket shows up.
+    failures += batch_update_case({"35b forked eight-row", 16, 32, 1, true},
+                                  {0, 1, 2, 3, 4, 5, 6, 7}, {8, 9, 10, 11, 12, 13, 14, 15}, 16,
+                                  13201u);
 
     std::cout << (failures == 0 ? "OK" : "FAIL") << " gated_delta_net correctness\n";
     return failures == 0 ? 0 : 1;

--- a/tests/ops/test_gated_delta_net_replay_record.cpp
+++ b/tests/ops/test_gated_delta_net_replay_record.cpp
@@ -1,5 +1,7 @@
 #include "ninfer/ops/gated_delta_net.h"
 
+#include "ninfer/ops/gated_rmsnorm.h"
+
 #include "ops/op_tester.h"
 
 #include <algorithm>
@@ -214,6 +216,48 @@ int run_case(std::int32_t value_heads, std::int32_t width, std::int32_t batch,
     if (state_after != state) {
         std::cerr << "replay record modified source state" << suffix << "\n";
         ++failures;
+    }
+
+    // The gated post-mixer norm folded into this kernel's tail has to reproduce the standalone
+    // kernel bit for bit, and has to keep doing so on a second launch queued behind the first:
+    // the tail's completion tickets wrap by atomicInc instead of being reset, so a launch that
+    // leaves a slot non-zero elects the next launch's winner before its rows are written.
+    {
+        constexpr float kNormEps                     = 1.0e-6F;
+        const std::vector<std::uint16_t> weight_bits = make_bf16(kStateDim, seed + 6);
+        const std::vector<std::uint16_t> gate_bits   = make_bf16(value_elements, seed + 7);
+        DeviceBuffer device_weight                   = to_device(weight_bits);
+        DeviceBuffer device_gate                     = to_device(gate_bits);
+        DeviceBuffer expected_norm(value_elements * sizeof(std::uint16_t));
+        DeviceBuffer first_norm(value_elements * sizeof(std::uint16_t));
+        DeviceBuffer second_norm(value_elements * sizeof(std::uint16_t));
+        expected_norm.fill(0);
+        first_norm.fill(0xff);
+        second_norm.fill(0xff);
+
+        Tensor weight_tensor(device_weight.p, DType::BF16, {kStateDim});
+        Tensor gate_tensor(device_gate.p, DType::BF16, {kStateDim, value_heads, columns});
+        Tensor mixer_tensor(record_out.p, DType::BF16, {kStateDim, value_heads, columns});
+        Tensor expected_tensor(expected_norm.p, DType::BF16, {kStateDim, value_heads, columns});
+        ops::gated_rmsnorm(mixer_tensor, weight_tensor, gate_tensor, kNormEps, expected_tensor,
+                           nullptr);
+        cuda_synchronize();
+        const std::vector<std::uint16_t> expected_bits =
+            from_device<std::uint16_t>(expected_norm, value_elements);
+
+        ops::set_gdn_post_norm({device_gate.p, device_weight.p, first_norm.p, kNormEps});
+        ops::gated_delta_net_replay_record(q, k, v, g_tensor, beta_tensor, kScale, record_states,
+                                           valid, initial, key_record_tensor, value_record_tensor,
+                                           gate_record_tensor, record_output, nullptr);
+        ops::set_gdn_post_norm({device_gate.p, device_weight.p, second_norm.p, kNormEps});
+        ops::gated_delta_net_replay_record(q, k, v, g_tensor, beta_tensor, kScale, record_states,
+                                           valid, initial, key_record_tensor, value_record_tensor,
+                                           gate_record_tensor, record_output, nullptr);
+        cuda_synchronize();
+        failures += verify_equal("fused post-norm first launch" + suffix, expected_bits,
+                                 from_device<std::uint16_t>(first_norm, value_elements));
+        failures += verify_equal("fused post-norm second launch" + suffix, expected_bits,
+                                 from_device<std::uint16_t>(second_norm, value_elements));
     }
     return failures;
 }


### PR DESCRIPTION
Based on `dev` at `59febed2`. Measured on one RTX 5090, Qwen3.6-35B-A3B:

| | `dev`, shipped default | this branch | |
|---|---:|---:|---:|
| **prefill** 4K / 16K / 32K tokens | 16 200 / 13 543 / 11 011 t/s | **23 003 / 18 890 / 14 876 t/s** | **+42.0% / +39.5% / +35.1%** |
| **decode** 4K / 16K / 32K context | 335.8 / 298.2 / 263.1 t/s | **379.6 / 337.7 / 295.5 t/s** | **+13.0% / +13.2% / +12.3%** |
| **MTP-3 decode** | 672.8 t/s | **705.0 t/s** | **+4.8%** |

The same branch is worth **+7.8% / +10.6% of prefill at 32K / 128K on `qwen3_8_27b_nvfp4`**;
that profile is broken out in [§3.7](#37-qwen38-27b-nvfp4).

**Every greedy output is byte-identical to `dev`.** 25 paired comparisons on this branch —
18 across three chunk widths × three context lengths, 7 on the decode and MTP-3 path — all
IDENTICAL, none differing, acceptance length 4.00 on both arms. `ctest` is 94/94.

The prefill column deserves an immediate caveat, because part of that number is already yours:
**about 21 points of it is `--prefill-chunk`, which costs nothing and needs no patch.** At an
equal chunk width this branch is worth +16.8% / +14.3% / +11.3% of prefill, and the rest comes
from a flag you already ship. The full decomposition is
[§1](#1-where-the-prefill-number-comes-from).

Provenance: the prefill row and §1 come from one two-round chunk sweep; decode and MTP-3 from a
separate two-round alternating A/B; the Qwen3.8-27B NVFP4 numbers in §3.7 from a third. The 8192
prefill point reproduces across both 35B runs (23 003 and 23 156 t/s).

The rest of this text is written so that each change can be read, judged and re-implemented on
its own. `D1`…`D4` refer to the existing `sparse_moe_d*` decode kernels; everything else uses the
repository's own vocabulary.

---

## Contents

1. [Where the prefill number comes from](#1-where-the-prefill-number-comes-from)
2. [Reproducing all of it in about fifteen minutes](#2-reproducing-all-of-it-in-about-fifteen-minutes)
3. [The changes, by area](#3-the-changes-by-area)
4. [Ranked by payoff](#4-ranked-by-payoff)
5. [What depends on what](#5-what-depends-on-what)
6. [If you would rather re-implement than merge](#6-if-you-would-rather-re-implement-than-merge)
7. [Measured and rejected](#7-measured-and-rejected)
8. [Contracts, portability, risk](#8-contracts-portability-risk)

---

## 1. Where the prefill number comes from

Two independent factors multiply. Median of two alternating rounds per cell, each point its own
process, arms interleaved so session drift is charged to both:

| chunk | context | `dev` | this branch | branch vs `dev` | `dev` vs its own default |
|---:|---|---:|---:|---:|---:|
| 1024 (default) | 4K | 16 200 | 17 667 | +9.1% | — |
| | 16K | 13 543 | 14 558 | +7.5% | — |
| | 32K | 11 011 | 11 654 | +5.8% | — |
| 4096 | 4K | 19 663 | 21 876 | +11.3% | +21.4% |
| | 16K | 16 313 | 17 893 | +9.7% | +20.4% |
| | 32K | 13 083 | 14 053 | +7.4% | +18.8% |
| 8192 | 4K | 19 648 | 23 003 | +17.1% | +21.3% |
| | 16K | 16 469 | 18 890 | +14.7% | +21.6% |
| | 32K | 13 349 | 14 876 | +11.4% | +21.2% |

Read the last column first: **`dev` on its own gains 19–21% of prefill by moving
`--prefill-chunk` from 1024 to 4096.** The grouped MoE route amortises its per-expert setup over
the length of a column run, and a 1024-token chunk does not give it one. Going to 8192 adds
almost nothing further on stock `dev`, because the internal slice cap binds; one of the commits
here removes that cap, which is why our own curve keeps climbing to 8192.

**We did not change the default.** Chunk width changes greedy output on a near-tie in the argmax,
so moving it is a product decision, not a performance patch. It is called out here because it is
the single cheapest thing in this document — a flag, on your current code, today. Workspace cost
is 120 / 482 / 963 MiB at 1024 / 4096 / 8192.

Our own contribution, isolated, is the middle column: **+5.8…9.1% at the shipped default, rising
to +11.3…16.8% at 8192** as the wider chunk lets the MoE prefill work land.

Decode and MTP-3 do not depend on chunk width; those numbers come from the separate two-round
alternating A/B named above.

---

## 2. Reproducing all of it in about fifteen minutes

Nothing here needs our harness. Two builds, one script, your own fixtures.

```bash
# arm A: dev as-is
git checkout 59febed2 && cmake --build build -j && cp build/apps/ninfer /tmp/cli_dev

# arm B: this branch
git checkout <this-branch> && cmake --build build -j && cp build/apps/ninfer /tmp/cli_new
```

Then, for any prompt file you already have, alternate the arms so drift is shared:

```bash
for r in 1 2 3; do
  for bin in /tmp/cli_dev /tmp/cli_new; do
    $bin qwen3_6_35b_a3b.ninfer --messages prompt.json --max-new 200 \
        --greedy --no-thinking --max-context 131072 --prefill-chunk 8192 --kv-dtype bf16
  done
done
```

`prefill speed` and `decode speed` are on stderr. For MTP-3 add `--spec mtp --draft-tokens 3`.

**The identity check is the one that matters**, and it is just `cmp`: with `--greedy` the two
arms must produce byte-identical stdout at the same chunk width. Every change in this branch was
developed against that gate, and five of them were additionally checked with a *negative* control
— a deliberately broken variant that must fail the gate — so that "IDENTICAL" means the gate is
live rather than vacuous.

Full numbers, raw logs and the sweep script are reproducible from the commands above; if you want
the exact fixtures we used, they are needle-in-a-haystack prompts at 4K/16K/32K with a 64-token
and a 200-token generation.

---

## 3. The changes, by area

38 commits. Each is scoped to one operator boundary and carries its own rationale in the message.
Grouped here by what they touch, with the incremental gain measured when the change was made.

### 3.1 MoE decode: fewer graph nodes, warmer L2 (largest single block)

At T=1 the step is 447 graph nodes and several launch work smaller than the node itself.

| change | mechanism | incremental decode gain |
|---|---|---:|
| fold the pre-MoE rmsnorm into the D1/D3 prologues | the block that needs the normalised row computes it, using a bit-exact clone of the block reduce; D3's recompute hides inside its PDL wait | +1.2% |
| fold the router top-8 selection into the last-arriving D1 block | removes the single-warp D2 node whose 2.85 µs of node price carried 1.79 µs of work; the ticket is a self-resetting `atomicInc` wrapping at `gridDim.x - 1`, so no workspace slot and no host init | +0.7% |
| prefetch the next projection weights from the D4 tail | the epilogue warms L2 for the consumer that follows, capped at 8 MB | +2.5% |
| prefetch the shared-expert down weights from the D1 tail | removes the D4 shared-warp long pole | +1.9% |
| issue those prefetches before the block barrier | hides the issue cost behind the slowest warp | +0.9% |
| hoist the shared-expert W8 group scales out of the decode dot | scales are loop-invariant per group; the dot re-read them per element | +1.2% |

Three of these are prefetch placement rather than new arithmetic, and the placement is the whole
result: the same `prefetch` moved after the barrier is worth nothing.

### 3.2 Attention and norms

| change | mechanism | gain |
|---|---|---:|
| let causal attention apply the sigmoid gate itself | the reduce epilogue applies the gate through the same BF16 rounding the standalone multiply used; **the batched branch is included**, which is what serve and CLI both take | **+2.4…3.8% decode, +2.0% MTP3** |
| fuse the q/k rmsnorm into one decode kernel | one CTA per token normalises 16 query rows and 2 key rows in one launch; same reduction, same BF16x2 rounding; other geometries fall through to the existing pair | +1.7% |
| route the MTP draft head through the same fused op | the draft head was still paying two launches | +0.25% MTP3 |
| accumulate PV tiles in fp16 on consumer arches | `m16n8k16.f16.f16.f16.f16` runs at twice the f32-accumulate rate on sm_120; tiles fold to f32 at the group boundary so the dynamic range is unchanged | +4.3…9.2% on int8 KV |

Rope deliberately stays in its own kernel. An in-kernel rotation reusing the freshly rounded pair
reproduces every coefficient of `apply_rope_head` and still drifts by a last bit; that variant was
implemented and measured, it moved a token deep inside a long greedy generation and cost about
1% of MTP throughput through a lower acceptance rate. The code carries that note.

### 3.3 GDN

| change | mechanism | gain |
|---|---|---:|
| fold the gated post-mixer norm into the replay-record tail | the tail already holds the row; folding removes a launch | +0.25% MTP3 |
| fold the same into the batch-update tail | the batched path is the one serve takes | +0.39…0.57% decode |
| warm L2 for the out-projection from the batch-update tail | prefetch length is taken from the weight's own `payload_bytes` rather than a hard-coded extent, so it is right on 27B too | +0.99…1.59% decode |
| write the prefill convolution straight into q/k/v | removes a materialisation | prefill |
| carry the bf16-rounded projection as the next column's convolution tap | **correctness fix**: the unrounded value was being carried, so the tap disagreed with what the previous column actually wrote | — |

The two fold commits elect the tail block through a completion ticket that currently lives in a
module-global device symbol; that placement is wrong and is written up in
[§8](#known-issue-the-gdn-post-norm-tickets-sit-in-a-module-global-symbol).

### 3.4 MoE prefill

| change | mechanism | gain |
|---|---|---:|
| widen the Q4 gate/up weight decode | wider vector decode per iteration | prefill |
| widen the Q5/Q6 down weight decode | same, three-plane codes | prefill |
| stage the routed activations from `x` instead of a gathered copy | removes the gather and its arena | prefill |
| widen the prefill MoE tiles to BN=128 | the down kernel is generic in `ExpertBN`; 128 fits the 5090's occupancy | +1.9% at 32K |
| derive the grouped job width from the chunk, and let the route slice wider than 4096 | this is the cap that made 8192 worth nothing on stock `dev` — see §1 | +5.2% on the MoE bucket |
| barrier the prefill scan before it overwrites the cell its neighbour read | **correctness fix**: a race that was silent only because of the launch shape | — |

### 3.5 Small-T and projections

Four rows per CTA in the K=2048 decode projections; a direct decode out-projection path for the
35B, then sixteen rows per CTA for it, then making it the default; explicit launch bounds for the
small-T MoE down kernel; one CTA per column for the small-T router reduction; stop sending
two-column rounds to the one-row D4 schedule; widen the Q5 routed-down two-row window to eleven
tokens.

### 3.6 Host side

| change | mechanism | gain |
|---|---|---:|
| memoise the BPE merge result per distinct word within an encode call | repeated words in one prompt were re-merged | render 16 ms → 5 ms |
| skip NFC normalisation for pure ASCII | the scan is cheaper than the transform it usually skips | render |
| give 35B-A3B verify routes of different attention paths distinct graph execution profiles | **correctness fix**: two routes shared one profile, so the graph was rebuilt on every alternation between them | — |
| say what changed when a decode-graph update fails | diagnostics; the previous message did not name the field | — |

### 3.7 Qwen3.8-27B NVFP4

This branch is worth as much to the NVFP4 profile as to the MoE one, and the two commits that
name it are only part of that. Measured on `qwen3_8_27b_nvfp4`, chunk 4096, int8 KV, two
alternating rounds, medians:

| | `dev` 59febed2 | this branch | |
|---|---:|---:|---:|
| prefill 32K | 7 187 t/s | **7 749 t/s** | **+7.8%** |
| prefill 128K | 4 055 t/s | **4 484 t/s** | **+10.6%** |
| decode 32K / 128K | 81.1 / 71.0 t/s | 81.6 / 71.4 t/s | +0.6% / +0.5% |

Decode barely moves and that is expected: on this profile it already runs near the memory
roofline, and the decode work in this branch is MoE and W8, neither of which exists here. The
whole gain is prefill, and it grows with context.

Four commits carry it:

* **register the fused TMA SwiGLU for every chunk width it accepts** — it was registered only at
  exactly `T == 1024`, so any wider chunk fell back to materialising a `34816×T` bf16 arena and
  running a separate `silu_mul`. This is the single largest item on this model.
* **walk the TMA grid in token groups** so an expert's weights stay in L2 across the tiles that
  use them.
* **PV tiles in fp16** (§3.2) — +0.4% at 32K but **+6.0% at 128K**; its value grows with length,
  and it needs int8 KV, since the fp16 accumulation lives in the int8 kernel.
* **the GDN prefill convolution written straight into q/k/v** (§3.3) — the main contributor on
  short prompts, since 48 of the 64 layers here are GDN.

Plus a fifteen-token MTP draft window registered for Qwen3.6/3.8-27B.

**Where not to look next, so it costs you nothing to know.** The fused NVFP4 SwiGLU is 16.5% of
prefill and reaches 975 TFLOP/s against a 1945 TFLOP/s tier, which invites the conclusion that
the kernel is slow. It is not: marginal-cost ablations — each component issued twice, output held
byte-identical — put the TMA load path at a 1.79× time multiplier against 1.54× for the MMA and
1.06× for `ldmatrix`. The critical path is memory and it is saturated; during its own half of the
time the kernel issues at exactly the tier. Bigger tiles cannot fix it either: `BlockN=256` needs
256 accumulator registers against a 232 ceiling, and `BlockM>256` is outside what the TMA box
allows.

---

## 4. Ranked by payoff

If you only want the top of the list, this is the order we would take it in:

| rank | change | gain | lines | independent? |
|---:|---|---|---:|---|
| 1 | prefill chunk 1024 → 4096 (**a flag, not a patch**) | +19…21% prefill | 0 | yes |
| 2 | let the grouped route slice wider than 4096 | unlocks chunk 8192 | ~24 | yes |
| 3 | sigmoid gate inside the attention epilogue | +2.4…3.8% decode | ~79 | yes |
| 4 | prefetch next projection weights from the D4 tail | +2.5% decode | ~96 | yes |
| 5 | prefetch shared-expert down weights from the D1 tail | +1.9% decode | ~17 | needs 4 |
| 6 | fuse the q/k rmsnorm | +1.7% decode | ~129 | yes |
| 7 | PV tiles in fp16 on consumer arches | +4.3…9.2% attention | ~34 | yes |
| 8 | fold the pre-MoE rmsnorm into D1/D3 | +1.2% decode | ~150 | yes |
| 9 | hoist the shared-expert W8 group scales | +1.2% decode | ~41 | yes |
| 10 | fold the router selection into the last D1 block | +0.7% decode | ~31 | needs 8 |

Items 1 and 2 are the cheapest ratio in the whole document: one flag and one bound.

---

## 5. What depends on what

Almost everything is independent. The two real chains:

* router-selection fold **→** pre-MoE rmsnorm fold **→** the three D-tail prefetches.
  The selection fold assumes the D1 prologue already owns the normalised row.
* the MTP draft head routing **→** the fused q/k rmsnorm op it routes into.

Everything else can be taken in any order or alone. The GDN, attention, prefill-MoE, small-T,
host-side and 27B groups do not touch each other.

---

## 6. If you would rather re-implement than merge

That is a reasonable outcome and we have written this with it in mind — no attribution is being
asked for. Each subsection of §3 is one paragraph per idea, with the mechanism stated in terms of
the invariant it relies on rather than the diff, so it can be rebuilt without reading the patch.

Three things worth keeping whichever way you take them:

1. **The identity gate is what makes any of it safe to land.** Greedy `cmp` at a fixed chunk
   width, run on both a fresh process and a warm one. Several of these changes are bit-exact only
   because a rounding step was preserved exactly — the fused norm reproduces `rmsnorm_warp_bf16x2`'s
   BF16x2 rounding, the fused gate reads the reduced value back through the same BF16 rounding.
   A version that skips either is faster and wrong, and only the gate tells them apart.
2. **Prefetch placement is the result, not the prefetch.** The same instruction after the barrier
   is worth nothing; the gain is in issuing it while another warp is still the long pole.
3. **Two of the commits are correctness fixes independent of performance** — the GDN convolution
   tap carrying an unrounded value, and the prefill scan overwriting a cell its neighbour still
   needed. Those are worth taking even if none of the rest is.

---

## 7. Measured and rejected

So that none of this costs you a second time. All measured on the same machine, same gates.

| tried | result | why it is here |
|---|---|---|
| rope folded into the fused q/k norm kernel | last-bit drift, ≈ −1% MTP throughput via acceptance | the obvious next fusion; it is a trap |
| the gate fusion in the MTP attention epilogue as well | bit-identical but **−0.04% MTP3** | two vertices per step against ten already-fused full-attention layers |
| explicit launch bounds on the T=1 MoE down kernel | 22 056 → 21 397 ns in isolation, no end-to-end effect | reverted; the commit pair is not in this branch |
| `cp.async.bulk … .multicast::cluster` for shared expert tiles | correct data, **≈ 300× slower**; a single-CTA cluster with `mask=1` still costs 88.6 ms against 0.148 ms | the instruction assembles and runs on sm_120a but there is no hardware path under it |
| L2 persistence window (`accessPolicyWindow`, 60 MB available) | +1.0% sequential, +1.9% interleaved | 96 MB of L2 already holds a working set that size |
| 256-bit global loads (`ld.global.v8.b32`) | no bandwidth change; DRAM already at 1 700 GB/s = 94.7% of peak | it saves issue slots, not bandwidth |
| int8 for the W8 row-split prefill GEMM | +7.3% **only** if activation quantization is hoisted out of the kernel; quantizing in-kernel makes it −2.9% | each row block re-quantizes the same activations |
| 2:4 structured sparsity | the tier is real and measured at 15.6× the bf16 tier on this card | needs a pruned checkpoint; it is a model change, not a kernel change |

---

## 8. Contracts, portability, risk

* **No CLI, serving, artifact, tokenizer or documentation contract changes.** No new flags, no
  schema bump, no default moved. The one documentation edit describes existing behaviour.
* **Bit-exactness is the acceptance criterion, not a side effect.** Where a change could not be
  made bit-exact it was either dropped (rope) or split so that the exact part lands and the
  inexact part does not (the fused q/k norm is exactly this: the follow-up commit takes rope back
  out to restore identity, and pays 10.1 µs/token to do it).
* **Architecture-specific:** the fp16 PV accumulation is gated to consumer arches, where
  `m16n8k16.f16.f16.f16.f16` runs at twice the f32-accumulate rate. On parts where it does not,
  the existing path is taken.
* **Model-specific:** the two NVFP4 commits and the fifteen-token draft window apply to
  Qwen3.6/3.8-27B; the direct out-projection path is registered for the 35B.
* **Measured on one machine**, an RTX 5090 at a 500 W cap with CUDA 13.1. The relative numbers
  should hold on any sm_120 part; the absolute ones will not.
* **Known unrelated failure:** `ninfer_qwen3_6_27b_prefix_real_test` fails on this branch — and
  fails identically on clean `59febed2` (`path=0 reused=0 prompt=280`, same duration). It looks
  like it belongs to `fix(cache): retain prefixes across rewritten suffixes` rather than to
  anything here, and is flagged so it is not attributed to this branch.

### Known issue: the GDN post-norm tickets sit in a module-global symbol

`recurrent.cuh` declares `__device__ unsigned int g_gdn_post_norm_ticket[64 * 8]`, indexed only by
value head and batch row. The tail election is safe because every slot receives exactly
`gridDim.z` increments per launch and the wrapping `atomicInc` returns it to zero on its own — but
that invariant is **per launch, not per Program**. Two Programs running these kernels at once
would interleave their increments, and one could elect a final block before its own tiles had
finished, so the fused norm would read incomplete output. It is not reachable in the single-Program
configuration everything here was measured in, which is exactly why it is written down rather than
left to be discovered: it is a latent violation of the ownership boundary, not a bug I can point at.

The fix belongs where Program-lifetime device scratch lives, and that is a decision for this
repository rather than for us. What is already known about its shape, so nobody has to rediscover it:

* the kernel side is one line at each of the two `atomicInc` sites once a pointer reaches the
  access structs, which already carry the other `post_norm_*` fields;
* **`TextContext` cannot own it.** A `DeviceBuffer` member zeroed in its constructor compiles and
  removes the symbol, then fails at run time with `cudaMalloc failed:
  cudaErrorStreamCaptureUnsupported` — that constructor runs while the stream is capturing;
* `LinearAttentionStatePool` and `GdnReplayRecords` are non-owning views over a `DeviceSpan`
  somebody upstream allocates, so either one means extending a state layout;
* the workspace arena is reused inside a step, which would break the zero-on-entry invariant the
  tickets depend on.

That leaves allocation at Program construction, outside capture, handed down — landing squarely on
the ownership surface `refactor(runtime): make program the resource authority` just established.
Say where it should live and it is a small change; the three post-mixer-norm commits that use the
tickets are also separable on request, and are worth about 2% of decode between them.

This supersedes #67 and #69, which were built against the previous `master` and no longer apply:
`dev` deleted `include/ninfer/ops/gqa_attention.h`, which #67 modifies. The versions in this
branch are re-derived on the current tree, and the attention one is materially stronger than the
one in #67 — it fuses the batched branch, which the earlier version did not.
