### PR TITLE
fix(serve): repair invalid backslash escapes in typed tool-call parameters

### DIFF
--- a/src/serve/tool_call_parser.cpp
+++ b/src/serve/tool_call_parser.cpp
@@ -162,6 +162,45 @@ std::string_view remove_parameter_framing_newlines(std::string_view text) {
     return text.substr(begin, end - begin);
 }
 
+// Best-effort repair for a common Qwen tool-call quirk: a strictly-typed
+// (array/object/number/...) parameter value that is otherwise well-formed
+// JSON except for a backslash the model didn't double for JSON string
+// escaping -- e.g. a shell/regex "\*" or "\|" embedded verbatim inside a
+// command string argument (legal in the shell command itself, not a legal
+// JSON escape on its own: JSON only allows \" \\ \/ \b \f \n \r \t \uXXXX).
+// Only ever called as a fallback after a strict decode already failed, and
+// only doubles backslashes that aren't already part of a legal escape --
+// genuinely broken JSON (mismatched brackets, truncated values, ...) still
+// fails to parse after repair and falls through to outright rejection.
+std::string repair_invalid_json_escapes(std::string_view text) {
+    std::string out;
+    out.reserve(text.size());
+    bool in_string = false;
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        const char c = text[i];
+        if (in_string && c == '\\') {
+            constexpr std::string_view kLegalEscapes = "\"\\/bfnrtu";
+            const bool has_next = i + 1 < text.size();
+            if (has_next && kLegalEscapes.find(text[i + 1]) != std::string_view::npos) {
+                out.push_back(c);
+                out.push_back(text[i + 1]);
+                ++i;
+            } else {
+                // Illegal (or trailing) escape -- double the backslash so it
+                // round-trips as a literal backslash; the following byte (if
+                // any) is left for the next loop iteration to copy through
+                // as an ordinary character.
+                out.push_back('\\');
+                out.push_back('\\');
+            }
+            continue;
+        }
+        out.push_back(c);
+        if (c == '"') { in_string = !in_string; }
+    }
+    return out;
+}
+
 bool parse_parameter(std::string_view inner, std::size_t& pos, Json& args,
                      std::string_view tool_name, const ToolArgumentTypeContracts& contracts) {
     constexpr std::string_view kParamOpen  = "<parameter=";
@@ -189,7 +228,10 @@ bool parse_parameter(std::string_view inner, std::size_t& pos, Json& args,
             args[key] = value;
         } else {
             Json parsed = Json::parse(value, nullptr, false);
-            if (parsed.is_discarded()) { return false; }
+            if (parsed.is_discarded()) {
+                parsed = Json::parse(repair_invalid_json_escapes(value), nullptr, false);
+                if (parsed.is_discarded()) { return false; }
+            }
             args[key] = std::move(parsed);
         }
     }

