### PR TITLE
Register the NVFP4 fused SwiGLU at every multiple of its 256-token block: 1.06x to 1.37x where it newly applies

### DIFF
--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
@@ -21,7 +21,7 @@ enum class Nvfp4LinearSwiGluRoute {
     TmaFusedW4A4,
 };
 
-constexpr std::int32_t kPrimaryT = 1024;
+constexpr std::int32_t kTmaBlockM = 256;
 
 Nvfp4LinearSwiGluRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
     if (tokens <= 0) { throw std::invalid_argument("nvfp4 linear_swiglu: T must be positive"); }
@@ -36,7 +36,9 @@ Nvfp4LinearSwiGluRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
     if (tokens == 1) { return Nvfp4LinearSwiGluRoute::DecodeFusedA16; }
     if (tokens <= 4) { return Nvfp4LinearSwiGluRoute::SmallTFusedA16; }
     if (tokens <= 48) { return Nvfp4LinearSwiGluRoute::FusedW4A4; }
-    if (tokens == kPrimaryT) { return Nvfp4LinearSwiGluRoute::TmaFusedW4A4; }
+    if (tokens >= kTmaBlockM && (tokens % kTmaBlockM) == 0) {
+        return Nvfp4LinearSwiGluRoute::TmaFusedW4A4;
+    }
     return Nvfp4LinearSwiGluRoute::LinearW4A4Post;
 }
 
