### PR TITLE
The GDN prefill convolution writes q/k/v itself: 32 GB of copies gone per 32K prompt, 128 MiB of workspace freed

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -818,6 +818,30 @@ Aligned registered shapes use 16-byte BF16 packs in the cache-sized regime. GELU
 select their BF16x2 streaming routes for larger Vision items; odd or unaligned repository-internal
 test shapes exercise the scalar fallbacks.
 
+## Causal conv1d SiLU Op benchmark
+
+`ninfer_causal_conv1d_silu_bench` times one public entry per invocation. `--tokens` takes a list, so
+a route decision comes from one process rather than a series of them. `--cache` defaults to warm;
+pass `--cache cold` for the state route decisions are made in.
+
+```bash
+./build/bench/ninfer_causal_conv1d_silu_bench --split --cache cold --channels 8192 --tokens 1,2,7,15,16,17,24,32,33,64,65
+./build/bench/ninfer_causal_conv1d_silu_bench --split --cache cold --channels 10240 --tokens 1024,4096,8192
+```
+
+`--split` selects the split-output entry. Its partition follows the channel extent, because those
+are the row profiles the entry admits: `--channels 8192` gives (2048, 2048, 4096) and
+`--channels 10240` gives (2048, 2048, 6144).
+
+`--legacy-stage` times the stage the split entry replaced - one packed convolution into a `[C,T]`
+plane followed by three `extract_bf16_columns` - so the two can be compared under one set of
+timing conditions. It is a decision benchmark and is meant to be removed once that decision is
+closed.
+
+```bash
+./build/bench/ninfer_causal_conv1d_silu_bench --legacy-stage --split --cache cold --channels 8192 --tokens 1024,8192
+```
+
 ## Reports
 
 Table, JSON, and CSV reports all identify the selected target, artifact, Engine configuration,

--- a/bench/ops/causal_conv1d_silu_bench.cu
+++ b/bench/ops/causal_conv1d_silu_bench.cu
@@ -7,6 +7,7 @@
 //   ./ninfer_causal_conv1d_silu_bench --snapshot --channels 8192 --tokens 6 --slots 7
 // Printed logical GB/s is informational; NCU determines the applicable resource roofline.
 #include "ninfer/ops/causal_conv1d_silu.h"
+#include "ninfer/ops/scatter.h"
 #include "core/device.h"
 #include "ninfer_bench_common.h"
 