--- a/src/serve/tool_call_parser.cpp
+++ b/src/serve/tool_call_parser.cpp
@@ -172,6 +172,10 @@ std::string_view remove_parameter_framing_newlines(std::string_view text) {
 // only doubles backslashes that aren't already part of a legal escape --
 // genuinely broken JSON (mismatched brackets, truncated values, ...) still
 // fails to parse after repair and falls through to outright rejection.
+bool is_hex_digit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
 std::string repair_invalid_json_escapes(std::string_view text) {
     std::string out;
     out.reserve(text.size());
@@ -179,17 +183,27 @@ std::string repair_invalid_json_escapes(std::string_view text) {
     for (std::size_t i = 0; i < text.size(); ++i) {
         const char c = text[i];
         if (in_string && c == '\\') {
-            constexpr std::string_view kLegalEscapes = "\"\\/bfnrtu";
             const bool has_next = i + 1 < text.size();
-            if (has_next && kLegalEscapes.find(text[i + 1]) != std::string_view::npos) {
+            const char next     = has_next ? text[i + 1] : '\0';
+            constexpr std::string_view kSingleByteEscapes = "\"\\/bfnrt";
+            if (has_next && kSingleByteEscapes.find(next) != std::string_view::npos) {
                 out.push_back(c);
-                out.push_back(text[i + 1]);
+                out.push_back(next);
                 ++i;
+            } else if (has_next && next == 'u' && i + 5 < text.size() &&
+                      is_hex_digit(text[i + 2]) && is_hex_digit(text[i + 3]) &&
+                      is_hex_digit(text[i + 4]) && is_hex_digit(text[i + 5])) {
+                // Legal \uXXXX (exactly four hex digits) -- copy all six
+                // bytes through untouched.
+                out.append(text.substr(i, 6));
+                i += 5;
             } else {
-                // Illegal (or trailing) escape -- double the backslash so it
-                // round-trips as a literal backslash; the following byte (if
-                // any) is left for the next loop iteration to copy through
-                // as an ordinary character.
+                // Illegal (or trailing, or incomplete "\u") escape -- double
+                // the backslash so it round-trips as a literal backslash; the
+                // following byte(s) are left for normal per-character copying
+                // (e.g. a Windows path like "C:\users\greg" has a bare "\u"
+                // with no 4-hex-digit tail -- a lone 'u' is just an ordinary
+                // string character once the backslash is repaired).
                 out.push_back('\\');
                 out.push_back('\\');
             }

--- a/tests/test_tool_call_parser.cpp
+++ b/tests/test_tool_call_parser.cpp
@@ -258,6 +258,53 @@ int test_declared_type_mismatches_are_forwarded_without_coercion() {
     return failures;
 }
 
+int test_typed_parameter_repairs_invalid_backslash_escape() {
+    const auto contracts =
+        contracts_for("run_commands", Json{{"commands", Json{{"type", "array"}}}});
+
+    // "\*" and "\|" are common shell/regex metacharacter escapes that are
+    // legal in the shell command itself but not a legal JSON escape on their
+    // own (JSON only allows \" \\ \/ \b \f \n \r \t \uXXXX). The second array
+    // element carries genuinely legal escapes (\n, \") that must survive
+    // untouched by the repair pass.
+    const auto parsed = ninfer::serve::parse_qwen_tool_call_output(
+        "<tool_call>\n"
+        "<function=run_commands>\n"
+        "<parameter=commands>\n"
+        "[\"grep -n '^\\*\\|^* '\", \"good\\nline\\\"quoted\\\"end\"]\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>",
+        64, contracts);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 1,
+                      "typed array with an un-doubled backslash was not recovered");
+    const Json args = Json::parse(parsed.tool_calls.at(0).arguments_json);
+    const Json& commands = args.at("commands");
+    failures += check(commands.is_array() && commands.size() == 2,
+                      "repaired parameter did not decode as a two-element array");
+    failures += check(commands.at(0) == "grep -n '^\\*\\|^* '",
+                      "illegal backslash escape was not repaired to a literal backslash");
+    failures += check(commands.at(1) == "good\nline\"quoted\"end",
+                      "legal escapes were altered by the repair pass");
+
+    // Genuinely broken JSON (not just an escaping quirk) must still be
+    // rejected -- repair is a narrow fallback, not a lenient JSON parser.
+    const auto still_rejected = ninfer::serve::parse_qwen_tool_call_output(
+        "<tool_call>\n"
+        "<function=run_commands>\n"
+        "<parameter=commands>\n"
+        "[\"unterminated\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>",
+        64, contracts);
+    failures += check(!still_rejected.is_tool_call_response,
+                      "structurally truncated JSON was incorrectly recovered by the repair pass");
+    return failures;
+}
+
 int test_unknown_schema_keeps_legacy_inference() {
     const auto contracts = contracts_for(
         "legacy", Json{{"missing_type", Json::object()}, {"invalid_type", Json{{"type", "int"}}}});
@@ -335,6 +382,7 @@ int main() {
     failures += test_declared_strings_are_not_json_sniffed();
     failures += test_declared_non_string_values_are_json_decoded();
     failures += test_declared_type_mismatches_are_forwarded_without_coercion();
+    failures += test_typed_parameter_repairs_invalid_backslash_escape();
     failures += test_unknown_schema_keeps_legacy_inference();
     failures += test_incremental_filter_valid_tool();
     failures += test_incremental_filter_fallback();

--- a/tests/test_tool_call_parser.cpp
+++ b/tests/test_tool_call_parser.cpp
@@ -266,12 +266,17 @@ int test_typed_parameter_repairs_invalid_backslash_escape() {
     // legal in the shell command itself but not a legal JSON escape on their
     // own (JSON only allows \" \\ \/ \b \f \n \r \t \uXXXX). The second array
     // element carries genuinely legal escapes (\n, \") that must survive
-    // untouched by the repair pass.
+    // untouched by the repair pass. The third is a Windows-style path with a
+    // bare "\u" that isn't followed by four hex digits -- a naive "\u is
+    // always legal" check would leave it unrepaired and the whole call would
+    // still fail to parse. The fourth carries a genuine \uXXXX escape that
+    // must also survive untouched (only an *incomplete* \u is illegal).
     const auto parsed = ninfer::serve::parse_qwen_tool_call_output(
         "<tool_call>\n"
         "<function=run_commands>\n"
         "<parameter=commands>\n"
-        "[\"grep -n '^\\*\\|^* '\", \"good\\nline\\\"quoted\\\"end\"]\n"
+        "[\"grep -n '^\\*\\|^* '\", \"good\\nline\\\"quoted\\\"end\", "
+        "\"C:\\users\\greg\", \"snowman \\u2603\"]\n"
         "</parameter>\n"
         "</function>\n"
         "</tool_call>",
@@ -282,12 +287,17 @@ int test_typed_parameter_repairs_invalid_backslash_escape() {
                       "typed array with an un-doubled backslash was not recovered");
     const Json args = Json::parse(parsed.tool_calls.at(0).arguments_json);
     const Json& commands = args.at("commands");
-    failures += check(commands.is_array() && commands.size() == 2,
-                      "repaired parameter did not decode as a two-element array");
+    failures += check(commands.is_array() && commands.size() == 4,
+                      "repaired parameter did not decode as a four-element array");
     failures += check(commands.at(0) == "grep -n '^\\*\\|^* '",
                       "illegal backslash escape was not repaired to a literal backslash");
     failures += check(commands.at(1) == "good\nline\"quoted\"end",
                       "legal escapes were altered by the repair pass");
+    failures += check(commands.at(2) == "C:\\users\\greg",
+                      "a bare \\u not followed by four hex digits was not repaired "
+                      "(Windows-style path)");
+    failures += check(commands.at(3) == "snowman \u2603",
+                      "a genuine \\uXXXX escape was altered by the repair pass");
 
     // Genuinely broken JSON (not just an escaping quirk) must still be
     // rejected -- repair is a narrow fallback, not a lenient JSON parser.


### PR DESCRIPTION
## Concrete problem

A strictly-typed (`array`/`object`/...) tool-call parameter whose JSON value contains a backslash the model didn't double for JSON escaping makes `parse_parameter()` in `src/serve/tool_call_parser.cpp` reject the *entire* tool call and fall back to returning the raw `<tool_call>...` text as plain content, discarding an otherwise completely well-formed call.

Concretely: a `run_commands` tool with an `array`-typed `commands` parameter, where the model emits a shell command containing a literal regex/grep backslash escape (e.g. `grep -n '^\*\|^* '`). `\*` and `\|` aren't legal JSON string escapes (JSON only allows `\"` `\\` `\/` `\b` `\f` `\n` `\r` `\t` `\uXXXX`), so `Json::parse` discards the value, `parse_parameter` returns `false`, and the caller falls all the way back to `fallback(text)` — even though the tool-call structure itself (tags, function name, other parameters) was perfectly valid.

This is a different failure mode from #10 (structural tag/wrapper drift): the JSON here is syntactically complete, just contains one un-escaped backslash inside an otherwise well-formed value, and it's the *first* call in the response, so #10's tolerant recovery (which only engages once at least one call has already been successfully parsed) never gets a chance to help.

Reproduced against a real `qwen3_8_27b_nvfp4` NVFP4 artifact under Cline-style long agentic tool-use sessions.

## Design and why it's appropriate

In the strict (non-string, contract-typed) decode branch of `parse_parameter`, retry once against a repaired copy of the value before giving up:

```cpp
Json parsed = Json::parse(value, nullptr, false);
if (parsed.is_discarded()) {
    parsed = Json::parse(repair_invalid_json_escapes(value), nullptr, false);
    if (parsed.is_discarded()) { return false; }
}
args[key] = std::move(parsed);
```

`repair_invalid_json_escapes` is a narrow, single-pass repair: it tracks whether it's inside a JSON string and doubles a backslash *only* when it isn't already the first character of a legal JSON escape (`\" \\ \/ \b \f \n \r \t \u`). Legal escapes are copied through byte-for-byte untouched. It never touches structural characters outside strings, and it's applied only as a fallback after strict decode already failed — the common (already-valid) case never runs it, and genuinely broken JSON (truncated strings, mismatched brackets — not just an escaping quirk) still fails to parse after repair and correctly falls through to the existing rejection path unchanged.

This is deliberately scoped to the exact failure observed rather than a general lenient-JSON parser: it repairs *only* the specific defect (an un-doubled backslash), so it can't silently accept or misinterpret other classes of malformed input.

## Affected behavior/contract

`parse_qwen_tool_call_output`'s typed-parameter decode path in `src/serve/tool_call_parser.cpp` only. No CLI flag, no public API change, no schema version bump — this is purely an internal parsing robustness fix. Untyped ("legacy"/no-contract) parameters were already unaffected by this failure (they degrade to a string on parse failure rather than rejecting the call), so this only changes behavior for tools with explicit non-string JSON Schema parameter types.

## Verification

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
cmake --build build --parallel --target ninfer_tool_call_parser_test
./build/tests/ninfer_tool_call_parser_test
```

Result: `ok` (all cases pass), built clean against current `master` (`2190c4a1`) in an `nvidia/cuda:13.3.1-devel-ubuntu24.04` container.

Added `test_typed_parameter_repairs_invalid_backslash_escape` in `tests/test_tool_call_parser.cpp`, covering:
- a typed `array` parameter with an un-doubled `\*`/`\|` is now recovered, decoding to the correct literal-backslash string;
- a sibling array element with genuinely legal escapes (`\n`, `\"`) round-trips untouched by the repair pass;
- a structurally truncated/unterminated value (not just an escaping defect) still correctly fails and falls back to raw text — repair does not mask real errors.

No performance claim is made; this is a correctness fix on an already-failing path, not a modification to a hot loop (only reached once, after a strict decode has already failed).

## Not run

GPU-dependent tests (anything requiring an actual device/artifact) were not run — this change doesn't touch engine/runtime code, only the OpenAI-facing tool-call text parser, and the added test is a pure CPU unit test.

## AI usage disclosure

This implementation and its test were generated entirely by Claude Sonnet 5 (`claude-sonnet-5`). I (the submitter) reviewed the complete diff, reasoned through the escape-handling edge cases (legal-escape preservation, string-boundary tracking, genuinely-broken-JSON non-recovery) and the verification above, and take full responsibility for this change.