@@ -90,8 +92,11 @@ std::size_t nvfp4_linear_swiglu_workspace_capacity_bytes(LinearPolicy policy,
     if (min_tokens <= 48 && max_tokens >= 5) {
         maximum = fused_workspace_bytes(std::min(max_tokens, 48));
     }
-    if (min_tokens <= kPrimaryT && max_tokens >= kPrimaryT) {
-        maximum = fused_workspace_bytes(kPrimaryT);
+    if (max_tokens >= kTmaBlockM) {
+        const std::int32_t largest_fused = max_tokens - (max_tokens % kTmaBlockM);
+        if (largest_fused >= std::max(min_tokens, kTmaBlockM)) {
+            maximum = std::max(maximum, fused_workspace_bytes(largest_fused));
+        }
     }
 
     std::int32_t last_baseline = max_tokens;


### PR DESCRIPTION
`nvfp4_linear_swiglu` registers the fused TMA route at exactly one token count:

```cpp
constexpr std::int32_t kPrimaryT = 1024;
...
if (tokens == kPrimaryT) { return Nvfp4LinearSwiGluRoute::TmaFusedW4A4; }
return Nvfp4LinearSwiGluRoute::LinearW4A4Post;
```

The kernel behind that route accepts any `T` that is a multiple of its 256-token block. Every other
width falls into `LinearW4A4Post`, which runs the gate/up linear into a 34816 x T bf16 tensor in the
arena and then reads that tensor back through a separate `silu_mul`. At a 8,192-token prefill chunk
that is 570 MiB written and read for nothing. The route now selects the fused kernel for every
multiple of 256 from 256 up.

The operator is 1.06x to 1.37x faster at the widths this reaches - the three below 1024 gain most,
1.12x to 1.37x - and the change also removes a
sawtooth that is visible in the numbers below: on `master` a 1,023-token call costs more than a
1,024-token one, and a 1,279-token call costs more than a 1,280-token one, because the wider call
is the one that happens to be registered.

**Process.** This is new work with no Issue behind it, which the contribution guide asks for. I am
sending it as a pull request because the change is one condition in a route table and its evidence
is the same set of measurements an Issue would carry; if you would rather see it as an Issue first,
say so and I will close this and open one. It is unrelated to #99 and #106.

Targeted at `master`, one commit on `ce09aee5`. Every number here was measured at `1fc1cb76`, its
parent; the single commit between them cancels abandoned streaming requests in `src/serve` and is
on no path measured here. `dev` reviewed: it is two commits ahead
(`11e76d8d`, `0b5b7c9a`) adding a perplexity corpus and a `target_logprobs` op, and touches neither
this file nor the fused kernel.

## What changes

One file, `src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp`, nine lines added and four
removed. `resolve_route` and `nvfp4_linear_swiglu_workspace_capacity_bytes` move together:

```cpp
-constexpr std::int32_t kPrimaryT = 1024;
+constexpr std::int32_t kTmaBlockM = 256;
...
-    if (tokens == kPrimaryT) { return Nvfp4LinearSwiGluRoute::TmaFusedW4A4; }
+    if (tokens >= kTmaBlockM && (tokens % kTmaBlockM) == 0) {
+        return Nvfp4LinearSwiGluRoute::TmaFusedW4A4;
+    }
...
-    if (min_tokens <= kPrimaryT && max_tokens >= kPrimaryT) {
-        maximum = fused_workspace_bytes(kPrimaryT);
+    if (max_tokens >= kTmaBlockM) {
+        const std::int32_t largest_fused = max_tokens - (max_tokens % kTmaBlockM);
+        if (largest_fused >= std::max(min_tokens, kTmaBlockM)) {
+            maximum = std::max(maximum, fused_workspace_bytes(largest_fused));
+        }
     }
```

The capacity function has to answer for the widest fused width an interval can contain, which is
`max_tokens` rounded down to the block, and for the widest baseline width, which the existing
`last_baseline` logic already computes as one below `max_tokens` when `max_tokens` is itself fused.
Moving the route alone is not enough: the shipped Op test then reports
`exact workspace query/execution high-water mismatch` at 256, 512 and 768. That is how I found the
second half of this change, and it is why `kPrimaryT` is replaced rather than joined - the block
width is the only constant the route needs.

## Operator benchmark

`ninfer_nvfp4_linear_swiglu_bench`, policy A4, product geometry N=34816 K=5120, `--repeat 50`,
cold L2.

```bash
./build/bench/ninfer_nvfp4_linear_swiglu_bench --policy a4 \
  --t-sweep 256,512,768,1024,1280,2048,4096,8192 --repeat 50
```

| T | master, us | branch, us | speedup | |
|---:|---:|---:|---:|---|
| 256 | 155.62 | 139.26 | **1.117** | newly fused |
| 512 | 313.38 | 229.38 | **1.366** | newly fused |
| 768 | 410.59 | 317.44 | **1.293** | newly fused |
| 1024 | 415.74 | 417.50 | 0.996 | fused on both - the harness floor |
| 1280 | 528.38 | 499.71 | **1.057** | newly fused |
| 2048 | 835.62 | 765.66 | **1.091** | newly fused |
| 4096 | 1677.06 | 1478.66 | **1.134** | newly fused |
| 8192 | 3440.64 | 3056.70 | **1.126** | newly fused |

T=1024 is the control: both arms take the fused route there, and the 0.996 it reads is what this
benchmark returns when nothing changed.

A second sweep puts each multiple of 256 next to its neighbours, which is the whole predicate on
display:

| T | 255 | **256** | 257 | 511 | **512** | 513 | 767 | **768** | 769 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| speedup | 1.000 | **1.118** | 1.000 | 1.000 | **1.342** | 1.000 | 1.000 | **1.282** | 1.000 |

| T | 1023 | 1024 | 1025 | 1279 | **1280** | 1281 | **1536** | **2048** | **2304** |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| speedup | 1.000 | 1.000 | 1.000 | 1.000 | **1.057** | 1.000 | **1.076** | **1.095** | **1.091** |

Every width that is not a multiple of 256 reads 1.000 or 0.9999. The sawtooth is in the absolute
numbers on `master`: 1023 costs 538.59 us against 417.79 at 1024, and 1279 costs 661.47 against
530.43 at 1280.

## Workspace

The change edits the capacity function, and workspace boundaries are contract, so I enumerated
`nvfp4_linear_swiglu_workspace_capacity_bytes` over a grid of `(min_tokens, max_tokens)` intervals
on both arms and diffed the answers - value and throw behaviour:

| intervals probed | branch asks MORE | branch asks LESS | throw behaviour changed |
|---:|---:|---:|---:|
| 4560 | **0** | 1175 | **0** |

Where it asks less it is 72,512 bytes, on every such interval: once `max_tokens` is itself fused,
the widest width that still needs the materialised tensor is `max_tokens - 1`, one token narrower
than before, and 34816 x 1 bf16 plus alignment is exactly that. The fused workspace is far smaller
than the baseline one, so it never becomes the maximum.

## Numerics

This is not a bit-identical change. The fused epilogue computes the SiLU from the f32 accumulator
instead of from a materialised bf16 tensor, so at every width it re-routes the arithmetic differs.
The project ships an FP64 oracle for exactly this question; its A4 case list stops at 1024, so I
extended the list to the re-routed widths and ran the same test, same criterion, on both arms.

```bash
NINFER_OP_REPORT_STATS=1 ./build/tests/ninfer_linear_swiglu_nvfp4_test
```

| T | master rel_l2 | of limit | branch rel_l2 | of limit | gross, master -> branch |
|---:|---:|---:|---:|---:|---|
| 5 | 0.11102 | 69.4% | 0.11102 | 69.4% | 0.639 -> 0.639 |
| 48 | 0.083602 | 52.3% | 0.083602 | 52.3% | 0.639 -> 0.639 |
| 49 | 0.083578 | 52.2% | 0.083578 | 52.2% | 0.639 -> 0.639 |
| 128 | 0.066212 | 41.4% | 0.066212 | 41.4% | 0.589 -> 0.589 |
| **256** | 0.059000 | 36.9% | **0.058382** | 36.5% | 0.531 -> 0.486 |
| **512** | 0.057068 | 35.7% | **0.056556** | 35.3% | 0.531 -> 0.486 |
| **768** | 0.054019 | 33.8% | **0.053731** | 33.6% | 0.408 -> 0.373 |
| 1024 | 0.052689 | 32.9% | 0.052689 | 32.9% | 0.373 -> 0.373 |
| **1280** | 0.051590 | 32.2% | **0.051256** | 32.0% | 0.336 -> 0.307 |
| **2048** | 0.050108 | 31.3% | **0.049686** | 31.1% | 0.286 -> 0.261 |
| **4096** | 0.052342 | 32.7% | **0.052338** | 32.7% | 0.286 -> **0.326** |

The widths the change does not touch are identical, as they must be. At every re-routed width the
relative L2 residual against the oracle is smaller on the branch. The gross ratio is smaller at five
of the six and larger at 4096, 0.286 -> 0.326, which is still a third of the gross limit; I am
reporting it rather than reading the rel_l2 column alone. The test's verdict is `OK` on both arms.

## Codegen

A host route table should move no device code, and it does not:

```
cuobjdump -sass, master binary against branch binary
functions: 2937 / 2937      changed bodies: 0
```

No allocation site, graph node or public signature changes either; the diff is one file.

## Tests

```bash
cd build && ctest -j1
```

`100% tests passed, 0 tests failed out of 94`, 1 skipped, on this branch and on `master` built in
the same directory in the same run. The skip is `27b_load_plan`, which needs both real 27B artifacts
and only one is on this box. `tests/ops/linear_swiglu/test_nvfp4.cpp` is the test whose A4 case list
I extended for the table above; unmodified, it qualifies T=1024 on the fused route, which this
change leaves on the fused route.

## End to end

Confirmation only; the operator benchmark above is the claim. Qwen3.8-27B NVFP4, arms alternating
inside each round, every point its own process, greedy, four rounds, on an otherwise idle box.

```bash
./build/apps/ninfer qwen3_8_27b_nvfp4.ninfer --messages <prompt> --max-new 32 --greedy \
  --no-thinking --max-context 131072 --prefill-chunk <chunk> --kv-dtype bf16
```

| prefill chunk | prompt tokens | per-round branch/master | prefill | decode |
|---:|---:|---|---:|---:|
| 8192 | 33,031 | 1.0198 1.0245 1.0261 1.0218 | **+2.30%** | -0.00% |
| 8192 | 65,882 | 1.0168 1.0213 1.0186 1.0208 | **+1.94%** | -0.02% |
| 1024 | 33,031 | 1.0007 1.0012 1.0002 1.0002 | +0.06% | +0.00% |
| 768 | 33,031 | 1.0408 1.0431 1.0422 1.0425 | **+4.22%** | +0.00% |
| 512 | 33,031 | 1.0399 1.0402 1.0409 1.0411 | **+4.05%** | +0.01% |

The 1,024 row is the control: that width is fused on both arms, and four rounds of it read
1.0002 to 1.0012, which is what this measurement returns when nothing changed. I quote the paired
per-round ratios rather than a mean of means because the absolute rate drifts about 2% between the
first and later rounds on both arms; the ratios do not.

All 20 generations are byte-identical to `master`. So are all 24 cross-chunk comparisons - on this
prompt the four chunk widths agree with each other on both arms, so the arithmetic difference the
oracle table shows does not reach the argmax here. That is an observation about this corpus, not a
guarantee.

## Checks not run

- No `ncu` counters: `RmProfilingAdminOnly` is set on this host.
- Below 256 nothing changes: `T <= 4` and `T <= 48` keep their own fused routes, and 49-255 stays on
  the materialising path. I did not look for a schedule that would serve that band.
- `docs/performance.md` does publish Qwen3.8-27B NVFP4 prefill throughput, but its campaigns run at
  a 1,024-token prefill chunk, which this change leaves on the route it already took; only a final
  partial chunk that happens to be a multiple of 256 would be re-routed. The chunk-1024 row in the
  table above reads +0.06% over four rounds, so I do not expect those figures to move - but I have
  not re-run that harness, which uses INT8 group-64 KV, CUDA Graphs, prefix reuse and stochastic
  sampling through the serve corpus, and I am not proposing edits to the document.
- Speculation is off in every run here.
- The 35B-A3B and dense 27B models take no NVFP4 SwiGLU route and are not measured.

RTX 5090, sm_120a, driver 580.105.08, CUDA 13.1.115, Release, `-DCMAKE_CUDA_ARCHITECTURES=120a`.
