### PR TITLE
serve: advertise context_length in /v1/models

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -49,8 +49,8 @@ cannot be combined with `--vision`. A later request cannot enable a capability o
 | Method and path | Behavior |
 |---|---|
 | `GET /health` | process health |
-| `GET /v1/models` | configured OpenAI model alias |
-| `GET /v1/models/{id}` | lookup of the configured alias |
+| `GET /v1/models` | model list; each entry carries the configured OpenAI model alias and `context_length` |
+| `GET /v1/models/{id}` | lookup of the configured alias with `context_length` |
 | `POST /v1/chat/completions` | OpenAI-style chat generation |
 | `POST /v1/responses` | OpenAI Responses Core generation, state, typed Items, and SSE |
 | `POST /v1/responses/input_tokens` | Responses prompt-token count without generation |
@@ -490,7 +490,17 @@ Pass `--api-key VALUE` to require the same value as an OpenAI bearer token or An
 
 ```bash
 curl http://127.0.0.1:8080/v1/models \
-  -H 'Authorization: Bearer local-secret'
+  -H 'Authorization: Bearer ***'
+```
+
+The model object advertises `context_length`: the engine's per-request logical
+ceiling set by `--max-context` (not the shared Main Text KV pool size).
+OpenAI-compatible clients read it to discover the window instead of
+hardcoding or guessing it.
+
+```json
+{"data":[{"context_length":240000,"created":1756272000,"id":"qwen3.8-27b",
+          "object":"model","owned_by":"ninfer"}],"object":"list"}
 ```
 
 `--cors` adds permissive browser CORS headers. It is disabled by default.

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -378,7 +378,8 @@ void HttpServer::register_routes() {
 }
 
 void HttpServer::handle_models(const httplib::Request&, httplib::Response& res) const {
-    res.set_content(make_models_list(public_model_id_, unix_time_now()), "application/json");
+    res.set_content(make_models_list(public_model_id_, unix_time_now(), options_.max_context),
+                    "application/json");
 }
 
 void HttpServer::handle_model(const httplib::Request& req, httplib::Response& res) const {
@@ -392,7 +393,8 @@ void HttpServer::handle_model(const httplib::Request& req, httplib::Response& re
         write_error(res, error);
         return;
     }
-    res.set_content(make_model_object(public_model_id_, unix_time_now()), "application/json");
+    res.set_content(make_model_object(public_model_id_, unix_time_now(), options_.max_context),
+                    "application/json");
 }
 
 void HttpServer::handle_chat_completions(const httplib::Request& req, httplib::Response& res) {

--- a/src/serve/openai_schema.cpp
+++ b/src/serve/openai_schema.cpp
@@ -685,18 +685,23 @@ std::string make_chat_chunk_usage(const std::string& id, const std::string& mode
 
 std::string sse_done() { return "data: [DONE]\n\n"; }
 
-std::string make_models_list(const std::string& model_id, std::int64_t created) {
+std::string make_models_list(const std::string& model_id, std::int64_t created,
+                             std::uint32_t context_length) {
     const Json payload = {{"object", "list"},
                           {"data", Json::array({Json{{"id", model_id},
                                                      {"object", "model"},
                                                      {"created", created},
-                                                     {"owned_by", "ninfer"}}})}};
+                                                     {"owned_by", "ninfer"},
+                                                     {"context_length",
+                                                      context_length}}})}};
     return payload.dump();
 }
 
-std::string make_model_object(const std::string& model_id, std::int64_t created) {
+std::string make_model_object(const std::string& model_id, std::int64_t created,
+                              std::uint32_t context_length) {
     const Json payload = {
-        {"id", model_id}, {"object", "model"}, {"created", created}, {"owned_by", "ninfer"}};
+        {"id", model_id},       {"object", "model"},      {"created", created},
+        {"owned_by", "ninfer"}, {"context_length", context_length}};
     return payload.dump();
 }
 

