### PR TITLE
fix(qwen3.8): wire-format detect nvfp4 artifact profile

### DIFF
--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -15,6 +15,7 @@ struct DeviceContext;
 
 namespace artifact {
 class Binder;
+class Reader;
 class MaterializedArtifact;
 struct ArtifactIdentity;
 struct MaterializationPlan;
@@ -121,7 +122,8 @@ struct Package {
     using Program                    = qwen3_6::Program<detail::Variant>;
 
     [[nodiscard]] static ModelSamplingDefaults sampling_defaults(std::string_view model);
-    [[nodiscard]] static WeightsProfile resolve_weights(const artifact::ArtifactIdentity& identity);
+    [[nodiscard]] static WeightsProfile
+    resolve_weights(const artifact::ArtifactIdentity& identity, const artifact::Reader& reader);
     [[nodiscard]] static LoadPlan plan_load(artifact::Binder& binder, const EngineOptions& options,
                                             WeightsProfile weights_profile);
     [[nodiscard]] static std::unique_ptr<LoadedModel>

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -8,6 +8,7 @@
 
 #include <stdexcept>
 #include <utility>
+#include <variant>
 
 namespace ninfer::targets::qwen3_6_27b::detail {
 
@@ -82,7 +83,8 @@ ModelSamplingDefaults Package::sampling_defaults(std::string_view model) {
                              std::string(target_key) + "'");
 }
 
-Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentity& identity) {
+Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentity& identity,
+                                                  const artifact::Reader& reader) {
     if (identity.model_id == model_id && identity.weights_id == "groupwise-int") {
         return WeightsProfile::Qwen36GroupwiseInt;
     }
@@ -93,6 +95,17 @@ Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentit
         return WeightsProfile::Qwen36Nvfp4;
     }
     if (identity.model_id == qwen3_8_model_id && identity.weights_id == "nvfp4") {
+        // Qwen3.8-27B NVFP4 ships in two wire formats. The upstream FP8 profile keeps the
+        // vocabulary and attention endpoints in row-scaled FP8; the community W8+NVFP4
+        // profile (e.g. Ostfralla/Qwen3.8-27B-NVFP4-NInfer) uses W8 vocabulary endpoints
+        // and the Qwen3.6 NVFP4 layer layout. Detect the wire format from the artifact's
+        // text/token_embedding descriptor instead of guessing.
+        const artifact::ObjectDescriptor* embedding = reader.find("text/token_embedding");
+        const auto* tensor =
+            embedding == nullptr ? nullptr : std::get_if<artifact::TensorDescriptor>(embedding);
+        if (tensor != nullptr && tensor->format == artifact::NumericFormat::W8G32_F16S) {
+            return WeightsProfile::Qwen36Nvfp4;
+        }
         return WeightsProfile::Qwen38Nvfp4;
     }
     throw std::runtime_error("artifact identity '" + identity.model_id + "/" + identity.weights_id +

--- a/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
+++ b/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
@@ -15,6 +15,7 @@ struct DeviceContext;
 
 namespace artifact {
 class Binder;
+class Reader;
 class MaterializedArtifact;
 struct ArtifactIdentity;
 struct MaterializationPlan;
@@ -116,7 +117,8 @@ struct Package {
     using Program                    = qwen3_6::Program<detail::Variant>;
 
     [[nodiscard]] static ModelSamplingDefaults sampling_defaults(std::string_view model);
-    [[nodiscard]] static WeightsProfile resolve_weights(const artifact::ArtifactIdentity& identity);
+    [[nodiscard]] static WeightsProfile
+    resolve_weights(const artifact::ArtifactIdentity& identity, const artifact::Reader& reader);
     [[nodiscard]] static LoadPlan plan_load(artifact::Binder& binder, const EngineOptions& options,
                                             WeightsProfile weights_profile);
     [[nodiscard]] static std::unique_ptr<LoadedModel>

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -64,7 +64,9 @@ ModelSamplingDefaults Package::sampling_defaults(std::string_view model) {
                              std::string(target_key) + "'");
 }
 
-Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentity& identity) {
+Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentity& identity,
+                                                  const artifact::Reader& reader) {
+    (void)reader;
     if (identity.model_id == model_id && identity.weights_id == "groupwise-int") {
         return WeightsProfile::GroupwiseInt;
     }

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -92,7 +92,7 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
                                        artifact::Reader& reader, Clock::time_point load_start,
                                        std::string_view target_key) {
     const auto& identity                          = reader.identity();
-    const auto weights_profile                    = Target::resolve_weights(identity);
+    const auto weights_profile                    = Target::resolve_weights(identity, reader);
     const ModelSamplingDefaults sampling_defaults = Target::sampling_defaults(identity.model_id);
     const runtime::ContextCostIdentity context_cost_identity{
         .hardware_class = runtime::context_cost_hardware_class(


### PR DESCRIPTION
Qwen3.8-27B NVFP4 ships in two wire formats: the upstream FP8 profile (row-scaled FP8 vocabulary/attention endpoints, 21 GB artifact) and the community W8+NVFP4 profile (W8 vocabulary endpoints, Qwen3.6 NVFP4 layer layout, 18.3 GB artifact). Resolve the weights profile from the artifact's text/token_embedding descriptor instead of always selecting the FP8 profile.

The W8+NVFP4 profile comes from Ostfralla/Qwen3.8-27B-NVFP4-NInfer (https://huggingface.co/Ostfralla/Qwen3.8-27B-NVFP4-NInfer) and runs significantly faster on an RTX 5090 while leaving more VRAM, so it supports a larger context (262144 tokens at full speed) than the 21 GB upstream FP8 artifact, which cannot reach those speeds on the same hardware.

Existing artifacts are unaffected: the upstream FP8 model still resolves to the FP8 profile (Qwen38Nvfp4) because its token_embedding is row-scaled FP8; only W8-embedded community artifacts are routed to Qwen36Nvfp4.