### PR TITLE
fix(runtime): bound pressure planner committed targets

### DIFF
--- a/src/runtime/engine/shared_capture_planner.h
+++ b/src/runtime/engine/shared_capture_planner.h
@@ -101,6 +101,7 @@ public:
         queue_.push_back(identity);
         std::optional<Incumbent> incumbent;
         std::uint32_t targets_evaluated = 0;
+        std::uint32_t canonical_targets = 1;
         std::size_t cursor              = 0;
 
         while (cursor < queue_.size() && targets_evaluated < input.target_budget) {
@@ -127,12 +128,13 @@ public:
 
             if (!assessment.expandable || contains(expanded_, target)) { continue; }
             auto prepared                 = session.prepare_expansion(target);
-            const std::uint32_t remaining = input.target_budget - targets_evaluated;
+            const std::uint32_t remaining = input.target_budget - canonical_targets;
             if (prepared.new_canonical_count() > remaining) {
                 session.discard_expansion(std::move(prepared));
                 continue;
             }
             const auto children = session.commit_expansion(std::move(prepared));
+            canonical_targets += children.new_canonical_count;
             expanded_.push_back(target);
             for (const PressureTargetHandle child : children.children) {
                 if (!contains(assessed_, child) && !contains(queue_, child)) {

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -954,6 +954,7 @@ public:
     std::uint32_t private_pressure_alternatives     = 1;
     std::uint64_t pressure_action_immediate_ns      = 100'000'000;
     std::uint32_t pressure_action_degradation_units = 1;
+    std::optional<std::uint32_t> pressure_expansion_arena_capacity;
     bool include_cumulative_private_target          = false;
     bool combined_target_cancels_pressure_copy      = false;
     std::optional<std::uint64_t> pressure_target_immediate_ns_override;
@@ -1295,6 +1296,12 @@ FakePressurePlanningSession::commit_expansion(FakePreparedPressureExpansion&& pr
     require(scratch_live_ && prepared.generation == generation_ &&
                 prepared.scratch_generation == scratch_generation_,
             "fake prepared expansion is stale");
+    if (program_->pressure_expansion_arena_capacity) {
+        const std::size_t maximum = *program_->pressure_expansion_arena_capacity;
+        if (prepared.new_count > maximum - std::min(maximum, targets_.size())) {
+            throw std::length_error("prepared pressure expansion exceeds the target arena");
+        }
+    }
     committed_children_.clear();
     std::uint32_t new_count = 0;
     for (Target& child : expansion_scratch_) {
@@ -2201,6 +2208,96 @@ void test_repeated_private_reuse_selects_zero_prefill_shared_promotion() {
     (void)finish_active(manager, program, second, 16);
 }
 
+void test_shared_capture_bounds_committed_pressure_targets() {
+    using Planner = ninfer::runtime::SharedCapturePlanner<FakePackage>;
+
+    FakeProgram program;
+    program.required_pressure_actions             = 11;
+    program.private_pressure_alternatives         = 2;
+    program.pressure_expansion_arena_capacity     = Planner::kTargetBudget + 2U;
+    program.pressure_target_immediate_ns_override = 0;
+    FakeCaptureAssessment capture{
+        .shortlist_key          = FakeShortlistKey{.digest = 99, .frontier = 64},
+        .shared_evidence        = ninfer::SharedCandidateEvidence::ExplicitBoundary,
+        .protected_rebuild_work = PrefillWork{.tokens = 64},
+        .projected_recovery_ns  = 0,
+        .publishes_shared       = true,
+        .physically_feasible    = false,
+    };
+    std::array<FakeContinuationHandle, 16> private_owner_storage;
+    std::array<FakeSharedPrefixHandle, 4> shared_owner_storage;
+    std::array<const FakeContinuationHandle*, 16> private_owners;
+    std::array<std::uint32_t, 16> private_ordinals;
+    std::array<const FakeSharedPrefixHandle*, 4> shared_owners;
+    std::array<std::uint32_t, 4> shared_ordinals;
+    std::array<Planner::OwnerPolicy, 20> owner_policies;
+    std::array<Planner::CheckpointPolicy, 20> checkpoint_policies;
+    for (std::size_t index = 0; index < private_owner_storage.size(); ++index) {
+        private_owner_storage[index] =
+            FakeContinuationHandle(static_cast<std::uint32_t>(index + 1U), 0);
+        private_owners[index]   = &private_owner_storage[index];
+        private_ordinals[index] = static_cast<std::uint32_t>(index);
+        owner_policies[index]   = Planner::OwnerPolicy{
+            .ordinal                  = static_cast<std::uint32_t>(index),
+            .private_retention_weight = 1,
+        };
+        checkpoint_policies[index] = Planner::CheckpointPolicy{
+            .owner_ordinal = static_cast<std::uint32_t>(index),
+            .checkpoint    = CheckpointRef{.kind     = CheckpointKind::SessionEndpoint,
+                                           .frontier = 16,
+                                           .ordinal  = 0},
+            .rebuild_ns    = 100,
+        };
+    }
+    for (std::size_t index = 0; index < shared_owner_storage.size(); ++index) {
+        const std::size_t ordinal      = private_owner_storage.size() + index;
+        shared_owner_storage[index].id = static_cast<std::uint32_t>(index + 1U);
+        shared_owners[index]           = &shared_owner_storage[index];
+        shared_ordinals[index]         = static_cast<std::uint32_t>(ordinal);
+        owner_policies[ordinal]        = Planner::OwnerPolicy{
+            .ordinal = static_cast<std::uint32_t>(ordinal),
+        };
+        checkpoint_policies[ordinal] = Planner::CheckpointPolicy{
+            .owner_ordinal = static_cast<std::uint32_t>(ordinal),
+            .checkpoint    = CheckpointRef{.kind     = CheckpointKind::SharedStablePrefix,
+                                           .frontier = 16,
+                                           .ordinal  = 0},
+            .rebuild_ns    = 100,
+        };
+    }
+
+    Planner planner;
+    const auto result = planner.plan(program, test_cost_model(),
+                                     Planner::Input{
+                                         .capture                = &capture,
+                                         .private_owners         = private_owners,
+                                         .private_owner_ordinals = private_ordinals,
+                                         .shared_owners          = shared_owners,
+                                         .shared_owner_ordinals  = shared_ordinals,
+                                         .owner_policies         = owner_policies,
+                                         .checkpoint_policies    = checkpoint_policies,
+                                         .candidate_rebuild_ns   = 1000,
+                                         .target_budget          = Planner::kTargetBudget,
+                                     });
+    require(!result, "bounded shared capture search unexpectedly found a feasible pressure target");
+
+    program.required_pressure_actions = 0;
+    const auto later                  = planner.plan(program, test_cost_model(),
+                                                     Planner::Input{
+                                                         .capture                = &capture,
+                                                         .private_owners         = private_owners,
+                                                         .private_owner_ordinals = private_ordinals,
+                                                         .shared_owners          = shared_owners,
+                                                         .shared_owner_ordinals  = shared_ordinals,
+                                                         .owner_policies         = owner_policies,
+                                                         .checkpoint_policies    = checkpoint_policies,
+                                                         .candidate_rebuild_ns   = 1000,
+                                                         .target_budget          = Planner::kTargetBudget,
+                                                     });
+    require(later.has_value(),
+            "ordinary pressure capacity outcome prevented a later valid shared capture plan");
+}
+
 void test_shared_capture_combines_two_pressure_owners() {
     FakeManager manager = make_manager(1, 4, 1);
     FakeProgram program;
@@ -2396,6 +2493,8 @@ int main() {
              test_observed_shared_candidate_requires_independent_domains);
     run_test("zero-prefill private promotion",
              test_repeated_private_reuse_selects_zero_prefill_shared_promotion);
+    run_test("shared capture committed target bound",
+             test_shared_capture_bounds_committed_pressure_targets);
     run_test("shared capture multi-owner pressure",
              test_shared_capture_combines_two_pressure_owners);
     run_test("terminal fallback", test_terminal_fallback_releases_failed_retention);


### PR DESCRIPTION
## Summary

- count every committed canonical pressure-planning target against the existing 4,096-target search budget
- discard an expansion atomically when its complete set of new child targets will not fit
- preserve deterministic breadth-first ordering, stable target handles, and the existing memory bound
- add a regression covering 16 private owners, four shared owners, full target-budget pressure, and a subsequent valid planning operation

## Problem

The planner bounded work using the number of targets that had been assessed. A single assessed target can commit several unique children, which remain queued and unassessed. The number of committed canonical targets could therefore exceed the assessed-target count.

With a wide owner topology, the planner could pass its assessment-count check and then attempt to commit more children than the Qwen target arena had remaining capacity for. This raised:

```text
prepared pressure expansion exceeds the target arena
```

The exception could escape the request path, terminate the inference worker, and leave later requests returning HTTP 503 until restart.

## Fix

The resource manager now tracks the identity target and each newly committed canonical child against the same existing target budget. If an expansion's complete child set does not fit, the expansion is discarded before any partial commit.

The 4,096 limit is unchanged. Genuine stale-state and invariant errors remain errors.

## Testing

- driverless resource-manager/planner suite
- resource-manager ASan/UBSan run
- admission-policy driverless test
- KV-capacity driverless test
- `git diff --check`
- formatting checks

The regression deterministically failed before the change and passes afterward. It also verifies that another valid planning operation succeeds after budget exhaustion.

## Production observation

This patch was generated and implemented with AI assistance. It has also been running in a production deployment after review and CI. The original target-arena failure reproduced twice before the patch and has not been observed again since deployment. That is encouraging operational evidence, but it is not presented as a substitute for the deterministic regression test or as proof that every workload is covered.

Closes #121.
