### PR TITLE
The routed MoE gate/up stages from x instead of a gathered copy: one kernel gone, operator 1.046x

### DIFF
--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
@@ -32,15 +32,20 @@ struct SparseMoePrefillPlan {
 struct SparseMoePrefillWorkspace {
     Tensor token_ids;
     Tensor token_alpha;
-    // Selection writes one rank local to a routing tile. Gather must keep this source separate
+    // Selection writes one rank local to a routing tile. The gather must keep this source separate
     // from the final inverse map because all threads in an assignment block consume the rank while
-    // thread 0 publishes the packed column.
+    // thread 0 publishes the packed column. The index kernel does both from one thread per
+    // assignment, so the separation is there for the gather the W8 routed codec still takes.
     Tensor local_rank;
     Tensor shared_scale;
-    // Scan is the final consumer of tile_counts. The inverse map aliases its dead prefix for the
-    // remaining gather/reduce lifetime; 256 * ceil(T / 8) is at least 8 * T elements.
+    // Scan is the final consumer of tile_counts. Both maps below alias its dead prefix for the
+    // remaining lifetime; 256 * ceil(T / 8) is at least 32 * T elements and they take 8 * T each.
     Tensor tile_counts;
     Tensor packed_index;
+    // The token each packed column was routed from, so the routed gate/up GEMM can stage its
+    // activation tile from `x` instead of from a materialised copy. Sits in the same dead prefix
+    // behind packed_index and needs no allocation of its own.
+    Tensor packed_token;
     Tensor tile_bases;
     Tensor expert_offsets;
     Tensor route_job_experts;
@@ -51,7 +56,8 @@ struct SparseMoePrefillWorkspace {
 
     // The three large allocations are lifetime unions:
     //   router scores FP32 <-> shared SwiGLU BF16
-    //   gathered X BF16    <-> routed down output BF16
+    //   gathered X BF16    <-> routed down output BF16 <-> adaptive FP32 activations
+    //     (a Q4 routed gate/up stages from x and gathers nothing, so it only ever writes here)
     //   routed SwiGLU BF16 <-> routed FP32 token reduction
     Tensor score_storage;
     Tensor shared_activation;
@@ -68,12 +74,17 @@ SparseMoePrefillWorkspace allocate_sparse_moe_prefill_workspace(Arena& arena,
     const std::int32_t route_tiles =
         (capacity_tokens + kSparseMoeRouteTileTokens - 1) / kSparseMoeRouteTileTokens;
 
-    out.token_ids      = arena.alloc(DType::I32, {assignments}, 256);
-    out.token_alpha    = arena.alloc(DType::FP32, {assignments}, 256);
-    out.local_rank     = arena.alloc(DType::I32, {assignments}, 256);
-    out.shared_scale   = arena.alloc(DType::FP32, {capacity_tokens}, 256);
-    out.tile_counts    = arena.alloc(DType::I32, {256, route_tiles}, 256);
-    out.packed_index   = Tensor(out.tile_counts.data, DType::I32, {assignments});
+    out.token_ids    = arena.alloc(DType::I32, {assignments}, 256);
+    out.token_alpha  = arena.alloc(DType::FP32, {assignments}, 256);
+    out.local_rank   = arena.alloc(DType::I32, {assignments}, 256);
+    out.shared_scale = arena.alloc(DType::FP32, {capacity_tokens}, 256);
+    out.tile_counts  = arena.alloc(DType::I32, {256, route_tiles}, 256);
+    // Both maps alias the dead prefix of tile_counts, whose last reader is the scan. The
+    // layout builder allocates nothing, so the offset is only formed when there is a pointer.
+    auto* const counts = static_cast<std::int32_t*>(out.tile_counts.data);
+    out.packed_index   = Tensor(counts, DType::I32, {assignments});
+    out.packed_token =
+        Tensor(counts != nullptr ? counts + assignments : nullptr, DType::I32, {assignments});
     out.tile_bases     = arena.alloc(DType::I32, {256, route_tiles}, 256);
     out.expert_offsets = arena.alloc(DType::I32, {257}, 256);
     // A route job is one nonempty expert column tile. The bound is for the

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -250,6 +250,30 @@ sparse_moe_prefill_gather_kernel(const __nv_bfloat16* __restrict__ x, const int*
     if (threadIdx.x == 0) { packed_index[assignment] = packed; }
 }
 
+// Publishes the packed-column map without moving activations. One thread per assignment, so
+// unlike the gather it reads the tile-local rank and writes the inverse map from the same
+// thread and never has the two live in one buffer.
+template <bool Adaptive>
+__global__ void
+sparse_moe_prefill_index_kernel(const int* __restrict__ ids, const int* __restrict__ local_rank,
+                                int* __restrict__ packed_index, const int* __restrict__ tile_bases,
+                                int* __restrict__ packed_token, int assignments,
+                                const int* __restrict__ route_job_count) {
+    if constexpr (Adaptive) {
+        if (*route_job_count < 0) { return; }
+    }
+    const int assignment =
+        static_cast<int>(blockIdx.x) * static_cast<int>(blockDim.x) + static_cast<int>(threadIdx.x);
+    if (assignment >= assignments) { return; }
+    const int token  = assignment / kTopK;
+    const int expert = ids[assignment];
+    const int tile   = token / kSparseMoeRouteTileTokens;
+    const int packed =
+        tile_bases[static_cast<std::int64_t>(tile) * kExperts + expert] + local_rank[assignment];
+    packed_index[assignment] = packed;
+    packed_token[packed]     = token;
+}
+
 constexpr int kExpertBM                = 64;
 constexpr int kExpertBN                = 64;
 constexpr int kExpertBK                = 64;
@@ -262,15 +286,20 @@ constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
 
 template <int ExpertWarps, int ExpertBN>
 __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
-    const __nv_bfloat16* __restrict__ gathered, const int* __restrict__ expert_offsets,
-    const int* __restrict__ route_job_experts, const int* __restrict__ route_job_columns,
-    const int* __restrict__ route_job_count, const std::uint8_t* __restrict__ codes,
-    const std::uint8_t* __restrict__ scales, __nv_bfloat16* __restrict__ activation) {
+    const __nv_bfloat16* __restrict__ x, const int* __restrict__ packed_token,
+    const int* __restrict__ expert_offsets, const int* __restrict__ route_job_experts,
+    const int* __restrict__ route_job_columns, const int* __restrict__ route_job_count,
+    const std::uint8_t* __restrict__ codes, const std::uint8_t* __restrict__ scales,
+    __nv_bfloat16* __restrict__ activation) {
     constexpr int ExpertThreads = ExpertWarps * 32;
     constexpr int GroupsPerRow  = kHidden / 64;
     constexpr int WarpCols      = ExpertBN / ExpertWarps;
     constexpr int WarpNT        = WarpCols / 8;
+    constexpr int StageChunks   = kExpertBK / 8;
+    constexpr int StageIters    = ExpertBN * StageChunks / ExpertThreads;
     static_assert(ExpertBN % ExpertWarps == 0 && WarpCols % 8 == 0);
+    static_assert(StageIters * ExpertThreads == ExpertBN * StageChunks,
+                  "the staging loop is unrolled, so every thread must take the same column count");
     __shared__ __align__(16) __nv_bfloat16 As[kExpertBM * kExpertBK];
     __shared__ __align__(16) __nv_bfloat16 Bs[kExpertStages][ExpertBN * kExpertBK];
     __shared__ __align__(16) std::uint8_t Cr[kExpertStages][kExpertBM * 32];
@@ -292,14 +321,26 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
     const int total_work     = *route_job_count * row_blocks;
     for (int work = static_cast<int>(blockIdx.x); work < total_work;
          work += static_cast<int>(gridDim.x)) {
-        const int route_job     = work / row_blocks;
-        const int row_block     = work - route_job * row_blocks;
-        const int expert        = route_job_experts[route_job];
-        const int logical0      = row_block * (kExpertBM / 2);
-        const int begin         = expert_offsets[expert];
-        const int count         = expert_offsets[expert + 1] - begin;
-        const int column_base   = route_job_columns[route_job];
-        const int cols          = count - column_base < ExpertBN ? count - column_base : ExpertBN;
+        const int route_job   = work / row_blocks;
+        const int row_block   = work - route_job * row_blocks;
+        const int expert      = route_job_experts[route_job];
+        const int logical0    = row_block * (kExpertBM / 2);
+        const int begin       = expert_offsets[expert];
+        const int count       = expert_offsets[expert + 1] - begin;
+        const int column_base = route_job_columns[route_job];
+        const int cols        = count - column_base < ExpertBN ? count - column_base : ExpertBN;
+        // A thread stages the same columns of all kHidden / kExpertBK tiles, so it resolves their
+        // rows once for the whole job instead of reading the map and redoing the row multiply per
+        // tile. A column past the tile is clamped onto a live one and then zero-filled.
+        // ptxas allots exactly 80 registers per thread at __launch_bounds__(256, 3) on
+        // sm_120a and this kernel now uses all of them, so widening this array spills.
+        const __nv_bfloat16* src_row[StageIters];
+#pragma unroll
+        for (int i = 0; i < StageIters; ++i) {
+            const int col = (tid + i * ExpertThreads) / StageChunks;
+            const int row = packed_token[col < cols ? begin + column_base + col : begin];
+            src_row[i]    = x + static_cast<std::int64_t>(row) * kHidden;
+        }
         float acc[4][WarpNT][4] = {};
 
         auto global_row = [&](int local_row) {
@@ -321,16 +362,13 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
 
         auto stage_inputs = [&](int stage, int kt) {
             const int k0 = kt * kExpertBK;
-            for (int item = tid; item < ExpertBN * (kExpertBK / 8); item += ExpertThreads) {
-                const int col        = item / (kExpertBK / 8);
-                const int k8         = item - col * (kExpertBK / 8);
-                const int packed_col = begin + column_base + col;
-                auto* dst            = &Bs[stage][col * kExpertBK + gemm_swz64(col, k8 * 8)];
-                const auto* src =
-                    gathered +
-                    static_cast<std::int64_t>(col < cols ? packed_col : begin) * kHidden + k0 +
-                    k8 * 8;
-                cp_async_zfill<16, Cache::cg>(dst, src, col < cols ? 16 : 0);
+#pragma unroll
+            for (int i = 0; i < StageIters; ++i) {
+                const int item = tid + i * ExpertThreads;
+                const int col  = item / StageChunks;
+                const int k8   = item - col * StageChunks;
+                auto* dst      = &Bs[stage][col * kExpertBK + gemm_swz64(col, k8 * 8)];
+                cp_async_zfill<16, Cache::cg>(dst, src_row[i] + k0 + k8 * 8, col < cols ? 16 : 0);
             }
 
             const int group = kt;
@@ -1134,6 +1172,7 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
     auto* scores            = static_cast<float*>(workspace.score_storage.data);
     auto* shared_activation = static_cast<__nv_bfloat16*>(workspace.shared_activation.data);
     auto* grouped_io        = static_cast<__nv_bfloat16*>(workspace.grouped_io.data);
+    auto* packed_token      = static_cast<int*>(workspace.packed_token.data);
     auto* routed_activation = static_cast<__nv_bfloat16*>(workspace.routed_storage.data);
     auto* routed_sum        = static_cast<float*>(workspace.routed_sum.data);
 
@@ -1169,6 +1208,8 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             route_tiles, route_job_bn, tokens, adaptive);
         CUDA_CHECK(cudaGetLastError());
 
+        const bool routed_gate_up_q4 = weights.routed_gate_up.qtype == QType::Q4G64_F16S;
+        const int index_blocks       = (assignments + kExpertThreads - 1) / kExpertThreads;
         if (adaptive) {
             auto* adaptive_activations = reinterpret_cast<float*>(grouped_io);
             sparse_moe_decode_launch_d3_small_t(input_slice, weights, ids, adaptive_activations,
@@ -1177,8 +1218,14 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
             sparse_moe_decode_launch_d4_small_t(
                 weights, output_slice, ids, alpha, shared_scale, adaptive_activations, tokens,
                 SparseMoeSmallTD4Schedule::Rows4, stream, route_job_count);
-            sparse_moe_prefill_gather_kernel<true><<<assignments, kExpertThreads, 0, stream>>>(
-                input, ids, local_rank, packed_index, tile_bases, grouped_io, route_job_count);
+            // adaptive implies a Q5/Q6 routed down, and prefill_min_tokens admits those only
+            // with a Q4 routed gate/up, so this path is always the indexed one.
+            sparse_moe_prefill_index_kernel<true><<<index_blocks, kExpertThreads, 0, stream>>>(
+                ids, local_rank, packed_index, tile_bases, packed_token, assignments,
+                route_job_count);
+        } else if (routed_gate_up_q4) {
+            sparse_moe_prefill_index_kernel<false><<<index_blocks, kExpertThreads, 0, stream>>>(
+                ids, local_rank, packed_index, tile_bases, packed_token, assignments, nullptr);
         } else {
             sparse_moe_prefill_gather_kernel<false><<<assignments, kExpertThreads, 0, stream>>>(
                 input, ids, local_rank, packed_index, tile_bases, grouped_io, nullptr);
@@ -1186,17 +1233,18 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         CUDA_CHECK(cudaGetLastError());
 
         const dim3 routed_gate_grid(kIntermediate / (kExpertBM / 2), kExperts);
-        if (weights.routed_gate_up.qtype == QType::Q4G64_F16S) {
+        // Same predicate that decided whether packed_token was written above.
+        if (routed_gate_up_q4) {
             if (wide_plan) {
                 sparse_moe_prefill_q4_gate_up_kernel<8, 64>
                     <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
-                        grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
-                        routed_gate_codes, routed_gate_scales, routed_activation);
+                        input, packed_token, offsets, route_job_experts, route_job_columns,
+                        route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             } else {
                 sparse_moe_prefill_q4_gate_up_kernel<4, 32>
                     <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
-                        grouped_io, offsets, route_job_experts, route_job_columns, route_job_count,
-                        routed_gate_codes, routed_gate_scales, routed_activation);
+                        input, packed_token, offsets, route_job_experts, route_job_columns,
+                        route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             }
         } else if (weights.routed_gate_up.qtype == QType::W8G32_F16S) {
             sparse_moe_prefill_w8_gate_up_kernel<true>


### PR DESCRIPTION
`sparse_moe_prefill_gather_kernel` materialises one 2048-wide BF16 row for **every (token, expert)
assignment**. At top-8 of 256 that is eight copies of every token: a 4096-token slice writes 32,768
rows of 4 KiB, which `sparse_moe_prefill_q4_gate_up_kernel` then reads straight back.

The GEMM does not need the copy, only the token each packed column came from. The copy kernel
becomes an index kernel publishing that map, and the staging loop follows it into `x`:

```cpp
-                const int packed_col = begin + column_base + col;
-                const auto* src = gathered +
-                    static_cast<std::int64_t>(col < cols ? packed_col : begin) * kHidden + ...
+            const int col = (tid + i * ExpertThreads) / StageChunks;
+            const int row = packed_token[col < cols ? begin + column_base + col : begin];
+            src_row[i]    = x + static_cast<std::int64_t>(row) * kHidden;
```

A thread stages the same columns of every `kHidden / kExpertBK` tile, so it resolves their rows once
per route job into `src_row[]` and the k-loop walks pointers. The map stays in registers, so shared
per block is unchanged. A column past the tile is clamped onto a live row exactly as it was clamped
onto a live packed column, and zero-filled by the same predicate.

Two files, +96/-36, one commit on `3d9fda22`. `dev` is two commits ahead
(`11e76d8d`, `0b5b7c9a`); neither touches these files.

## Where the time goes

`nsys profile -t cuda --cuda-graph-trace=node`, Qwen3.6-35B-A3B, 64,512-token prompt, chunk 8192,
one pass per arm:

| kernel | master ms | branch ms | delta |
|---|--:|--:|--:|
| `sparse_moe_prefill_gather_kernel` | 55.59 | **0.00** | **-55.59** |
| `sparse_moe_prefill_qx_down_kernel` | 365.63 | 361.71 | -3.92 |
| `sparse_moe_prefill_w8_gate_up_kernel` | 90.80 | 89.26 | -1.54 |
| `sparse_moe_prefill_q4_gate_up_kernel` | 663.66 | 666.27 | +2.61 |
| these four | 1175.68 | 1117.24 | -58.44 |
| every kernel in the run | 4393.3 | 4345.6 | **-47.7 (-1.09%)** |

The saving is the gather kernel's own time and nothing else: 55.59 of the 58.44 those four move.
The GEMM that stopped reading the copy is 2.61 ms slower, because it now resolves the map and reads
`x` rather than a densely packed buffer.

One pass per arm, so the small rows are attribution rather than measurement, and the run total says
by how much: the four above move -58.44 while the whole run moves -47.7, so about 10.7 ms drifted
the other way on kernels this change does not touch - attention +5.3 and the two widest
`w8_rowsplit_gemm_mma` instantiations +2.4 together. That is the resolution of a single pass here.
The -1.09% over all kernels is the figure to read against the end-to-end table, not the -5.0% those
four alone would suggest.

`sparse_moe_prefill_w8_gate_up_kernel` is the shared expert and does not gather; this artifact's
routed codec is Q4/Q5, so the branch's gather time is zero. The gather stays in the tree for the W8
routed codec, which this artifact does not exercise.

## Operator

`ninfer_sparse_moe_bench --codec all --cache cold --execution eager --repeat 50`, eager because
prefill is not graph-captured. It times the whole routed MoE operator, the gather included, which
is why it gains where the GEMM row above loses. **Three independent passes**; a row counts only if it moves in all
three. `w8-w8` is the same operator on a codec this change does not reach.

| codec | T | master us | branch us | pass 1 / 2 / 3 |
|---|--:|--:|--:|---|
| q4-q5 | 1024 | 782.37 | 753.66 | **1.038 1.044 1.041** |
| q4-q5 | 2048 | 1060.86 | 1009.66 | **1.051 1.051 1.053** |
| q4-q5 | 4096 | 1985.54 | 1898.53 | **1.046 1.046 1.046** |
| q4-q5 | 8192 | 4050.30 | 3864.99 | **1.048 1.047 1.047** |
| q4-q6 | 1024 | 790.53 | 759.84 | **1.040 1.040 1.040** |
| q4-q6 | 2048 | 1062.91 | 1011.71 | **1.051 1.050 1.053** |
| q4-q6 | 4096 | 1995.78 | 1910.78 | **1.044 1.046 1.045** |
| q4-q6 | 8192 | 4076.93 | 3907.74 | **1.043 1.046 1.048** |
| w8-w8 | 1024-8192 | 1001.47-4986.30 | 1001.50-4992.32 | 0.9985 to 1.0030, 12 cells |

Eight rows move in all three passes, median **1.046**; the us columns are pass 1.

**Roofline.** The operator is far from both roofs and this moves it a little closer to one. `logical
TFLOP/s` and `unique_weight_gbps` are the benchmark's own columns: the first counts the GEMM's
nominal MACs, the second the bytes of distinct expert weight the call touches, which is not DRAM
traffic.

| codec | T | logical TFLOP/s | % of the bf16 MMA tier | unique weight GB/s | % of 1792 GB/s spec |
|---|--:|--:|--:|--:|--:|
| q4-q5 | 4096 | 119.0 -> 124.4 | 46.1 -> 48.2 | 234.6 -> 245.3 | 13.1 -> 13.7 |
| q4-q5 | 8192 | 116.7 -> 122.2 | 45.2 -> 47.4 | 115.0 -> 120.5 | 6.4 -> 6.7 |
| w8-w8 | 4096 | 94.7 -> 94.7 | 36.7 -> 36.7 | 344.8 -> 344.9 | 19.2 -> 19.2 |

The tier is `mma.m16n8k16` bf16 with f32 accumulate, 257.9 TFLOP/s measured on this card by our own
microbenchmark; the weights are Q4 and dequantised into it. 1792 GB/s is the vendor figure for this
part. With `--cache cold` the unique weight bytes are a lower bound on the call's DRAM traffic, so
that column understates achieved bandwidth rather than overstating it.

## Workspace is unchanged

The two maps alias the dead prefix of `tile_counts`, whose last reader is
`sparse_moe_prefill_scan_kernel` (`sparse_moe_prefill_kernels.cu:183,204`), launched before the
index kernel. The buffer holds `256 * ceil(T/8) >= 32*T` elements and the two maps take `8*T` each, so the margin
is at least 2x at every width. The
offset is formed only when there is a pointer, because the same function is instantiated with
`WorkspaceLayoutBuilder`, which allocates none.

No allocation is added or removed and the arena sequence is unchanged, so
`sparse_moe_prefill_workspace_bytes` is identical by construction. The benchmark reports
43,378,176 / 86,752,768 / 173,501,952 / 173,501,952 at T = 1024/2048/4096/8192 on both arms - flat
above 4096 because the plan slices there - and the engine's `gpu workspace peak` is
104.38 / 417.53 / 835.06 MiB at chunk 1024/4096/8192 on both.

`grouped_io` stays and keeps its size: the routed down projection still writes its output there.
This removes a kernel, not capacity.

## Numerics

`gathered[packed_col]` was written as `x[token]`, and `packed_token[packed_col]` resolves to that
same token, so the staged bytes are the same bytes. Greedy output is byte-identical to `master` at
all three end-to-end points below, compared as whole generations.

`3a61ef3f` split the gather's two index lifetimes because thread 0 publishes the packed column while
its block consumes the tile-local rank. The index kernel is one thread per assignment and does both
from that thread, so the overlap does not arise; the fix stays for W8's gather.

The gather is still the W8 routed path. Inside the adaptive block it is not: adaptive requires a
Q5/Q6 routed down and `prefill_min_tokens` admits those only with a Q4 routed gate/up, so that
branch was unreachable and is removed with its instantiation.

## Resources

Paired on kernel name and template arguments; the added parameter changes the mangled symbol, so a
census keyed on the full symbol reports no change.

| instantiation | instructions | REG | SHARED |
|---|--:|--:|--:|
| `q4_gate_up<8, 64>` | 704 -> 664 | 75 -> 80 | 33792 -> 33792 |
| `q4_gate_up<4, 32>` | 672 -> 632 | 116 -> 124 | 25600 -> 25600 |
| `index_kernel<0/1>` | new, 40 / 48 | 16 | 0 |
| `gather_kernel<false>` | 48, unchanged | 20 | 0 |
| `gather_kernel<true>` | removed | | |
| the other 11 | unchanged | unchanged | unchanged |

`__launch_bounds__(ExpertWarps * 32, 3)` asks for three blocks per SM; the device reports
`sharedMemPerMultiprocessor` 102400 and `regsPerMultiprocessor` 65536. Shared is unchanged because
the map is in registers: 33792 x 3 = 101376. Registers: 80 x 256 x 3 = 61440. Both fit, zero spills
either side, and occupancy is unchanged: 3 blocks/SM for `<8, 64>` and 4 for `<4, 32>`, before and
after. But ptxas allots exactly 80 registers per thread at this bound on sm_120a, so the change
consumes the remaining headroom.

Two other forms were built and measured. A shared tile for the map costs `ExpertBN * sizeof(int)`,
cutting the shared headroom from 1024 bytes to 256, and was slower on every Q4 point. Recomputing
the token inline was slower by 0.4 to 1.4%, because the map read and the 64-bit row multiply are
then redone for each of the 32 k-tiles.

## Tests

`cd build && ctest -j1`: 96 of 98 pass on this branch and **the same 96 on `master` built in the
same directory in the same run**. The two failures, `ninfer_qwen3_6_frontend_test` and
`ninfer_qwen3_6_27b_prefix_real_test`, are identical on both arms and unrelated to this change.

## End to end

Confirmation only. Warmup discarded, then ABAB with twelve repeats per arm, pinned to the least
busy cores of a shared host. "Range" is (max - min) / mean over the twelve.

| point | median B/A | mean B/A | range A / B |
|---|--:|--:|---|
| 35B-A3B, chunk 1024, 64,512 tokens | **+1.45%** | +1.42% | 6.92% / 8.12% |
| 35B-A3B, chunk 8192, 64,512 tokens | **+1.38%** | +1.18% | 1.48% / 1.49% |
| Qwen3.6-27B dense, chunk 8192 | +0.03% | -0.03% | 0.51% / 0.84% |

Fixture is `bench/fixtures/ttft/text/long_64k_independent.json`. The dense 27B row is the null
control. Both statistics are printed because they disagree by 0.20 of a point on the chunk-8192 row
even though its range is the tighter of the two; the wide range on chunk 1024 appears on both arms
equally.

## Not checked

- No `ncu` counters: `RmProfilingAdminOnly` is set on this host, so the roofline figures come from
  the benchmark's columns and a microbenchmark peak rather than from counters.
- The `<4, 32>` instantiation is covered by the Op tests and the census, but every benchmark width
  selects `<8, 64>`.
- `docs/performance.md` publishes 35B-A3B prefill at a 1024-token chunk, a path this change is on,
  so those figures would move by roughly the chunk-1024 row above. I have not re-run that harness
  and propose no edits here; I will open a separate issue for the refresh unless you would rather it
  came with this change.

RTX 5090, sm_120a, driver 580.126.09, CUDA 13.1.115, Release, `-DCMAKE_CUDA_ARCHITECTURES=120a`,
power limit 575 W. Both arms run under the same limit and every ratio is between them.
