### PR TITLE
The NVFP4 A4 oracle covers no width the fused SwiGLU route newly reaches: add T=256

### DIFF
--- a/tests/ops/linear_swiglu/test_nvfp4.cpp
+++ b/tests/ops/linear_swiglu/test_nvfp4.cpp
@@ -10,7 +10,7 @@ int main() {
 
     try {
         constexpr std::array<std::int32_t, 4> kA16Cases{1, 4, 8, 16};
-        constexpr std::array<std::int32_t, 5> kA4Cases{5, 48, 49, 128, 1024};
+        constexpr std::array<std::int32_t, 6> kA4Cases{5, 48, 49, 128, 256, 1024};
         int failures = 0;
         failures += run_profile("LinearSwiGLU NVFP4_A16",
                                 {QType::NVFP4, 34816, 5120, 17408, 1801U, ActivationCompute::A16},


### PR DESCRIPTION
`00369f63` registered the fused TMA SwiGLU for every multiple of its 256-token block. The A4 case
list in `tests/ops/linear_swiglu/test_nvfp4.cpp` is `{5, 48, 49, 128, 1024}`, and 1024 took the
fused route before that commit as well, so `ctest` executes none of the widths it newly reaches.
This adds the narrowest of them.

```diff
-        constexpr std::array<std::int32_t, 5> kA4Cases{5, 48, 49, 128, 1024};
+        constexpr std::array<std::int32_t, 6> kA4Cases{5, 48, 49, 128, 256, 1024};
```

Your Codex reviewer raised this on #113 (`discussion_r3886491016`) and it is right; the PR merged
before I answered it, so it comes as its own change.

## Why 256 and only 256

- It is the narrowest width the new predicate admits, so it is the single case that exercises both
  new legs at once: the one in `resolve_route` and the one in
  `nvfp4_linear_swiglu_workspace_capacity_bytes`.
- It is a `T` below the old `kPrimaryT`, a shape the old route could not produce at all.
- The criterion is untouched and the list's maximum extent stays 1024, which is what the review
  asked for.

## It catches a real regression, not a hypothetical one

`AGENTS.md:L280-L282` asks that a test protect supported behavior or a realistic regression. This
one does, and the regression is not hypothetical - it is the state I passed through while writing
`00369f63`. Moving `resolve_route` to the block width while leaving the capacity query keyed on
1024 compiles and looks correct, and it is wrong.

I rebuilt exactly that state on top of current `master` to check the case earns its place:

| arm | `resolve_route` | capacity query | verdict |
|---|---|---|---|
| A: `master` + this case | block width | block width | **`OK`** |
| B: control | block width | re-keyed to 1024 | **`FAIL`** |

Arm B fails on this case and names it:

```
LinearSwiGLU NVFP4_A4 T=256: exact workspace query/execution high-water mismatch
FAIL LinearSwiGLU NVFP4 correctness
```

Without `T = 256` in the list, arm B passes: nothing else in `ctest` reaches a fused width the
capacity query would under-report.

## What the case reports on master

```bash
NINFER_OP_REPORT_STATS=1 ./build/tests/ninfer_linear_swiglu_nvfp4_test
```

| T | rel_l2 | of the 0.16 criterion | gross ratio |
|---:|---:|---:|---:|
| 5 | 0.111020 | 69.4% | 0.639 |
| 48 | 0.083602 | 52.3% | 0.639 |
| 49 | 0.083578 | 52.2% | 0.639 |
| 128 | 0.066212 | 41.4% | 0.589 |
| **256** | **0.058382** | **36.5%** | **0.486** |
| 1024 | 0.052689 | 32.9% | 0.373 |

The new case sits between 128 and 1024 on both columns and well inside the criterion, which is
what a width on a qualified route should look like. The other five rows are unchanged.

## Tests

```bash
cd build && ctest -j1
```

`100% tests passed, 0 tests failed out of 98`, 1 skipped - `27b_load_plan`, which needs both real
27B artifacts and only one is on this box. The nvfp4 test's own wall time does not move: 2.28 s
before the case and 1.98 s after, so the coverage is free.

One file, one line. No source, contract or workspace change.

RTX 5090, sm_120a, driver 580.105.08, CUDA 13.1.115, Release, `-DCMAKE_CUDA_ARCHITECTURES=120a`.
Base is `89e297e1`.