--- a/src/serve/openai_schema.h
+++ b/src/serve/openai_schema.h
@@ -66,8 +66,13 @@ std::string make_chat_chunk_usage(const std::string& id, const std::string& mode
 std::string sse_done();
 
 // /v1/models payloads.
-std::string make_models_list(const std::string& model_id, std::int64_t created);
-std::string make_model_object(const std::string& model_id, std::int64_t created);
+// context_length advertises the engine's per-request logical ceiling
+// (--max-context) so OpenAI-compatible clients (e.g. Hermes Agent) can read
+// the live context window instead of relying on a static config value.
+std::string make_models_list(const std::string& model_id, std::int64_t created,
+                             std::uint32_t context_length);
+std::string make_model_object(const std::string& model_id, std::int64_t created,
+                              std::uint32_t context_length);
 
 // Error object body.
 std::string make_error_body(const ApiError& error);

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -708,15 +708,18 @@ int test_tool_chunk_serialization() {
 
 int test_models_and_error() {
     int failures    = 0;
-    const Json list = Json::parse(make_models_list("qwen3.6-27b", 1));
+    const Json list = Json::parse(make_models_list("qwen3.6-27b", 1, 262144));
     failures += check(list.at("object") == "list", "models list object");
     failures += check(list.at("data").at(0).at("id") == "qwen3.6-27b", "models list id");
     failures += check(list.at("data").at(0).at("object") == "model", "models list entry object");
     failures += check(list.at("data").at(0).at("owned_by") == "ninfer", "models list owner");
+    failures += check(list.at("data").at(0).at("context_length") == 262144,
+                      "models list context_length");
 
-    const Json one = Json::parse(make_model_object("qwen3.6-27b", 1));
+    const Json one = Json::parse(make_model_object("qwen3.6-27b", 1, 131072));
     failures += check(one.at("id") == "qwen3.6-27b" && one.at("object") == "model", "model object");
     failures += check(one.at("owned_by") == "ninfer", "model owner");
+    failures += check(one.at("context_length") == 131072, "model object context_length");
 
     ApiError error;
     error.status   = 400;


### PR DESCRIPTION
## Problem

OpenAI-compatible clients commonly discover the model's context window by
probing `GET /v1/models` (and `/v1/models/{id}`) and reading per-model
metadata. ninfer's model objects only carry `id`, `object`, `created`,
`owned_by`, so clients can't discover the window and have to hardcode or
guess it (e.g. Hermes Agent keeps a static `model.context_length` in its
config and re-probes only when that is absent; routers like LiteLLM fall
back to registry defaults or conservative values).

## Change

Advertise the engine's per-request logical ceiling
(`ServeOptions::max_context`, i.e. the `--max-context` flag) as
`context_length` in both model-object payloads:

- `GET /v1/models` — `data[].context_length`
- `GET /v1/models/{id}` — top-level `context_length`

```json
{"data":[{"context_length":262144,"created":1787925112,"id":"qwen3.8-27b",
          "object":"model","owned_by":"ninfer"}],"object":"list"}
```

Notes:

- This is the **logical per-sequence ceiling**, not the shared KV pool
  size (which stays an internal admission detail). Clients use it exactly
  the way OpenAI's `context_length` semantics are used.
- Purely additive: unknown fields are ignored by conforming clients, so
  this cannot break existing consumers.
- It tracks the flag live: restart with a different `--max-context` and
  the endpoint reports the new value with no other moving parts.
- `docs/serving.md` route table is unchanged in spirit (same routes, one
  extra field); no CLI/behavior changes.

## Verification

- `ninfer_openai_schema_test` (BUILD_TESTING=ON, CUDA devel image):
  asserts `context_length` on both payloads — passes.
- Live serve: container rebuilt from this commit, `--max-context 262144`;
  both endpoints return `"context_length": 262144`; 16-token smoke
  completion OK.
- End-to-end client check: Hermes Agent with the static override removed
  resolves the window to 262144 purely from the live probe.

## Test plan (for CI)

No new infrastructure — the existing `ninfer_openai_schema_test` target
covers it.