### PR TITLE
fix(runtime): exclude the admission source from guided pressure closure

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/pressure_planner.h
+++ b/src/targets/qwen3_6/impl/runtime/pressure_planner.h
@@ -659,6 +659,13 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guided_closure_target(
         std::optional<Selection> selected;
         for (int destructive = 0; destructive < 2 && !selected; ++destructive) {
             for (const std::size_t owner_index : owner_order) {
+                // populate_options gives the admission's source owner no options
+                // (eviction_choices == 0), and every other owner walk skips it on that
+                // basis. Skip it here as well: proposing pressure decisions for the
+                // continuation the admission itself reuses is rejected by
+                // compose_materialization through the engine-fatal "materialization
+                // pressure owner is duplicated" contract check (#135).
+                if (options.eviction_choices[owner_index] == 0) { continue; }
                 const std::uint16_t current_choice = target.owner_choices[owner_index];
                 const PressureDecision* current =
                     current_choice == 0 ? nullptr


### PR DESCRIPTION
## Linked issue and scope

Fixes #135 — the pressure planner terminates the inference engine with
`materialization pressure owner is duplicated`; the HTTP server stays up and every subsequent
request returns 503 `inference engine is unavailable` until a manual restart.

I am filing this ahead of maintainer scoping on the issue because the defect is engine-fatal for
any deployment that reaches sustained KV pressure (three independent reports on #135, including a
`--max-concurrency 1` reproduction), and the fix restores an existing invariant rather than making
a design decision. Happy to rescope or rework per review.

## Root cause

`populate_options` deliberately gives the admission's reuse source no pressure options — the
`selected_private_source` / `selected_shared_source` checks skip it, leaving its
`eviction_choices[owner] == 0`. Every other owner walk in the planning session honors that marker:

- `prepare_expansion`: `if (eviction_choice == 0) { continue; }`
- the guidance loop (`assess_target` relief accounting): `if (eviction_choice == 0 || ...) { continue; }`
- `root_maximal_target`: copies `eviction_choices`, so the source contributes choice 0
- `seal` / `seal_capture` / target assessment: skip `choice == 0`

`guided_closure_target` (new in 3d9fda2) is the one walk that does not. Its selection loop iterates
`owner_order`, which is built from **all** owners, and calls
`inspect_pressure_successors(continuation_states[...], residual, &*protection, current)` directly.
`protection` shields only the specific state image and pages the admission claims
(`inspect_pressure_option` uses it nowhere else), so the program returns non-evicting successors
(checkpoint demotions/drops) for the source continuation. The closure then pushes them into the
source's deliberately empty option list, selects a nonzero choice for it, and
`compose_materialization` rejects the plan through the engine-fatal duplicate-owner contract check.

This was established empirically, not by reading alone: instrumenting the throw site on the
production deployment from #135 captured 8 collisions, and every one was the source-equality branch
with a non-evicting decision:

```text
[dup-owner] position=0 index=3 gen=1 has_source=1 source_index=3 source_gen=1 accumulated=[] owners=2 evicts=0
[dup-owner] position=0 index=0 gen=2 has_source=1 source_index=0 source_gen=2 accumulated=[] owners=3 evicts=0
[dup-owner] position=1 index=2 gen=2 has_source=1 source_index=2 source_gen=2 accumulated=[1:2] owners=4 evicts=0
...
```

It also explains the reports on #135: concurrency, KV dtype, vision, Host KV size and shared
prefixes are all irrelevant to the defect — they only change how often the pressure planner runs
during an admission that reuses a retained continuation, which is the actual trigger (consistent
with the `--max-concurrency 1` + `reuse=private_response_replay` reproduction reported there).

## Design

One guard at the top of the guided closure's selection loop, identical in meaning to the guard
every other owner walk already uses:

```cpp
if (options.eviction_choices[owner_index] == 0) { continue; }
```

`eviction_choices == 0` marks exactly the admission's source: `populate_options` throws
`"... has no maximal outcome"` for any other owner it cannot evict. The closure can still use every
other owner; when the residual cannot be closed without touching the source, it returns
`std::nullopt` and the caller falls back exactly as before this walk existed. No public contract,
ownership boundary, or schema changes.

Two observations left for the maintainer, deliberately **not** part of this PR:

- `compose_materialization` treats a planner-proposed duplicate as engine-fatal although both call
  sites already handle `std::nullopt`; a soft rejection would keep a future planner slip from
  taking the engine down. Separate decision, separate PR if wanted.
- The demotions the closure proposed for the source are not absurd in isolation (demote an unused
  checkpoint of the reused continuation). If that is ever intended, composition would need distinct
  source handling; this guard restores today's invariant without deciding that question.

## Verification

On the PR branch exactly as submitted (RTX 5090 32 GiB `sm_120a`, driver 610.74, CUDA 13.3
compile/runtime, g++ 14.2, Debian 13 under WSL2, `-DCMAKE_CUDA_ARCHITECTURES=120a`, Release):

```
ninja -C build ninfer_resource_manager_test ninfer_admission_policy_test
./build/tests/ninfer_resource_manager_test   # ok, exit 0
./build/tests/ninfer_admission_policy_test   # ok, exit 0
```

A/B against the fault, on an otherwise identical build with the throw site instrumented (log +
soft-reject) so collisions are countable without killing the engine, Qwen3.8-27B NVFP4,
`--max-concurrency 4 --kv-dtype fp8 --max-context 234496 --kv-capacity 234496 --host-kv-mib 24576
--host-state-slots 8 --spec mtp --draft-tokens 3 --lm-head-draft --vision`:

- 5 concurrent sessions sharing a ~45k-token prefix (the config that previously faulted in
  40–45 s): **without the guard 8 collisions in ~4 min; with it 0 collisions**, 81 requests, 0 errors.
- 3 concurrent ~130k-token appending conversations against the 234k pool (the workload that killed
  the production deployment twice): 20 min, 0 collisions, 0 errors.
- Production soak with the guard: the deployment from #135 has been serving two live coding agents
  — 324 requests, prompts up to 152,441 tokens, sustained pressure-planner activity — with zero
  collisions and zero engine failures, where the unfixed build died twice within ~11–31 minutes of
  the same traffic.

## Checks not run

- No performance claim is made and none was measured; the guard only skips an owner that could
  never contribute a composable plan.
- The multi-hour mixed soak ran on the instrumented sibling build, not the exact PR binary; the
  delta between them is diagnostics at the (now unreachable) throw site.
- Vision/CUDA execution routes are untouched by this change and were exercised only incidentally
  (the production deployment runs `--vision`).