@@ -23,6 +24,8 @@ using namespace ninfer::bench;
 
 namespace {
 
+constexpr std::size_t kFlushBytes = std::size_t{256} << 20;
+
 struct Options {
     std::int32_t channels     = 8192;
     std::int32_t tokens       = 1024;
@@ -30,11 +33,45 @@ struct Options {
     std::int32_t initial_slot = 6;
     std::int32_t batch        = 1;
     std::vector<std::int32_t> valid_columns;
+    std::vector<std::int32_t> token_list;
     bool decode   = false;
     bool prefill  = false;
     bool distinct = false;
     bool snapshot = false;
+    bool split    = false;
+    bool legacy   = false;
+    bool cold     = false;
 };
+
+// The candidate partition for a channel extent. Which partitions are registered is the entry's
+// business, not the benchmark's: this builds the obvious one and lets the entry accept or reject it.
+constexpr std::int32_t kSplitKeyDim = 2048;
+
+bool split_partition(std::int32_t channels, std::int32_t& key_dim, std::int32_t& value_dim) {
+    key_dim   = kSplitKeyDim;
+    value_dim = channels - 2 * kSplitKeyDim;
+    return value_dim > 0;
+}
+
+Result time_stage(const Options& options, const launch_fn& launch, double bytes_moved) {
+    if (!options.cold) { return bench_loop(launch, bytes_moved); }
+    constexpr int kColdWarmup = 20;
+    constexpr int kColdRepeat = 40;
+    DeviceBuffer flush(kFlushBytes);
+    const ColdTiming timing = measure_cold_launch(launch, flush, nullptr, kColdWarmup, kColdRepeat);
+    Result result;
+    result.n_runs        = kColdRepeat;
+    result.median_us     = timing.median_us;
+    result.min_us        = timing.min_us;
+    result.p95_us        = timing.p95_us;
+    const double seconds = timing.median_us * 1e-6;
+    result.gbs           = seconds > 0.0 ? bytes_moved / seconds / 1e9 : 0.0;
+    return result;
+}
+
+std::string cache_tag(const Options& options, const char* entry) {
+    return options.cold ? std::string(entry) + "-cold" : std::string(entry);
+}
 
 __global__ void copy_u128_kernel(const uint4* src, uint4* dst, std::size_t n4) {
     const std::size_t start  = blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
@@ -66,14 +103,14 @@ void copy_bytes_launch(const DeviceBuffer& src, DeviceBuffer& dst, std::size_t c
     CUDA_CHECK(cudaGetLastError());
 }
 
-void run_copy_baseline(double bytes, const char* tag) {
+void run_copy_baseline(const Options& options, double bytes, const char* tag) {
     const auto copy_bytes   = static_cast<std::size_t>(bytes / 2.0);
     const auto padded_bytes = (copy_bytes + sizeof(uint4) - 1u) & ~(sizeof(uint4) - 1u);
     DeviceBuffer src        = make_varied_bf16(padded_bytes / 2u, 0xc001c0deU);
     DeviceBuffer dst        = make_zeros(padded_bytes);
 
-    const Result r =
-        bench_loop([&](cudaStream_t s) { copy_bytes_launch(src, dst, copy_bytes, s); }, bytes);
+    const Result r = time_stage(
+        options, [&](cudaStream_t s) { copy_bytes_launch(src, dst, copy_bytes, s); }, bytes);
     print_result(tag, r);
 }
 
@@ -103,7 +140,8 @@ void run_prefill(const Options& options, bool distinct) {
     // Informational compulsory traffic: x/out, the four-tap weight, and state read/write. NCU
     // counters remain the performance authority.
     const double bytes = 4.0 * static_cast<double>(n) + 20.0 * options.channels;
-    const Result r     = bench_loop(
+    const Result r     = time_stage(
+        options,
         [&](cudaStream_t s) {
             if (distinct) {
                 ops::causal_conv1d_silu(tx, tw, tin, tout_state, tout, s);
@@ -112,8 +150,99 @@ void run_prefill(const Options& options, bool distinct) {
             }
         },
         bytes);
+    const std::string tag = shape_tag(cache_tag(options, distinct ? "distinct" : "prefill").c_str(),
+                                      options.channels, options.tokens);
+    print_result(tag.c_str(), r);
+}
+
+// Split-output prefill. The destinations partition the channel extent the way the GDN caller
+// does: two key-sized ranges followed by the value range.
+void run_split(const Options& options) {
+    std::int32_t key_dim   = 0;
+    std::int32_t value_dim = 0;
+    if (!split_partition(options.channels, key_dim, value_dim)) {
+        std::printf("SKIP: --channels %d leaves no value rows\n", options.channels);
+        return;
+    }
+    const std::size_t n       = static_cast<std::size_t>(options.channels) * options.tokens;
+    const std::size_t state_n = static_cast<std::size_t>(options.channels) * 3u;
+
+    DeviceBuffer x = make_varied_bf16(n, 0x12345678U);
+    DeviceBuffer weight =
+        make_varied_bf16(static_cast<std::size_t>(options.channels) * 4u, 0x87654321U);
+    DeviceBuffer state_in  = make_varied_bf16(state_n, 0x31415926U);
+    DeviceBuffer state_out = make_zeros(state_n * 2u);
+    DeviceBuffer q         = make_zeros(static_cast<std::size_t>(key_dim) * options.tokens * 2u);
+    DeviceBuffer k         = make_zeros(static_cast<std::size_t>(key_dim) * options.tokens * 2u);
+    DeviceBuffer v         = make_zeros(static_cast<std::size_t>(value_dim) * options.tokens * 2u);
+
+    Tensor tx(x.p, DType::BF16, {options.channels, options.tokens});
+    Tensor tw(weight.p, DType::BF16, {options.channels, 4});
+    Tensor tin(state_in.p, DType::BF16, {options.channels, 3});
+    Tensor tout_state(state_out.p, DType::BF16, {options.channels, 3});
+    Tensor tq(q.p, DType::BF16, {key_dim, options.tokens});
+    Tensor tk(k.p, DType::BF16, {key_dim, options.tokens});
+    Tensor tv(v.p, DType::BF16, {value_dim, options.tokens});
+
+    // x in, q+k+v out, the four-tap weight and both states. NCU counters remain the performance
+    // authority.
+    const double bytes = 4.0 * static_cast<double>(n) + 20.0 * options.channels;
+    const Result r     = time_stage(
+        options,
+        [&](cudaStream_t s) {
+            ops::causal_conv1d_silu_split(tx, tw, tin, tout_state, tq, tk, tv, s);
+        },
+        bytes);
     const std::string tag =
-        shape_tag(distinct ? "distinct" : "prefill", options.channels, options.tokens);
+        shape_tag(cache_tag(options, "split").c_str(), options.channels, options.tokens);
+    print_result(tag.c_str(), r);
+}
+
+// The stage the split entry replaced: one packed convolution into a [C,T] plane, then three
+// column extractions out of it. Temporary, for the implementation decision only.
+void run_legacy_stage(const Options& options) {
+    std::int32_t key_dim   = 0;
+    std::int32_t value_dim = 0;
+    if (!split_partition(options.channels, key_dim, value_dim)) {
+        std::printf("SKIP: --channels %d leaves no value rows\n", options.channels);
+        return;
+    }
+    const std::size_t n       = static_cast<std::size_t>(options.channels) * options.tokens;
+    const std::size_t state_n = static_cast<std::size_t>(options.channels) * 3u;
+
+    DeviceBuffer x = make_varied_bf16(n, 0x12345678U);
+    DeviceBuffer weight =
+        make_varied_bf16(static_cast<std::size_t>(options.channels) * 4u, 0x87654321U);
+    DeviceBuffer state_in  = make_varied_bf16(state_n, 0x31415926U);
+    DeviceBuffer state_out = make_zeros(state_n * 2u);
+    DeviceBuffer packed    = make_zeros(n * 2u);
+    DeviceBuffer q         = make_zeros(static_cast<std::size_t>(key_dim) * options.tokens * 2u);
+    DeviceBuffer k         = make_zeros(static_cast<std::size_t>(key_dim) * options.tokens * 2u);
+    DeviceBuffer v         = make_zeros(static_cast<std::size_t>(value_dim) * options.tokens * 2u);
+
+    Tensor tx(x.p, DType::BF16, {options.channels, options.tokens});
+    Tensor tw(weight.p, DType::BF16, {options.channels, 4});
+    Tensor tin(state_in.p, DType::BF16, {options.channels, 3});
+    Tensor tout_state(state_out.p, DType::BF16, {options.channels, 3});
+    Tensor tpacked(packed.p, DType::BF16, {options.channels, options.tokens});
+    Tensor tq(q.p, DType::BF16, {key_dim, options.tokens});
+    Tensor tk(k.p, DType::BF16, {key_dim, options.tokens});
+    Tensor tv(v.p, DType::BF16, {value_dim, options.tokens});
+
+    // The convolution moves x in and the packed plane out; the three extractions read that plane
+    // back and write the same bytes again.
+    const double bytes = 8.0 * static_cast<double>(n) + 20.0 * options.channels;
+    const Result r     = time_stage(
+        options,
+        [&](cudaStream_t s) {
+            ops::causal_conv1d_silu(tx, tw, tin, tout_state, tpacked, s);
+            ops::extract_bf16_columns(tpacked, 0, tq, s);
+            ops::extract_bf16_columns(tpacked, key_dim, tk, s);
+            ops::extract_bf16_columns(tpacked, 2 * key_dim, tv, s);
+        },
+        bytes);
+    const std::string tag =
+        shape_tag(cache_tag(options, "legacy-stage").c_str(), options.channels, options.tokens);
     print_result(tag.c_str(), r);
 }
 
@@ -131,11 +260,11 @@ void run_decode(const Options& options) {
     Tensor tout(out.p, DType::BF16, {options.channels, 1});
 
     const double bytes = 24.0 * options.channels;
-    const Result r =
-        bench_loop([&](cudaStream_t s) { ops::causal_conv1d_silu(tx, tw, ts, tout, s); }, bytes);
-    const std::string tag = shape_tag("decode", options.channels, 1);
+    const Result r     = time_stage(
+        options, [&](cudaStream_t s) { ops::causal_conv1d_silu(tx, tw, ts, tout, s); }, bytes);
+    const std::string tag = shape_tag(cache_tag(options, "decode").c_str(), options.channels, 1);
     print_result(tag.c_str(), r);
-    run_copy_baseline(bytes, "copy same-byte decode baseline");
+    run_copy_baseline(options, bytes, cache_tag(options, "copy same-byte decode baseline").c_str());
 }
 
 void run_snapshot(const Options& options) {
@@ -191,22 +320,25 @@ void run_snapshot(const Options& options) {
     // and publishes three BF16 state columns.
     const double bytes = 8.0 * options.channels + 6.0 * options.channels * options.batch +
                          10.0 * static_cast<double>(n);
-    const Result r = bench_loop(
+    const Result r     = time_stage(
+        options,
         [&](cudaStream_t s) {
             ops::causal_conv1d_silu_snapshot(tx, tw, ts, tvalid, tslot, tsnapshot_base, tout, s);
         },
         bytes);
-    const std::string tag =
-        shape_tag(options.valid_columns.empty() ? "snapshot dense" : "snapshot masked",
+    const std::string tag = shape_tag(
+        cache_tag(options, options.valid_columns.empty() ? "snapshot dense" : "snapshot masked")
+            .c_str(),
                   options.channels, options.tokens, options.batch);
     print_result(tag.c_str(), r);
 }
 
 void print_usage(const char* program) {
     std::fprintf(stderr,
-                 "usage: %s [--decode] [--prefill] [--distinct] [--snapshot] "
-                 "[--channels C] [--tokens T] [--batch B] [--valid-columns V0,V1,...] "
-                 "[--slots S] [--initial-slot I]\n",
+                 "usage: %s [--decode] [--prefill] [--distinct] [--snapshot] [--split] "
+                 "[--legacy-stage] [--cache warm|cold] [--channels C] [--tokens T[,T...]] "
+                 "[--batch B] [--valid-columns V0,V1,...] [--slots S] "
+                 "[--initial-slot I]\n",
                  program);
 }
 
@@ -242,6 +374,19 @@ bool parse_options(int argc, char** argv, Options& options) {
             options.distinct = true;
         } else if (!std::strcmp(argv[i], "--snapshot")) {
             options.snapshot = true;
+        } else if (!std::strcmp(argv[i], "--split")) {
+            options.split = true;
+        } else if (!std::strcmp(argv[i], "--legacy-stage")) {
+            options.legacy = true;
+        } else if (!std::strcmp(argv[i], "--cache") && i + 1 < argc) {
+            const char* value = argv[++i];
+            if (!std::strcmp(value, "cold")) {
+                options.cold = true;
+            } else if (!std::strcmp(value, "warm")) {
+                options.cold = false;
+            } else {
+                return false;
+            }
         } else if (!std::strcmp(argv[i], "--valid-columns") && i + 1 < argc) {
             if (!parse_valid_columns(argv[++i], options.valid_columns)) { return false; }
         } else if ((!std::strcmp(argv[i], "--channels") || !std::strcmp(argv[i], "--tokens") ||
@@ -253,9 +398,19 @@ bool parse_options(int argc, char** argv, Options& options) {
                 const long parsed = std::strtol(argv[i], nullptr, 10);
                 if (parsed < 0 || parsed > INT32_MAX) { return false; }
                 options.initial_slot = static_cast<std::int32_t>(parsed);
+            } else if (!std::strcmp(flag, "--tokens")) {
+                options.token_list.clear();
+                const char* cursor = argv[i];
+                while (*cursor != 0) {
+                    char* end         = nullptr;
+                    const long parsed = std::strtol(cursor, &end, 10);
+                    if (end == cursor || parsed <= 0 || parsed > INT32_MAX) { return false; }
+                    options.token_list.push_back(static_cast<std::int32_t>(parsed));
+                    cursor = (*end == ',') ? end + 1 : end;
+                }
+                if (options.token_list.empty()) { return false; }
             } else {
                 std::int32_t* destination = !std::strcmp(flag, "--channels") ? &options.channels
-                                            : !std::strcmp(flag, "--tokens") ? &options.tokens
                                             : !std::strcmp(flag, "--batch")  ? &options.batch
                                                                              : &options.slots;
                 if (!parse_positive(argv[i], *destination)) { return false; }
@@ -264,20 +419,26 @@ bool parse_options(int argc, char** argv, Options& options) {
             return false;
         }
     }
-    if (!options.decode && !options.prefill && !options.distinct && !options.snapshot) {
+    if (!options.decode && !options.prefill && !options.distinct && !options.snapshot &&
+        !options.split && !options.legacy) {
         options.decode = options.prefill = true;
     }
-    if (options.batch > 8 || (options.batch > 1 && options.tokens > 16) ||
+    if (options.batch > 8 ||
         ((!options.snapshot) && (options.batch != 1 || !options.valid_columns.empty())) ||
         (!options.valid_columns.empty() &&
          options.valid_columns.size() != static_cast<std::size_t>(options.batch))) {
         return false;
     }
-    for (const std::int32_t valid : options.valid_columns) {
-        if (valid > options.tokens) return false;
+    for (const std::int32_t tokens : options.token_list.empty()
+                                        ? std::vector<std::int32_t>{options.tokens}
+                                        : options.token_list) {
+        if (options.batch > 1 && tokens > 16) { return false; }
+        if (options.snapshot && options.batch == 1 && tokens > options.slots) { return false; }
+        for (const std::int32_t valid : options.valid_columns) {
+            if (valid > tokens) { return false; }
+        }
     }
-    return !options.snapshot || options.batch > 1 ||
-           (options.initial_slot < options.slots && options.tokens <= options.slots);
+    return !options.snapshot || options.batch > 1 || options.initial_slot < options.slots;
 }
 
 } // namespace
@@ -295,9 +456,17 @@ int main(int argc, char** argv) {
         return 2;
     }
 
-    if (options.decode) run_decode(options);
-    if (options.prefill) run_prefill(options, false);
-    if (options.distinct) run_prefill(options, true);
-    if (options.snapshot) run_snapshot(options);
+    std::vector<std::int32_t> tokens = options.token_list;
+    if (tokens.empty()) { tokens.push_back(options.tokens); }
+    for (const std::int32_t t : tokens) {
+        Options point = options;
+        point.tokens  = t;
+        if (point.decode) run_decode(point);
+        if (point.prefill) run_prefill(point, false);
+        if (point.distinct) run_prefill(point, true);
+        if (point.snapshot) run_snapshot(point);
+        if (point.legacy) run_legacy_stage(point);
+        if (point.split) run_split(point);
+    }
     return 0;
 }

--- a/include/ninfer/ops/causal_conv1d_silu.h
+++ b/include/ninfer/ops/causal_conv1d_silu.h
@@ -30,6 +30,16 @@ void causal_conv1d_silu(const Tensor& x, const Tensor& weight, Tensor& conv_stat
 void causal_conv1d_silu(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
                         Tensor& conv_state_out, Tensor& out, cudaStream_t stream);
 
+// Split-output form. `ideal` is unchanged; its rows are written to three destinations instead of
+// one, partitioned in row order as out0, out1, out2. Every destination is contiguous BF16 with the
+// column count of x, and every operand is four-byte aligned. The supported row profiles are
+// (2048, 2048, 4096) over C = 8192 and (2048, 2048, 6144) over C = 10240; any other profile is
+// rejected. conv_state_in and conv_state_out follow the family rule above: disjoint or exactly the
+// same storage. No destination may overlap another, x, weight, or either state.
+void causal_conv1d_silu_split(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                              Tensor& conv_state_out, Tensor& out0, Tensor& out1, Tensor& out2,
+                              cudaStream_t stream);
+
 /**
  * Snapshot form for B independent sequences. `x` and `out` are contiguous BF16 [C,W,B],
  * `conv_states` is contiguous BF16 [C,3,Slots], and `initial_state_slots` and

--- a/src/ops/kernel/causal_conv1d.cuh
+++ b/src/ops/kernel/causal_conv1d.cuh
@@ -20,8 +20,59 @@ __device__ __forceinline__ void causal_conv1d_acc_pair(__nv_bfloat162 w, __nv_bf
 
 inline constexpr int kCausalConvChannelTile = 32;
 
+namespace detail {
+
+// One destination column resolved for a fixed row: the address of element (row,0) and the row
+// count of the destination that owns it.
+template <class Element>
+struct CausalConvOutputColumn {
+    Element* base;
+    std::int32_t rows;
+
+    __device__ __forceinline__ Element* at(std::int32_t t) const {
+        return base + static_cast<std::int64_t>(t) * rows;
+    }
+};
+
+// Output address map for a single contiguous [rows,T] destination. One destination admits any
+// row count, so the leading dimension stays a runtime value. The pointer is not restrict: the
+// entries that use this map do not establish that their destination is disjoint from x.
+template <class Element>
+struct CausalConvContiguousOutput {
+    Element* out;
+    std::int32_t rows;
+
+    __device__ __forceinline__ CausalConvOutputColumn<Element> column(std::int64_t row) const {
+        return {out + row, rows};
+    }
+};
+
+// Output address map for three destinations partitioned by row. The partition is a template
+// parameter: the registered geometries are the only ones the wrapper admits, so the boundaries and
+// the three leading dimensions are constants here. Callers writing pairs pass halved row counts,
+// which requires every boundary to be even.
+template <class Element, std::int32_t Rows0, std::int32_t Rows1, std::int32_t Rows2>
+struct CausalConvSplitOutput3 {
+    static_assert(Rows0 > 0 && Rows1 > 0 && Rows2 > 0);
+
+    Element* __restrict__ out0;
+    Element* __restrict__ out1;
+    Element* __restrict__ out2;
+
+    __device__ __forceinline__ CausalConvOutputColumn<Element> column(std::int64_t row) const {
+        constexpr std::int32_t split1 = Rows0;
+        constexpr std::int32_t split2 = Rows0 + Rows1;
+        if (row < split1) { return {out0 + row, Rows0}; }
+        if (row < split2) { return {out1 + (row - split1), Rows1}; }
+        return {out2 + (row - split2), Rows2};
+    }
+};
+
+} // namespace detail
+
+template <class Output>
 __global__ void causal_conv1d_prefill_kernel(const __nv_bfloat16* x, const __nv_bfloat16* weight,
-                                             const __nv_bfloat16* conv_state, __nv_bfloat16* out,
+                                             const __nv_bfloat16* conv_state, Output out,
                                              std::int32_t C, std::int32_t T) {
     const std::int64_t C64      = static_cast<std::int64_t>(C);
     const std::int64_t c_blocks = div_up(C64, static_cast<std::int64_t>(blockDim.x));
@@ -32,28 +83,28 @@ __global__ void causal_conv1d_prefill_kernel(const __nv_bfloat16* x, const __nv_
     if (t >= T || c64 >= C64) { return; }
 
     const std::int32_t c       = static_cast<std::int32_t>(c64);
-    const std::int64_t out_idx = static_cast<std::int64_t>(t) * C64 + c64;
+    const std::int64_t in_idx = static_cast<std::int64_t>(t) * C64 + c64;
     const __nv_bfloat16 x0     = (t >= 3) ? x[static_cast<std::int64_t>(t - 3) * C64 + c64]
                                           : conv_state[static_cast<std::int64_t>(t) * C64 + c64];
     const __nv_bfloat16 x1     = (t >= 2) ? x[static_cast<std::int64_t>(t - 2) * C64 + c64]
                                           : conv_state[static_cast<std::int64_t>(t + 1) * C64 + c64];
     const __nv_bfloat16 x2     = (t >= 1) ? x[static_cast<std::int64_t>(t - 1) * C64 + c64]
                                           : conv_state[static_cast<std::int64_t>(t + 2) * C64 + c64];
-    const __nv_bfloat16 x3     = x[out_idx];
+    const __nv_bfloat16 x3    = x[in_idx];
 
     float acc = 0.0f;
     acc += __bfloat162float(weight[c]) * __bfloat162float(x0);
     acc += __bfloat162float(weight[C64 + c]) * __bfloat162float(x1);
     acc += __bfloat162float(weight[2 * C64 + c]) * __bfloat162float(x2);
     acc += __bfloat162float(weight[3 * C64 + c]) * __bfloat162float(x3);
-    out[out_idx] = __float2bfloat16_rn(silu(acc));
+    *out.column(c64).at(t) = __float2bfloat16_rn(silu(acc));
 }
 
+template <class Output>
 __global__ void causal_conv1d_prefill_pairs_kernel(const __nv_bfloat16* x,
                                                    const __nv_bfloat16* weight,
-                                                   const __nv_bfloat16* conv_state,
-                                                   __nv_bfloat16* out, std::int32_t C,
-                                                   std::int32_t T) {
+                                                   const __nv_bfloat16* conv_state, Output out,
+                                                   std::int32_t C, std::int32_t T) {
     const std::int64_t C2        = static_cast<std::int64_t>(C / 2);
     const std::int64_t c_blocks  = div_up(C2, static_cast<std::int64_t>(blockDim.x));
     const std::int64_t block     = static_cast<std::int64_t>(blockIdx.x);
@@ -65,16 +116,15 @@ __global__ void causal_conv1d_prefill_pairs_kernel(const __nv_bfloat16* x,
     const auto* x2      = reinterpret_cast<const __nv_bfloat162*>(x);
     const auto* weight2 = reinterpret_cast<const __nv_bfloat162*>(weight);
     const auto* state2  = reinterpret_cast<const __nv_bfloat162*>(conv_state);
-    auto* out2          = reinterpret_cast<__nv_bfloat162*>(out);
 
-    const std::int64_t out_idx = static_cast<std::int64_t>(t) * C2 + p;
+    const std::int64_t in_idx = static_cast<std::int64_t>(t) * C2 + p;
     const __nv_bfloat162 x0    = (t >= 3) ? x2[static_cast<std::int64_t>(t - 3) * C2 + p]
                                           : state2[static_cast<std::int64_t>(t) * C2 + p];
     const __nv_bfloat162 x1    = (t >= 2) ? x2[static_cast<std::int64_t>(t - 2) * C2 + p]
                                           : state2[static_cast<std::int64_t>(t + 1) * C2 + p];
     const __nv_bfloat162 x2v   = (t >= 1) ? x2[static_cast<std::int64_t>(t - 1) * C2 + p]
                                           : state2[static_cast<std::int64_t>(t + 2) * C2 + p];
-    const __nv_bfloat162 x3    = x2[out_idx];
+    const __nv_bfloat162 x3   = x2[in_idx];
 
     float acc0 = 0.0f;
     float acc1 = 0.0f;
@@ -82,7 +132,7 @@ __global__ void causal_conv1d_prefill_pairs_kernel(const __nv_bfloat16* x,
     causal_conv1d_acc_pair(weight2[C2 + p], x1, acc0, acc1);
     causal_conv1d_acc_pair(weight2[2 * C2 + p], x2v, acc0, acc1);
     causal_conv1d_acc_pair(weight2[3 * C2 + p], x3, acc0, acc1);
-    out2[out_idx] = __floats2bfloat162_rn(silu(acc0), silu(acc1));
+    *out.column(p).at(t) = __floats2bfloat162_rn(silu(acc0), silu(acc1));
 }
 
 // Writes the trailing width-3 conv window after consuming the T input columns.
@@ -123,52 +173,13 @@ __global__ void causal_conv1d_prefill_state_kernel(const __nv_bfloat16* x,
     }
 }
 
-// Small-T ordinary form. One thread owns a channel for the complete sequence, so the initial
-// state and four weights are loaded once and the final state is published in the same launch.
-// conv_state_in and conv_state_out may be identical or disjoint.
-__global__ void causal_conv1d_sequence_kernel(const __nv_bfloat16* x, const __nv_bfloat16* weight,
-                                              const __nv_bfloat16* conv_state_in,
-                                              __nv_bfloat16* conv_state_out, __nv_bfloat16* out,
-                                              std::int32_t C, std::int32_t T) {
-    const std::int64_t c64 = blockIdx.x * static_cast<std::int64_t>(blockDim.x) + threadIdx.x;
-    const std::int64_t C64 = static_cast<std::int64_t>(C);
-    if (c64 >= C64) { return; }
-
-    __nv_bfloat16 s0 = conv_state_in[c64];
-    __nv_bfloat16 s1 = conv_state_in[C64 + c64];
-    __nv_bfloat16 s2 = conv_state_in[2 * C64 + c64];
-    const float w0   = __bfloat162float(weight[c64]);
-    const float w1   = __bfloat162float(weight[C64 + c64]);
-    const float w2   = __bfloat162float(weight[2 * C64 + c64]);
-    const float w3   = __bfloat162float(weight[3 * C64 + c64]);
-
-    for (std::int32_t t = 0; t < T; ++t) {
-        const std::int64_t out_idx = static_cast<std::int64_t>(t) * C64 + c64;
-        const __nv_bfloat16 x0     = x[out_idx];
-
-        float acc = 0.0f;
-        acc += w0 * __bfloat162float(s0);
-        acc += w1 * __bfloat162float(s1);
-        acc += w2 * __bfloat162float(s2);
-        acc += w3 * __bfloat162float(x0);
-
-        out[out_idx] = __float2bfloat16_rn(silu(acc));
-        s0           = s1;
-        s1           = s2;
-        s2           = x0;
-    }
-
-    conv_state_out[c64]           = s0;
-    conv_state_out[C64 + c64]     = s1;
-    conv_state_out[2 * C64 + c64] = s2;
-}
-
 // Small-T ordinary form parallelized across both channels and tokens. Each CTA owns one channel
 // tile for the full sequence. Loading history into shared memory before any state publication makes
 // the exact-alias state form safe without a second kernel.
+template <class Output>
 __global__ void causal_conv1d_smallt_kernel(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                                             const __nv_bfloat16* conv_state_in,
-                                            __nv_bfloat16* conv_state_out, __nv_bfloat16* out,
+                                            __nv_bfloat16* conv_state_out, Output out,
                                             std::int32_t C, std::int32_t T) {
     __shared__ __nv_bfloat16 history[3][kCausalConvChannelTile];
     __shared__ __nv_bfloat16 weights[4][kCausalConvChannelTile];
@@ -201,15 +212,15 @@ __global__ void causal_conv1d_smallt_kernel(const __nv_bfloat16* x, const __nv_b
         p1 < 0 ? history[p1 + 3][lane] : x[static_cast<std::int64_t>(p1) * C64 + c64];
     const __nv_bfloat16 x2 =
         p2 < 0 ? history[p2 + 3][lane] : x[static_cast<std::int64_t>(p2) * C64 + c64];
-    const std::int64_t out_idx = static_cast<std::int64_t>(t) * C64 + c64;
-    const __nv_bfloat16 x3     = x[out_idx];
+    const std::int64_t x_idx = static_cast<std::int64_t>(t) * C64 + c64;
+    const __nv_bfloat16 x3   = x[x_idx];
 
     float acc = 0.0f;
     acc += __bfloat162float(weights[0][lane]) * __bfloat162float(x0);
     acc += __bfloat162float(weights[1][lane]) * __bfloat162float(x1);
     acc += __bfloat162float(weights[2][lane]) * __bfloat162float(x2);
     acc += __bfloat162float(weights[3][lane]) * __bfloat162float(x3);
-    out[out_idx] = __float2bfloat16_rn(silu(acc));
+    *out.column(c64).at(t) = __float2bfloat16_rn(silu(acc));
 
     if (t == 0) {
         for (std::int32_t s = 0; s < 3; ++s) {

--- a/src/ops/launcher/causal_conv1d.cu
+++ b/src/ops/launcher/causal_conv1d.cu
@@ -12,6 +12,11 @@
 #include <string>
 
 namespace ninfer::ops::detail {
+
+// The small-T routes launch one thread per channel and token in one block, so the bound and the
+// channel tile together may not exceed the hardware block ceiling.
+static_assert(kCausalConvChannelTile * kCausalConvParallelMaxTokens <= 1024,
+              "small-T block would exceed 1024 threads");
 namespace {
 
 int grid_for(std::int64_t n, int block, const char* label) {
@@ -52,20 +57,22 @@ void causal_conv1d_prefill_launch(const Tensor& x, const Tensor& weight,
     if (((x_addr | w_addr | in_addr | out_state_addr | out_addr) & (alignof(__nv_bfloat162) - 1)) ==
             0 &&
         (C & 1) == 0) {
+        const CausalConvContiguousOutput<__nv_bfloat162> out_map{
+            reinterpret_cast<__nv_bfloat162*>(out.data), C / 2};
         causal_conv1d_prefill_pairs_kernel<<<prefill_output_grid_for(C / 2, T, kPairBlock),
                                              kPairBlock, 0, stream>>>(
             static_cast<const __nv_bfloat16*>(x.data),
             static_cast<const __nv_bfloat16*>(weight.data),
-            static_cast<const __nv_bfloat16*>(conv_state_in.data),
-            static_cast<__nv_bfloat16*>(out.data), C, T);
+            static_cast<const __nv_bfloat16*>(conv_state_in.data), out_map, C, T);
         CUDA_CHECK(cudaGetLastError());
     } else {
+        const CausalConvContiguousOutput<__nv_bfloat16> out_map{
+            static_cast<__nv_bfloat16*>(out.data), C};
         causal_conv1d_prefill_kernel<<<prefill_output_grid_for(C, T, kOutputBlock), kOutputBlock, 0,
                                        stream>>>(
             static_cast<const __nv_bfloat16*>(x.data),
             static_cast<const __nv_bfloat16*>(weight.data),
-            static_cast<const __nv_bfloat16*>(conv_state_in.data),
-            static_cast<__nv_bfloat16*>(out.data), C, T);
+            static_cast<const __nv_bfloat16*>(conv_state_in.data), out_map, C, T);
         CUDA_CHECK(cudaGetLastError());
     }
 
@@ -84,27 +91,100 @@ void causal_conv1d_smallt_launch(const Tensor& x, const Tensor& weight, const Te
     const dim3 block(kCausalConvChannelTile, static_cast<unsigned int>(T));
     const int grid = grid_for(C, kCausalConvChannelTile, "small-T");
 
+    const CausalConvContiguousOutput<__nv_bfloat16> out_map{static_cast<__nv_bfloat16*>(out.data),
+                                                            C};
     causal_conv1d_smallt_kernel<<<grid, block, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data), static_cast<const __nv_bfloat16*>(weight.data),
         static_cast<const __nv_bfloat16*>(conv_state_in.data),
-        static_cast<__nv_bfloat16*>(conv_state_out.data), static_cast<__nv_bfloat16*>(out.data), C,
-        T);
+        static_cast<__nv_bfloat16*>(conv_state_out.data), out_map, C, T);
     CUDA_CHECK(cudaGetLastError());
 }
 
-void causal_conv1d_sequence_launch(const Tensor& x, const Tensor& weight,
-                                   const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
-                                   cudaStream_t stream) {
+template <std::int32_t Rows0, std::int32_t Rows1, std::int32_t Rows2>
+void smallt_split_launch(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                         Tensor& conv_state_out, Tensor& out0, Tensor& out1, Tensor& out2,
+                         cudaStream_t stream) {
     const std::int32_t C = x.ne[0];
     const std::int32_t T = x.ne[1];
-    const int block      = T == 1 ? 256 : 32;
+    if (Rows0 + Rows1 + Rows2 != C) {
+        throw std::invalid_argument("causal_conv1d: split geometry does not cover the channels");
+    }
+    const dim3 block(kCausalConvChannelTile, static_cast<unsigned int>(T));
+    const int grid = grid_for(C, kCausalConvChannelTile, "small-T");
 
-    causal_conv1d_sequence_kernel<<<grid_for(C, block, "sequence"), block, 0, stream>>>(
+    const CausalConvSplitOutput3<__nv_bfloat16, Rows0, Rows1, Rows2> out_map{
+        static_cast<__nv_bfloat16*>(out0.data), static_cast<__nv_bfloat16*>(out1.data),
+        static_cast<__nv_bfloat16*>(out2.data)};
+    causal_conv1d_smallt_kernel<<<grid, block, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data), static_cast<const __nv_bfloat16*>(weight.data),
         static_cast<const __nv_bfloat16*>(conv_state_in.data),
-        static_cast<__nv_bfloat16*>(conv_state_out.data), static_cast<__nv_bfloat16*>(out.data), C,
-        T);
+        static_cast<__nv_bfloat16*>(conv_state_out.data), out_map, C, T);
     CUDA_CHECK(cudaGetLastError());
+}
+
+void causal_conv1d_smallt_split_launch(const Tensor& x, const Tensor& weight,
+                                       const Tensor& conv_state_in, Tensor& conv_state_out,
+                                       Tensor& out0, Tensor& out1, Tensor& out2,
+                                       CausalConvSplitGeometry geometry, cudaStream_t stream) {
+    switch (geometry) {
+    case CausalConvSplitGeometry::Rows2048x2048x4096:
+        smallt_split_launch<2048, 2048, 4096>(x, weight, conv_state_in, conv_state_out, out0, out1,
+                                              out2, stream);
+        return;
+    case CausalConvSplitGeometry::Rows2048x2048x6144:
+        smallt_split_launch<2048, 2048, 6144>(x, weight, conv_state_in, conv_state_out, out0, out1,
+                                              out2, stream);
+        return;
+    }
+    throw std::logic_error("causal_conv1d: unhandled split geometry");
+}
+
+template <std::int32_t Rows0, std::int32_t Rows1, std::int32_t Rows2>
+void prefill_split_launch(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                          Tensor& conv_state_out, Tensor& out0, Tensor& out1, Tensor& out2,
+                          cudaStream_t stream) {
+    static_assert((Rows0 % 2) == 0 && (Rows1 % 2) == 0 && (Rows2 % 2) == 0,
+                  "a pair must not straddle two destinations");
+    constexpr int kChannelBlock = 256;
+    constexpr int kPairBlock    = 256;
+    const std::int32_t C        = x.ne[0];
+    const std::int32_t T        = x.ne[1];
+    if (Rows0 + Rows1 + Rows2 != C) {
+        throw std::invalid_argument("causal_conv1d: split geometry does not cover the channels");
+    }
+
+    const CausalConvSplitOutput3<__nv_bfloat162, Rows0 / 2, Rows1 / 2, Rows2 / 2> out_map{
+        reinterpret_cast<__nv_bfloat162*>(out0.data), reinterpret_cast<__nv_bfloat162*>(out1.data),
+        reinterpret_cast<__nv_bfloat162*>(out2.data)};
+    causal_conv1d_prefill_pairs_kernel<<<prefill_output_grid_for(C / 2, T, kPairBlock), kPairBlock,
+                                         0, stream>>>(
+        static_cast<const __nv_bfloat16*>(x.data), static_cast<const __nv_bfloat16*>(weight.data),
+        static_cast<const __nv_bfloat16*>(conv_state_in.data), out_map, C, T);
+    CUDA_CHECK(cudaGetLastError());
+
+    causal_conv1d_prefill_state_kernel<<<grid_for(C, kChannelBlock, "prefill state"), kChannelBlock,
+                                         0, stream>>>(
+        static_cast<const __nv_bfloat16*>(x.data),
+        static_cast<const __nv_bfloat16*>(conv_state_in.data),
+        static_cast<__nv_bfloat16*>(conv_state_out.data), C, T);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void causal_conv1d_prefill_split_launch(const Tensor& x, const Tensor& weight,
+                                        const Tensor& conv_state_in, Tensor& conv_state_out,
+                                        Tensor& out0, Tensor& out1, Tensor& out2,
+                                        CausalConvSplitGeometry geometry, cudaStream_t stream) {
+    switch (geometry) {
+    case CausalConvSplitGeometry::Rows2048x2048x4096:
+        prefill_split_launch<2048, 2048, 4096>(x, weight, conv_state_in, conv_state_out, out0, out1,
+                                               out2, stream);
+        return;
+    case CausalConvSplitGeometry::Rows2048x2048x6144:
+        prefill_split_launch<2048, 2048, 6144>(x, weight, conv_state_in, conv_state_out, out0, out1,
+                                               out2, stream);
+        return;
+    }
+    throw std::logic_error("causal_conv1d: unhandled split geometry");
 }
 
 void causal_conv1d_decode_launch(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,

--- a/src/ops/launcher/causal_conv1d.h
+++ b/src/ops/launcher/causal_conv1d.h
@@ -10,17 +10,28 @@
 
 namespace ninfer::ops::detail {
 
-inline constexpr std::int32_t kCausalConvSequenceMaxTokens = 64;
-inline constexpr std::int32_t kCausalConvParallelMaxTokens = 16;
+// Registered split partitions, named by their row profile. The wrapper resolves one of these from
+// the destination row counts and refuses anything else.
+enum class CausalConvSplitGeometry {
+    Rows2048x2048x4096,
+    Rows2048x2048x6144,
+};
+
+inline constexpr std::int32_t kCausalConvParallelMaxTokens = 32;
 
 void causal_conv1d_prefill_launch(const Tensor& x, const Tensor& weight,
                                   const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
                                   cudaStream_t stream);
-void causal_conv1d_sequence_launch(const Tensor& x, const Tensor& weight,
-                                   const Tensor& conv_state_in, Tensor& conv_state_out, Tensor& out,
-                                   cudaStream_t stream);
+void causal_conv1d_prefill_split_launch(const Tensor& x, const Tensor& weight,
+                                        const Tensor& conv_state_in, Tensor& conv_state_out,
+                                        Tensor& out0, Tensor& out1, Tensor& out2,
+                                        CausalConvSplitGeometry geometry, cudaStream_t stream);
 void causal_conv1d_smallt_launch(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
                                  Tensor& conv_state_out, Tensor& out, cudaStream_t stream);
+void causal_conv1d_smallt_split_launch(const Tensor& x, const Tensor& weight,
+                                       const Tensor& conv_state_in, Tensor& conv_state_out,
+                                       Tensor& out0, Tensor& out1, Tensor& out2,
+                                       CausalConvSplitGeometry geometry, cudaStream_t stream);
 void causal_conv1d_decode_launch(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
                                  Tensor& conv_state_out, Tensor& out, cudaStream_t stream);
 void causal_conv1d_snapshot_launch(const Tensor& x, const Tensor& weight, Tensor& conv_states,

--- a/src/ops/wrapper/causal_conv1d_silu.cpp
+++ b/src/ops/wrapper/causal_conv1d_silu.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace ninfer::ops {
 namespace {
@@ -129,6 +130,111 @@ void require_metadata_accessible(const Tensor& metadata, const char* label) {
     }
 }
 
+bool overlaps(const Tensor& lhs, const Tensor& rhs) {
+    const auto lhs_begin = reinterpret_cast<std::uintptr_t>(lhs.data);
+    const auto rhs_begin = reinterpret_cast<std::uintptr_t>(rhs.data);
+    return lhs_begin < rhs_begin + rhs.bytes() && rhs_begin < lhs_begin + lhs.bytes();
+}
+
+void require_accessible(const Tensor& tensor, const char* label) {
+    if (!tensor.is_contiguous()) {
+        throw std::invalid_argument(std::string("causal_conv1d: ") + label + " must be contiguous");
+    }
+    if (tensor.data == nullptr) {
+        throw std::invalid_argument(std::string("causal_conv1d: ") + label +
+                                    " data pointer must be non-null");
+    }
+}
+
+detail::CausalConvSplitGeometry resolve_split_geometry(const Tensor& x, const Tensor& out0,
+                                                       const Tensor& out1, const Tensor& out2) {
+    if (out0.dtype != DType::BF16 || out1.dtype != DType::BF16 || out2.dtype != DType::BF16) {
+        throw std::invalid_argument("causal_conv1d: split destinations must be BF16");
+    }
+    if (out0.ne[2] != 1 || out0.ne[3] != 1 || out1.ne[2] != 1 || out1.ne[3] != 1 ||
+        out2.ne[2] != 1 || out2.ne[3] != 1) {
+        throw std::invalid_argument("causal_conv1d: split destinations must be rank-2");
+    }
+    if (out0.ne[1] != x.ne[1] || out1.ne[1] != x.ne[1] || out2.ne[1] != x.ne[1]) {
+        throw std::invalid_argument("causal_conv1d: split destinations must match the x column "
+                                    "count");
+    }
+    if (x.ne[0] == 8192 && out0.ne[0] == 2048 && out1.ne[0] == 2048 && out2.ne[0] == 4096) {
+        return detail::CausalConvSplitGeometry::Rows2048x2048x4096;
+    }
+    if (x.ne[0] == 10240 && out0.ne[0] == 2048 && out1.ne[0] == 2048 && out2.ne[0] == 6144) {
+        return detail::CausalConvSplitGeometry::Rows2048x2048x6144;
+    }
+    throw std::invalid_argument("causal_conv1d: split received an unregistered row profile");
+}
+
+// The prefill split route reads and writes __nv_bfloat162. The requirement is stated uniformly for
+// the entry rather than per route, so a caller does not have to know which route its column count
+// selects.
+void require_pair_aligned(const Tensor& tensor, const char* label) {
+    constexpr std::uintptr_t kPairBytes = 4; // one BF16 pair
+    const auto address                  = reinterpret_cast<std::uintptr_t>(tensor.data);
+    if ((address & (kPairBytes - 1)) != 0) {
+        throw std::invalid_argument(std::string("causal_conv1d: ") + label +
+                                    " must be four-byte aligned");
+    }
+}
+
+// The contract allows the two state arguments to be disjoint or exactly the same storage, and
+// nothing in between: every route either reads a state element before publishing it from another
+// thread, or declares both pointers restrict.
+void require_state_alias_rule(const Tensor& conv_state_in, const Tensor& conv_state_out) {
+    if (conv_state_in.data == conv_state_out.data) { return; }
+    if (overlaps(conv_state_in, conv_state_out)) {
+        throw std::invalid_argument("causal_conv1d: conv_state_in and conv_state_out must be "
+                                    "disjoint or exactly the same storage");
+    }
+}
+
+void require_packed_nonoverlap(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                               const Tensor& conv_state_out, const Tensor& out) {
+    const Tensor* const written[2] = {&out, &conv_state_out};
+    const Tensor* const others[3]  = {&x, &weight, &conv_state_in};
+    for (const Tensor* target : written) {
+        for (const Tensor* other : others) {
+            // The state pair is governed by require_state_alias_rule, which admits an exact alias.
+            if (target == &conv_state_out && other == &conv_state_in) { continue; }
+            if (overlaps(*target, *other)) {
+                throw std::invalid_argument(
+                    "causal_conv1d: out and conv_state_out must not overlap x, weight, or "
+                    "conv_state_in");
+            }
+        }
+    }
+    if (overlaps(out, conv_state_out)) {
+        throw std::invalid_argument("causal_conv1d: out must not overlap conv_state_out");
+    }
+}
+
+void require_split_nonoverlap(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                              const Tensor& conv_state_out, const Tensor& out0, const Tensor& out1,
+                              const Tensor& out2) {
+    const Tensor* const writes[4] = {&out0, &out1, &out2, &conv_state_out};
+    const Tensor* const others[4] = {&x, &weight, &conv_state_in, &conv_state_out};
+    for (int i = 0; i < 4; ++i) {
+        for (int j = i + 1; j < 3; ++j) {
+            if (overlaps(*writes[i], *writes[j])) {
+                throw std::invalid_argument(
+                    "causal_conv1d: split destinations must not overlap each other");
+            }
+        }
+        for (const Tensor* other : others) {
+            // The state pair is governed by require_state_alias_rule, which admits an exact alias.
+            if (writes[i] == &conv_state_out && other == &conv_state_in) { continue; }
+            if (writes[i] == other) { continue; }
+            if (overlaps(*writes[i], *other)) {
+                throw std::invalid_argument(
+                    "causal_conv1d: split destinations must not overlap x, weight, or the state");
+            }
+        }
+    }
+}
+
 } // namespace
 
 void causal_conv1d_silu(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
@@ -157,15 +263,62 @@ void causal_conv1d_silu(const Tensor& x, const Tensor& weight, const Tensor& con
         throw std::invalid_argument(
             "causal_conv1d: conv_state_out must be contiguous and non-null");
     }
+    require_state_alias_rule(conv_state_in, conv_state_out);
+    require_packed_nonoverlap(x, weight, conv_state_in, conv_state_out, out);
     if (x.ne[1] == 1) {
         detail::causal_conv1d_decode_launch(x, weight, conv_state_in, conv_state_out, out, stream);
     } else if (x.ne[1] <= detail::kCausalConvParallelMaxTokens) {
         detail::causal_conv1d_smallt_launch(x, weight, conv_state_in, conv_state_out, out, stream);
-    } else if (x.ne[1] <= detail::kCausalConvSequenceMaxTokens) {
-        detail::causal_conv1d_sequence_launch(x, weight, conv_state_in, conv_state_out, out,
-                                              stream);
     } else {
         detail::causal_conv1d_prefill_launch(x, weight, conv_state_in, conv_state_out, out, stream);
+    }
+}
+
+void causal_conv1d_silu_split(const Tensor& x, const Tensor& weight, const Tensor& conv_state_in,
+                              Tensor& conv_state_out, Tensor& out0, Tensor& out1, Tensor& out2,
+                              cudaStream_t stream) {
+    if (x.dtype != DType::BF16 || weight.dtype != DType::BF16 ||
+        conv_state_in.dtype != DType::BF16 || conv_state_out.dtype != DType::BF16) {
+        throw std::invalid_argument("causal_conv1d: x/weight/conv_state must be BF16");
+    }
+    require_x_shape(x);
+    require_weight_shape(weight, x.ne[0]);
+    require_state_shape(conv_state_in, x.ne[0]);
+    require_state_shape(conv_state_out, x.ne[0]);
+    const detail::CausalConvSplitGeometry geometry = resolve_split_geometry(x, out0, out1, out2);
+
+    const std::int64_t n = numel_allow_zero(x, "x");
+    (void)numel_allow_zero(weight, "weight");
+    (void)numel_allow_zero(conv_state_in, "conv_state_in");
+    (void)numel_allow_zero(conv_state_out, "conv_state_out");
+    (void)numel_allow_zero(out0, "out0");
+    (void)numel_allow_zero(out1, "out1");
+    (void)numel_allow_zero(out2, "out2");
+    if (n == 0) { return; }
+
+    const std::pair<const Tensor*, const char*> operands[7] = {{&x, "x"},
+                                                               {&weight, "weight"},
+                                                               {&conv_state_in, "conv_state_in"},
+                                                               {&conv_state_out, "conv_state_out"},
+                                                               {&out0, "out0"},
+                                                               {&out1, "out1"},
+                                                               {&out2, "out2"}};
+    for (const auto& operand : operands) {
+        require_accessible(*operand.first, operand.second);
+        require_pair_aligned(*operand.first, operand.second);
+    }
+    require_state_alias_rule(conv_state_in, conv_state_out);
+    require_split_nonoverlap(x, weight, conv_state_in, conv_state_out, out0, out1, out2);
+
+    // Two routes, chosen by measurement. The small-T kernel launches one block of kChannelTile by T
+    // threads, so it holds two CTAs per SM to T = 24 and one above that; even at its ceiling of 32
+    // it beats the prefill pair, which is flat above it.
+    if (x.ne[1] <= detail::kCausalConvParallelMaxTokens) {
+        detail::causal_conv1d_smallt_split_launch(x, weight, conv_state_in, conv_state_out, out0,
+                                                  out1, out2, geometry, stream);
+    } else {
+        detail::causal_conv1d_prefill_split_launch(x, weight, conv_state_in, conv_state_out, out0,
+                                                   out1, out2, geometry, stream);
     }
 }
 
@@ -175,12 +328,11 @@ void causal_conv1d_silu(const Tensor& x, const Tensor& weight, Tensor& conv_stat
     if (n == 0) { return; }
 
     require_non_empty_accessible(x, weight, conv_state, out);
+    require_packed_nonoverlap(x, weight, conv_state, conv_state, out);
     if (x.ne[1] == 1) {
         detail::causal_conv1d_decode_launch(x, weight, conv_state, conv_state, out, stream);
     } else if (x.ne[1] <= detail::kCausalConvParallelMaxTokens) {
         detail::causal_conv1d_smallt_launch(x, weight, conv_state, conv_state, out, stream);
-    } else if (x.ne[1] <= detail::kCausalConvSequenceMaxTokens) {
-        detail::causal_conv1d_sequence_launch(x, weight, conv_state, conv_state, out, stream);
     } else {
         detail::causal_conv1d_prefill_launch(x, weight, conv_state, conv_state, out, stream);
     }

--- a/src/targets/qwen3_6/impl/runtime/text_context_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_context_impl.h
@@ -923,18 +923,13 @@ void TextContext::gdn_mix(const GdnLayerW& w, Tensor& x, int gidx, Phase ph) {
                 query_output, key_output, value_output, gate_output, ph, work_, s);
         }
     } else {
-        const auto conv = workspace_recipe::gdn_prefill_conv<TextConfig>(work_, T);
-        Tensor qkv      = conv.projected;
+        Tensor qkv = workspace_recipe::gdn_prefill_conv<TextConfig>(work_, T);
         Variant::gdn_input_projection(h, *w.projection, qkv, z, ph, work_, s);
-        Tensor qkv_c = conv.convolved;
         Tensor conv_state_in =
             state_.conv_slot(static_cast<std::uint32_t>(gidx), linear_state_source_slot_);
         Tensor conv_state_out =
             state_.conv_slot(static_cast<std::uint32_t>(gidx), linear_state_destination_slot_);
-        ops::causal_conv1d_silu(qkv, *w.conv1d, conv_state_in, conv_state_out, qkv_c, s);
-        ops::extract_bf16_columns(qkv_c, 0, qc, s);
-        ops::extract_bf16_columns(qkv_c, kCfg.key_dim, kc, s);
-        ops::extract_bf16_columns(qkv_c, 2 * kCfg.key_dim, vc, s);
+        ops::causal_conv1d_silu_split(qkv, *w.conv1d, conv_state_in, conv_state_out, qc, kc, vc, s);
     }
 
     Tensor q_recurrent = qc.view({kCfg.gdn_k_dim, kCfg.gdn_k_heads, T});

--- a/src/targets/qwen3_6/impl/runtime/workspace_recipe.h
+++ b/src/targets/qwen3_6/impl/runtime/workspace_recipe.h
@@ -113,17 +113,9 @@ GdnProjectionRoots gdn_projection(Allocator& allocator, std::int32_t tokens) {
     };
 }
 
-struct GdnPrefillConvRoots {
-    Tensor projected;
-    Tensor convolved;
-};
-
 template <class Config, class Allocator>
-GdnPrefillConvRoots gdn_prefill_conv(Allocator& allocator, std::int32_t tokens) {
-    return {
-        matrix(allocator, DType::BF16, Config::convolution_dim, tokens),
-        matrix(allocator, DType::BF16, Config::convolution_dim, tokens),
-    };
+Tensor gdn_prefill_conv(Allocator& allocator, std::int32_t tokens) {
+    return matrix(allocator, DType::BF16, Config::convolution_dim, tokens);
 }
 
 template <class Config, class Allocator>

--- a/tests/ops/test_causal_conv1d_silu.cpp
+++ b/tests/ops/test_causal_conv1d_silu.cpp
@@ -1,11 +1,14 @@
 #include "ninfer/ops/causal_conv1d_silu.h"
 #include "ops/op_tester.h"
 
+#include <cuda_runtime.h>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <stdexcept>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -158,6 +161,232 @@ const char* call_name(StateCall call) {
         return "distinct-entry-exact-alias";
     }
     return "unknown";
+}
+
+// Slice one channel range out of the oracle's packed [column][channel] output.
+std::vector<double> oracle_slice(const std::vector<double>& packed, std::int32_t C, std::int32_t T,
+                                 std::int32_t first, std::int32_t rows) {
+    std::vector<double> slice(static_cast<std::size_t>(rows) * static_cast<std::size_t>(T));
+    for (std::int32_t column = 0; column < T; ++column) {
+        for (std::int32_t row = 0; row < rows; ++row) {
+            slice[offset(row, column, rows)] = packed[offset(first + row, column, C)];
+        }
+    }
+    return slice;
+}
+
+// The packed distinct-state entry enforces the same family rules the split entry does. One case
+// per rule it gained.
+int packed_rejection_case(std::int32_t T) {
+    constexpr std::int32_t C = 8192;
+    const std::size_t n      = static_cast<std::size_t>(C) * static_cast<std::size_t>(T);
+    GuardedDeviceBuffer x(n * sizeof(std::uint16_t));
+    GuardedDeviceBuffer weight(static_cast<std::size_t>(C) * 4 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_in(static_cast<std::size_t>(C) * 3 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_out(static_cast<std::size_t>(C) * 3 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer out(n * sizeof(std::uint16_t));
+
+    const Tensor tx(x.data(), DType::BF16, {C, T});
+    const Tensor tw(weight.data(), DType::BF16, {C, 4});
+    const Tensor tsi(state_in.data(), DType::BF16, {C, 3});
+
+    auto is_rejected = [&](const Tensor& state_in_arg, Tensor state_out_arg, Tensor out_arg) {
+        try {
+            ops::causal_conv1d_silu(tx, tw, state_in_arg, state_out_arg, out_arg, nullptr);
+        } catch (const std::invalid_argument&) { return true; }
+        cuda_synchronize();
+        return false;
+    };
+
+    int failures         = 0;
+    auto expect_rejected = [&](bool rejected, const char* what) {
+        if (!rejected) {
+            std::cout << "FAIL causal_conv1d_silu T=" << T << " accepted " << what << '\n';
+            ++failures;
+        }
+    };
+    Tensor tso(state_out.data(), DType::BF16, {C, 3});
+    Tensor tout(out.data(), DType::BF16, {C, T});
+    Tensor out_over_x(x.data(), DType::BF16, {C, T});
+    Tensor shifted_state_out(static_cast<std::uint16_t*>(state_in.data()) + 2, DType::BF16, {C, 3});
+
+    expect_rejected(is_rejected(tsi, shifted_state_out, tout),
+                    "a state pair that overlaps without being the same storage");
+    expect_rejected(is_rejected(tsi, tso, out_over_x), "an out that overlaps x");
+    expect_rejected(is_rejected(tsi, tout, tout), "an out that overlaps conv_state_out");
+    return failures;
+}
+
+// The entry promises that a bad argument is rejected the same way whatever the column count.
+// One case per rejected class, on both sides of the route bound.
+int split_rejection_case(std::int32_t T) {
+    constexpr std::int32_t C  = 8192;
+    constexpr std::int32_t KD = 2048;
+    constexpr std::int32_t VD = 4096;
+    const std::size_t n       = static_cast<std::size_t>(C) * static_cast<std::size_t>(T);
+    GuardedDeviceBuffer x(n * sizeof(std::uint16_t));
+    GuardedDeviceBuffer weight(static_cast<std::size_t>(C) * 4 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_in(static_cast<std::size_t>(C) * 3 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_out(static_cast<std::size_t>(C) * 3 * sizeof(std::uint16_t));
+    GuardedDeviceBuffer q(static_cast<std::size_t>(KD) * T * sizeof(std::uint16_t));
+    GuardedDeviceBuffer k(static_cast<std::size_t>(KD) * T * sizeof(std::uint16_t));
+    GuardedDeviceBuffer v(static_cast<std::size_t>(VD) * T * sizeof(std::uint16_t));
+
+    const Tensor tx(x.data(), DType::BF16, {C, T});
+    const Tensor tw(weight.data(), DType::BF16, {C, 4});
+    const Tensor tsi(state_in.data(), DType::BF16, {C, 3});
+    Tensor tq(q.data(), DType::BF16, {KD, T});
+    Tensor tk(k.data(), DType::BF16, {KD, T});
+    Tensor tv(v.data(), DType::BF16, {VD, T});
+
+    const Tensor bad_null(nullptr, DType::BF16, {C, T});
+    const Tensor bad_dtype(weight.data(), DType::FP32, {C, 4});
+    Tensor bad_rank(q.data(), DType::BF16, {KD, T, 2});
+    Tensor bad_profile(q.data(), DType::BF16, {KD + 1, T});
+    Tensor other_profile(v.data(), DType::BF16, {6144, T});
+    Tensor bad_dest_dtype(q.data(), DType::FP32, {KD, T});
+    Tensor null_dest(nullptr, DType::BF16, {KD, T});
+    Tensor short_dest(q.data(), DType::BF16, {KD, T - 1});
+    Tensor over_x(x.data(), DType::BF16, {KD, T});
+    Tensor over_state(state_in.data(), DType::BF16, {KD, T});
+    Tensor misaligned(static_cast<std::uint16_t*>(q.data()) + 1, DType::BF16, {KD, T});
+
+    auto is_rejected = [&](const Tensor& x_in, const Tensor& weight_in, const Tensor& state_in_arg,
+                           Tensor state_out_arg, Tensor q_in, Tensor k_in, Tensor v_in) {
+        try {
+            ops::causal_conv1d_silu_split(x_in, weight_in, state_in_arg, state_out_arg, q_in, k_in,
+                                          v_in, nullptr);
+        } catch (const std::invalid_argument&) { return true; }
+        cuda_synchronize();
+        return false;
+    };
+    Tensor tso(state_out.data(), DType::BF16, {C, 3});
+    // A state pair that shares all but one element: the contract allows disjoint or exactly the
+    // same storage, and this is neither.
+    Tensor shifted_state_out(static_cast<std::uint16_t*>(state_in.data()) + 2, DType::BF16, {C, 3});
+
+    int failures = 0;
+    auto expect_rejected = [&](bool rejected, const char* what) {
+        if (!rejected) {
+            std::cout << "FAIL causal_conv1d_silu_split T=" << T << " accepted " << what << "\n";
+            ++failures;
+        }
+    };
+    expect_rejected(is_rejected(bad_null, tw, tsi, tso, tq, tk, tv), "a null x");
+    expect_rejected(is_rejected(tx, bad_dtype, tsi, tso, tq, tk, tv), "an FP32 weight");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, bad_rank, tk, tv), "a rank-3 destination");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, bad_profile, tk, tv),
+                    "a row profile that is not registered");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, tq, tk, other_profile),
+                    "the other geometry's row profile on these channels");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, bad_dest_dtype, tk, tv), "an FP32 destination");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, null_dest, tk, tv), "a null destination");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, short_dest, tk, tv),
+                    "a destination with fewer columns than x");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, tq, tq, tv),
+                    "two destinations in the same storage");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, over_x, tk, tv), "a destination overlapping x");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, over_state, tk, tv),
+                    "a destination overlapping the input state");
+    expect_rejected(is_rejected(tx, tw, tsi, tso, misaligned, tk, tv),
+                    "a destination that is not four-byte aligned");
+    expect_rejected(is_rejected(tx, tw, tsi, shifted_state_out, tq, tk, tv),
+                    "a state pair that overlaps without being the same storage");
+    return failures;
+}
+
+// One registered geometry, one column count, one state form. `offset_pairs` shifts every
+// destination by one BF16 pair, which the contract admits and the arena never produces.
+int split_case(std::int32_t C, std::int32_t q_dim, std::int32_t k_dim, std::int32_t value_dim,
+               std::int32_t T, bool alias_state, bool offset_pairs, std::uint32_t seed) {
+    const LogicalInput input       = make_input(C, T, seed);
+    const std::vector<float> state = make_state(C, seed + 2U);
+    const OracleResult oracle      = causal_conv_oracle(input.x, input.weight, state, C, T, false);
+    const std::vector<std::uint16_t> x_bits      = bf16_bits(input.x);
+    const std::vector<std::uint16_t> weight_bits = bf16_bits(input.weight);
+    const std::vector<std::uint16_t> state_bits  = bf16_bits(state);
+    const std::vector<std::uint16_t> final_bits  = bf16_bits(oracle.final_state);
+
+    const std::size_t pad     = offset_pairs ? 2U * sizeof(std::uint16_t) : 0U;
+    const std::size_t q_bytes = static_cast<std::size_t>(q_dim) * T * sizeof(std::uint16_t);
+    const std::size_t k_bytes = static_cast<std::size_t>(k_dim) * T * sizeof(std::uint16_t);
+    const std::size_t v_bytes = static_cast<std::size_t>(value_dim) * T * sizeof(std::uint16_t);
+
+    GuardedDeviceBuffer x(x_bits.size() * sizeof(std::uint16_t));
+    GuardedDeviceBuffer weight(weight_bits.size() * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_in(state_bits.size() * sizeof(std::uint16_t));
+    GuardedDeviceBuffer state_out(state_bits.size() * sizeof(std::uint16_t));
+    GuardedDeviceBuffer q(q_bytes + pad);
+    GuardedDeviceBuffer k(k_bytes + pad);
+    GuardedDeviceBuffer v(v_bytes + pad);
+
+    x.copy_from_host(x_bits.data(), x.bytes());
+    weight.copy_from_host(weight_bits.data(), weight.bytes());
+    state_in.copy_from_host(state_bits.data(), state_in.bytes());
+    state_out.fill(0x5a);
+    q.fill(kOutputPoison);
+    k.fill(kOutputPoison);
+    v.fill(kOutputPoison);
+
+    auto at = [&](GuardedDeviceBuffer& buffer) {
+        return static_cast<void*>(static_cast<char*>(buffer.data()) + pad);
+    };
+    auto pad_is_untouched = [&](GuardedDeviceBuffer& buffer, const char* label) {
+        if (pad == 0) { return 0; }
+        std::vector<std::uint8_t> head(pad);
+        buffer.copy_to_host(head.data(), pad);
+        for (const std::uint8_t byte : head) {
+            if (byte != kOutputPoison) {
+                std::cout << "FAIL causal_conv1d_silu_split wrote before " << label << '\n';
+                return 1;
+            }
+        }
+        return 0;
+    };
+
+    Tensor tx(x.data(), DType::BF16, {C, T});
+    Tensor tw(weight.data(), DType::BF16, {C, 4});
+    Tensor ts_in(state_in.data(), DType::BF16, {C, 3});
+    Tensor ts_out((alias_state ? state_in : state_out).data(), DType::BF16, {C, 3});
+    Tensor tq(at(q), DType::BF16, {q_dim, T});
+    Tensor tk(at(k), DType::BF16, {k_dim, T});
+    Tensor tv(at(v), DType::BF16, {value_dim, T});
+
+    ops::causal_conv1d_silu_split(tx, tw, ts_in, ts_out, tq, tk, tv, nullptr);
+    cuda_synchronize();
+
+    const std::string tag     = "causal_conv1d_silu_split C=" + std::to_string(C) +
+                                " T=" + std::to_string(T) + (alias_state ? " alias" : "") +
+                                (offset_pairs ? " offset" : "");
+    const std::size_t q_count = static_cast<std::size_t>(q_dim) * static_cast<std::size_t>(T);
+    const std::size_t k_count = static_cast<std::size_t>(k_dim) * static_cast<std::size_t>(T);
+    const std::size_t v_count = static_cast<std::size_t>(value_dim) * static_cast<std::size_t>(T);
+
+    int failures = 0;
+    failures += pad_is_untouched(q, "out0");
+    failures += pad_is_untouched(k, "out1");
+    failures += pad_is_untouched(v, "out2");
+    failures += verify_output(tag + " q", from_device_bf16(at(q), q_count),
+                              oracle_slice(oracle.output, C, T, 0, q_dim));
+    failures += verify_output(tag + " k", from_device_bf16(at(k), k_count),
+                              oracle_slice(oracle.output, C, T, q_dim, k_dim));
+    failures += verify_output(tag + " v", from_device_bf16(at(v), v_count),
+                              oracle_slice(oracle.output, C, T, q_dim + k_dim, value_dim));
+    failures +=
+        verify_bits(tag + " final state", (alias_state ? state_in : state_out).data(), final_bits);
+    failures += verify_bits(tag + " x preserved", x.data(), x_bits);
+    failures += verify_bits(tag + " weight preserved", weight.data(), weight_bits);
+    if (!alias_state) {
+        failures += verify_bits(tag + " initial state preserved", state_in.data(), state_bits);
+    }
+    failures += verify_buffer_guards(tag + " x", x);
+    failures += verify_buffer_guards(tag + " weight", weight);
+    failures += verify_buffer_guards(tag + " state input", state_in);
+    failures += verify_buffer_guards(tag + " state output", state_out);
+    failures += verify_buffer_guards(tag + " q", q);
+    failures += verify_buffer_guards(tag + " k", k);
+    failures += verify_buffer_guards(tag + " v", v);
+    return failures;
 }
 
 int ordinary_case(std::int32_t C, std::int32_t T, StateCall call, std::uint32_t seed) {
@@ -502,6 +731,8 @@ int main() {
     failures += snapshot_case(kQwen27Channels, 15, 18, 14, 1, 4015U);
     failures += snapshot_case(kQwen27Channels, 16, 18, 17, 1, 4016U);
     failures += snapshot_case(kQwen35Channels, 17, 20, 16, 1, 4017U);
+    // Above the small-T bound the snapshot entry takes the sequence-snapshot kernel.
+    failures += snapshot_case(kQwen35Channels, 40, 44, 40, 1, 4040U);
 
     failures += batched_snapshot_case(kQwen35Channels, 1, {8, 9, 10, 11, 12, 13, 14, 15},
                                       {0, 1, 2, 3, 4, 5, 6, 7}, {}, 16, 5001U);
@@ -510,6 +741,38 @@ int main() {
     // Row 0 reads slot 15 and overwrites it only after the final valid column. This is the
     // production same-row alias pattern; row 1 remains fully disjoint.
     failures += batched_snapshot_case(kQwen35Channels, 16, {15, 33}, {0, 16}, {16, 7}, 34, 5016U);
+
+    // The split entry: both channel geometries, across the column counts that select each of its
+    // two routes and the boundary between them.
+    for (const std::int32_t T : {1, 2, 7, 15, 16, 17, 32, 33, 63, 64, 65, 257, 1024}) {
+        failures += split_case(kQwen27Channels, 2048, 2048, 6144, T, false, false,
+                               6000U + static_cast<std::uint32_t>(T));
+        failures += split_case(kQwen35Channels, 2048, 2048, 4096, T, false, false,
+                               7000U + static_cast<std::uint32_t>(T));
+    }
+
+    // The exact-alias state form, on both geometries, across every route boundary.
+    for (const std::int32_t T : {1, 2, 15, 16, 17, 32, 33, 64, 65, 257}) {
+        failures += split_case(kQwen27Channels, 2048, 2048, 6144, T, true, false,
+                               6100U + static_cast<std::uint32_t>(T));
+        failures += split_case(kQwen35Channels, 2048, 2048, 4096, T, true, false,
+                               7100U + static_cast<std::uint32_t>(T));
+    }
+
+    // Destinations offset by a pair: four-byte aligned, which the contract admits, but not the
+    // 256-byte alignment the arena happens to give.
+    for (const std::int32_t T : {16, 33, 257}) {
+        failures += split_case(kQwen27Channels, 2048, 2048, 6144, T, false, true,
+                               6200U + static_cast<std::uint32_t>(T));
+        failures += split_case(kQwen35Channels, 2048, 2048, 4096, T, false, true,
+                               7200U + static_cast<std::uint32_t>(T));
+    }
+
+    // Argument rejection, on both sides of the route bound.
+    failures += split_rejection_case(16);
+    failures += split_rejection_case(128);
+    failures += packed_rejection_case(16);
+    failures += packed_rejection_case(128);
 
     std::cout << (failures == 0 ? "OK" : "FAIL") << " causal_conv1d_silu\n";
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
The chunked GDN prefill convolved into one packed `[C,T]` buffer and then pulled q, k and v out of
it with three `cudaMemcpy2DAsync` per layer per chunk. The convolution already knows which channel
each thread owns, so it can address the destination directly. `causal_conv1d_silu_split` does that.

Rebased onto `6e8b2e2a` and squashed to one commit. This description replaces the original one. The
four review points are answered below; the second one turned up a route-selection problem in the
shared part of this Op that the same measurement had to resolve.

## Scope

This PR predates the issue-first rule in `CONTRIBUTING.md`. Its problem and direction were
established in your review rather than in an Issue; if you would rather it be re-filed as an Issue
first, say so and I will close this and open one.

One decision: the convolution writes its three destinations instead of writing one plane that is
then copied three ways. Everything in the diff belongs to that decision, including the route
selection, which is the route table of this Op.

## 1. Compile-time geometry

`CausalConvSplitOutput3` now carries the partition in the type, following `w8_rowsplit_output.cuh`:

```cpp
template <class Element, std::int32_t Rows0, std::int32_t Rows1, std::int32_t Rows2>
struct CausalConvSplitOutput3 {
    Element* __restrict__ out0;
    Element* __restrict__ out1;
    Element* __restrict__ out2;
    __device__ __forceinline__ CausalConvOutputColumn<Element> column(std::int64_t row) const;
};
```

The struct holds only pointers; the boundaries and the three leading dimensions are constants inside
`column()`. The pointers carry `__restrict__` to record what the split entry proves - though I should
say that it buys nothing today: `column()` hands back a plain pointer, and the SASS is identical
instruction for instruction with and without the qualifier. `CausalConvContiguousOutput` keeps a
plain pointer and a runtime leading dimension: one destination admits any row count, and the packed
entries do not prove their destination disjoint from `x`.

The wrapper resolves `(x.ne[0], out0.ne[0], out1.ne[0], out2.ne[0])` to one of the two registered
profiles and throws otherwise, so dispatch stays where `op-development.md` section 4.1 puts it. Each
launcher takes the resolved tag, asserts that the geometry covers the channel extent it was handed,
and instantiates one kernel.

Two narrowings follow, both stated in `include/ninfer/ops/causal_conv1d_silu.h`. The partition
parity the paired route used to test at runtime is a `static_assert`. And the entry requires
four-byte aligned operands, which deletes the scalar split instantiation; the requirement is stated
for the entry rather than per route so a caller need not know which route its column count selects.
That alignment narrowing goes past what the review asked for - it buys one instantiation and one
host branch, and it is unobservable to the caller, whose tensors come off a 256-byte-aligned arena.

## 2. Route selection, measured

Both registered geometries, `T = 1..72`, cold L2, one process, median of 40:

```bash
./build/bench/ninfer_causal_conv1d_silu_bench --split --cache cold --channels 8192  --tokens $(seq -s, 1 72)
./build/bench/ninfer_causal_conv1d_silu_bench --split --cache cold --channels 10240 --tokens $(seq -s, 1 72)
```

**On `T == 1` the answer is no.** On this commit, cold: the split entry measures 4.13 us, the
dedicated decode kernel 4.10, and a same-byte device copy of the same bytes 4.10. All three sit at
the launch floor of this harness, so there is nothing for a split decode route to recover, and none
was added.

**The interval above the small-T bound was the finding.** The `sequence` route, which both entries
selected for `17 <= T <= 64`, measured 12.29 us at `T = 17` and 28.67 us at `T = 64`, while the
`prefill` route it handed over to at `T = 65` measured 8.19 us for strictly more work. Separately,
the small-T kernel had never been measured above its bound of 16, although it launches to 32
(`kCausalConvChannelTile` x T threads, capped at 1024). It does step there - its block is 32 x T, so
it holds two CTAs per SM to `T = 24` and one above - but even at its ceiling it stays under the
prefill route.

So the route table is now small-T to 32 and prefill above, and the sequence kernel, its launcher,
its declaration and `kCausalConvSequenceMaxTokens` are removed rather than bypassed - its only call
sites were the two entries above, and nothing else in the tree used them.

| T | before | after | |
|---:|---:|---:|---:|
| 17 | 12.29 us | 6.11 | x2.01 |
| 32 | 16.38 | 6.11 | **x2.68** |
| 48 | 22.53 | 8.22 | x2.74 |
| 64 | 28.67 | 8.19 | **x3.50** |

`C = 10240` is the same shape. Cold medians in this region land on a roughly 2 us grid, so read the
small-T numbers as ~4.1 and ~6.1 and the prefill ones as ~8.2; the route finding is three to ten grid
steps and survives that, but single-step differences within one route are not signal. The remaining
seam is `32 -> 33`, ~6.1 to ~8.2 us, and it is the small-T kernel's structural limit rather than a
tuning choice: at `T = 33` its block would need 32 x 33 = 1056 threads.

I took the removal as part of this decision rather than a separate PR because it is the route table
of the same Op and the measurement is the one point 2 asked for. Two consequences reach entries this
PR was not otherwise touching, and neither changes output. The packed entries' dispatch changes the
same way. And moving the small-T bound also moves the snapshot entry's, which reads the same
constant: `T` in 17..32 now takes `causal_conv1d_snapshot_smallt_kernel` instead of
`causal_conv1d_sequence_snapshot_kernel`. Measured on that entry, cold, `C = 8192`: 6.11 us at
`T = 8`, 16, 17 and 24, and 8.16 at 32 - flat across the bound that moved. If you would rather have
the removal separately, I will split it out.

## 3. The stage, not half of it

`--legacy-stage` times what the stage was - one packed convolution into a `[C,T]` plane, then three
`extract_bf16_columns` - against the split entry, in one process under one set of timing conditions:

```bash
./build/bench/ninfer_causal_conv1d_silu_bench --legacy-stage --split --cache cold --channels 8192 \
  --tokens 1,2,4,8,16,17,32,33,48,64,65,128,256,512,1024,2048,4096,8192
```

Speedup of the split entry over that stage, cold, by column count:

| C | 1-16 | 17-64 | 128 | 1024 | 8192 |
|---|---:|---:|---:|---:|---:|
| 8192 | x2.49-2.50 | x1.68-2.01 | x1.60 | x1.73 | x1.74 |
| 10240 | x1.68-2.50 | x1.74-2.01 | x1.79 | x1.78 | x1.75 |

The 10240 band is not homogeneous: its worst point is `T = 16` at x1.68, because that geometry is
already at ~6.1 us from `T = 15` where 8192 is still at ~4.1.

Absolute, `C = 8192`, cold: 10.27 -> 4.10 us at `T = 16`, 53.22 -> 30.75 at 1024, 360.48 -> 206.85 at
8192. Across the whole ladder on both geometries the range is x1.56 to x2.50.

So "the split convolution pays 3.2-5.0%" was measured against the packed convolution alone; against
the stage it replaces it is faster everywhere. The `--legacy-stage` arm is the decision benchmark you
allowed; it is here so you can reproduce the comparison, and I will drop it with the `scatter.h`
include on request.

## 4. Documents, names, state rule

The two model documents are reverted to their `master` text: the mathematics did not change, and
they should not carry a function name or a materialization decision.

The Op parameters are `out0/out1/out2`. For the record, no public header in `include/ninfer/ops/`
uses ordinal names today - `attn_input_proj.h` and `gdn_input_proj.h` name destinations by role - but
those Ops are themselves about q/k/v and this one is a convolution, so I read your point as applying
here specifically.

The state rule is enforced, on both distinct-state entries rather than only the new one:

```cpp
void require_state_alias_rule(const Tensor& conv_state_in, const Tensor& conv_state_out) {
    if (conv_state_in.data == conv_state_out.data) { return; }
    if (overlaps(conv_state_in, conv_state_out)) { throw std::invalid_argument(...); }
}
```

The packed entry had no overlap validation at all, and `causal_conv1d_decode_launch` selects
`causal_conv1d_decode_distinct_kernel` whenever the two pointers differ - a kernel that declares both
state pointers `__restrict__`. A partially overlapping pair was therefore undefined behaviour there.
The packed entry now also enforces the non-overlap the family contract states for `out` and
`conv_state_out`, which the route change made load-bearing: the prefill route publishes state in a
second launch that reads `x`, so an out-of-contract `out == x` call that the removed sequence kernel
happened to tolerate would otherwise corrupt state silently.

## Resources

Workspace peak, read from the engine's own report, 35B-A3B, same prompt on both arms:

| chunk | master | this branch |
|---|---:|---:|
| 8192 | 963.06 MiB | **835.06 MiB** |
| 1024 | 120.38 MiB | **104.38 MiB** |

Exactly `convolution_dim * chunk * 2` in each case - the buffer that no longer exists. No graph node
appears or disappears; prefill is not captured (`src/core/decode_graph.cpp` is the only capture
site). Per-kernel resources, from `cuobjdump --dump-resource-usage` on the two binaries: the split
small-T instantiations match the packed one at 38 registers and 1472 bytes of shared memory, and the
split prefill-pairs instantiations at 38 registers and no shared memory. Templating the packed
prefill kernel on its output map cost it two registers, 28 to 30.

After this change nothing under `src/` calls either packed `causal_conv1d_silu` overload or
`extract_bf16_columns`; their remaining uses are the tests, `bench/ops/gdn_layer_bench.cu`, which
composes the unfused snapshot alternative, and the `--legacy-stage` arm this PR adds. I have not
deleted them - that is a separate decision and I would rather you make it.

## Correctness

```bash
cd build && ctest -j1
```

92 pass, 1 skipped (`27b_load_plan`, no matching artifact on this box), 1 fails.
`ninfer_qwen3_6_27b_prefix_real_test` fails with `Host checkpoint restore changed greedy output:
restored=64,1248, baseline=64,56127, restored_spec=0/0/0/1 baseline_spec=0/0/0/1 reused=305
transfers=1/1/3/3` - identical on three consecutive runs of this commit. Unmodified `master` rebuilt
here fails with the same line, character for character; that comparison was run on `9dbc0740` and
`6e8b2e2a` during earlier work rather than on this commit, which changes nothing it touches. Both
arms of the test's own comparison run in one process on one artifact, so it is not an artifact or an
environment effect. I will report it separately.

The Op suite covers both registered geometries at `T = 1, 2, 7, 15, 16, 17, 32, 63, 64, 65, 257,
1024`, the exact-alias state form on both at `T = 1, 2, 15, 16, 17, 32, 33, 64, 65, 257`,
destinations offset by one pair
(four-byte aligned, which the contract admits, but not the 256-byte alignment the arena gives), and
thirteen rejection classes: a null `x`, an FP32 weight, a rank-3 destination, an unregistered row
profile, the other geometry's profile on these channels, an FP32 destination, a null destination, a
short column count, two destinations in one buffer, a destination overlapping `x`, a destination
overlapping the input state, a destination that is not four-byte aligned, and a state pair that
overlaps without being the same storage.

End to end on 35B-A3B, three rounds, arms alternating inside each round, greedy: prefill **+1.34%**
at 8,515 tokens, **+0.93%** at 33,031, **+0.76%** at 33,031 with chunk 1024. All nine generations
byte-identical to master.

## Checks not run

- No `ncu` counters: `RmProfilingAdminOnly` is set on this host. Kernel-level claims come from the Op
  benchmark and `cuobjdump`, not hardware counters.
- Qwen3.8-27B NVFP4 was not re-measured end to end on this rework. It reaches the 10240 geometry
  through the same entry and the Op benchmark covers that geometry, but the end-to-end rows are 35B
  only.
- The route removal is qualified by the Op suite and the end-to-end gate. I did not run the serve
  corpus.

RTX 5090, sm_120a, driver 580.105.08, CUDA 13.1.115, Release, `-DCMAKE_CUDA_ARCHITECTURES=120a`.
Base is `6e8b2e2a`.
