### PR TITLE
fix(runtime): probe Host KV allocator geometry in guided pressure closure

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/pressure_planner.h
+++ b/src/targets/qwen3_6/impl/runtime/pressure_planner.h
@@ -533,6 +533,14 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guided_closure_target(
                                         std::optional<std::size_t> override_owner,
                                         const PressureDecision* override_decision) {
         detail::PhysicalDelta pressure;
+        std::vector<const ContinuationHandle*> selected_private_handles;
+        std::vector<const PressureDecision*> selected_private_decisions;
+        std::vector<const SharedPrefixHandle*> selected_shared_handles;
+        std::vector<const PressureDecision*> selected_shared_decisions;
+        selected_private_handles.reserve(owners.size());
+        selected_private_decisions.reserve(owners.size());
+        selected_shared_handles.reserve(owners.size());
+        selected_shared_decisions.reserve(owners.size());
         for (std::size_t index = 0; index < owners.size(); ++index) {
             const PressureDecision* decision = nullptr;
             if (override_owner && *override_owner == index) {
@@ -551,11 +559,28 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guided_closure_target(
                 pressure.added, decision->effect.added);
             pressure.removed = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
                 pressure.removed, decision->effect.removed);
+            if (owners[index].shared) {
+                selected_shared_handles.push_back(owners[index].shared_handle);
+                selected_shared_decisions.push_back(decision);
+            } else {
+                selected_private_handles.push_back(owners[index].private_handle);
+                selected_private_decisions.push_back(decision);
+            }
         }
         detail::PhysicalResources residual =
             program->guided_materialization_deficit(*admission.impl_, pressure);
-        residual.host.kv_bytes =
-            std::max(residual.host.kv_bytes, admission.impl_->blocked_host_allocation_bytes);
+        // The candidate's Host KV allocation can be blocked by the extent allocator's geometry
+        // even when free bytes are ample (resource-scheduling-and-context-cache.md 3.1 keeps
+        // allocator geometry independent from total bytes).  Geometry is not expressible in the
+        // aggregated residual, so probe the allocator directly with the decisions selected so
+        // far: while the demote/drop/eviction combination still cannot be allocated, keep a
+        // non-zero residual so the closure keeps driving toward relief instead of closing on an
+        // infeasible target and falling back to a root re-prefill.
+        if (!program->guided_host_allocation_feasible(
+                *admission.impl_, selected_private_handles, selected_private_decisions,
+                selected_shared_handles, selected_shared_decisions)) {
+            residual.host.kv_bytes = std::max<std::size_t>(1, residual.host.kv_bytes);
+        }
         return residual;
     };
     const detail::PhysicalResources capacity = program->admission_capacity();
@@ -733,6 +758,14 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
     detail::PhysicalDelta approximate_pressure;
     std::uint32_t total_degradation = 0;
     std::uint32_t total_dropped     = 0;
+    std::vector<const ContinuationHandle*> selected_private_handles;
+    std::vector<const PressureDecision*> selected_private_decisions;
+    std::vector<const SharedPrefixHandle*> selected_shared_handles;
+    std::vector<const PressureDecision*> selected_shared_decisions;
+    selected_private_handles.reserve(owners.size());
+    selected_private_decisions.reserve(owners.size());
+    selected_shared_handles.reserve(owners.size());
+    selected_shared_decisions.reserve(owners.size());
     for (std::size_t index = 0; index < owners.size(); ++index) {
         const std::uint16_t choice = node.owner_choices[index];
         if (choice > options.owners[index].size()) {
@@ -745,6 +778,13 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
         approximate_pressure.removed = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
             approximate_pressure.removed, decision.effect.removed);
         estimated_pressure.append(decision.transfer_requirements);
+        if (owners[index].shared) {
+            selected_shared_handles.push_back(owners[index].shared_handle);
+            selected_shared_decisions.push_back(&decision);
+        } else {
+            selected_private_handles.push_back(owners[index].private_handle);
+            selected_private_decisions.push_back(&decision);
+        }
         const std::uint32_t units = NINFER_QWEN36_RUNTIME_NS::degradation_units(decision);
         total_degradation         = NINFER_QWEN36_RUNTIME_NS::planning_saturating_u32(
             static_cast<std::uint64_t>(total_degradation) + units);
@@ -761,8 +801,15 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
     }
     detail::PhysicalResources residual =
         program->guided_materialization_deficit(*candidate.impl_, approximate_pressure);
-    residual.host.kv_bytes =
-        std::max(residual.host.kv_bytes, candidate.impl_->blocked_host_allocation_bytes);
+    // Same allocator-geometry probe as the guided closure: while the selected decisions'
+    // demote/drop/eviction combination still cannot be allocated by the Host KV extent
+    // allocator, keep a non-zero residual so guidance does not report a target as closed
+    // that the exact composition would reject.
+    if (!program->guided_host_allocation_feasible(
+            *candidate.impl_, selected_private_handles, selected_private_decisions,
+            selected_shared_handles, selected_shared_decisions)) {
+        residual.host.kv_bytes = std::max<std::size_t>(1, residual.host.kv_bytes);
+    }
 
     const detail::PhysicalResources capacity = program->admission_capacity();
     constexpr std::uint64_t kResidualOne     = 1ULL << 20U;

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -1069,6 +1069,18 @@ private:
     [[nodiscard]] detail::PhysicalResources
     guided_materialization_deficit(const AdmissionCandidateImpl& admission,
                                    const detail::PhysicalDelta& pressure) const;
+    // Projects the candidate plus the selected pressure decisions onto the Host KV extent
+    // allocator: DemoteToHost actions become allocation requests, DropHostDuplicate actions
+    // release ordinary replicas, and evictions release the owner's host-resident pages as
+    // last-reference releases.  This mirrors the host side of compose_materialization without
+    // building a complete post-state, so the guided closure can tell whether the allocator
+    // geometry (which is not a byte deficit) is still blocking the target.
+    [[nodiscard]] bool guided_host_allocation_feasible(
+        const AdmissionCandidateImpl& admission,
+        std::span<const ContinuationHandle* const> private_owners,
+        std::span<const qwen3_6::detail::PressureDecision* const> private_decisions,
+        std::span<const SharedPrefixHandle* const> shared_owners,
+        std::span<const qwen3_6::detail::PressureDecision* const> shared_decisions) const;
     [[nodiscard]] bool
     protected_materialization_page(const MaterializationSourceProtection* protection,
                                    const KVAddressSpaceStore& addresses, std::uint32_t page_offset,

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -6526,6 +6526,140 @@ ProgramImplCore::guided_materialization_deficit(const AdmissionCandidateImpl& ad
     return positive_resource_difference(required, admission_capacity());
 }
 
+bool ProgramImplCore::guided_host_allocation_feasible(
+    const AdmissionCandidateImpl& admission,
+    std::span<const ContinuationHandle* const> private_owners,
+    std::span<const qwen3_6::detail::PressureDecision* const> private_decisions,
+    std::span<const SharedPrefixHandle* const> shared_owners,
+    std::span<const qwen3_6::detail::PressureDecision* const> shared_decisions) const {
+    if (admission.planning_revision != resource_revision_ ||
+        private_owners.size() != private_decisions.size() ||
+        shared_owners.size() != shared_decisions.size()) {
+        return false;
+    }
+    std::vector<HostKVPageLayout> host_layouts;
+    std::vector<HostKVAllocationRequest> host_requests;
+    std::vector<HostKVPageReplicaRelease> host_releases;
+    std::vector<HostKVPageReplicaRelease> last_reference_releases;
+    const auto demotion_count = [](const qwen3_6::detail::PressureDecision& decision) {
+        const auto count = [](const auto& changes) {
+            return static_cast<std::size_t>(
+                std::count_if(changes.begin(), changes.end(), [](const auto& action) {
+                    return action.kind == qwen3_6::detail::PressureKVDecisionKind::DemoteToHost;
+                }));
+        };
+        return count(decision.main_kv_changes) + count(decision.backend_kv_changes);
+    };
+    std::size_t demotion_total = 0;
+    for (const qwen3_6::detail::PressureDecision* decision : private_decisions) {
+        if (decision != nullptr) { demotion_total += demotion_count(*decision); }
+    }
+    for (const qwen3_6::detail::PressureDecision* decision : shared_decisions) {
+        if (decision != nullptr) { demotion_total += demotion_count(*decision); }
+    }
+    host_layouts.reserve(demotion_total);
+    host_requests.reserve(demotion_total);
+
+    const auto append_actions = [&](const KVAddressSpaceStore& addresses, LogicalKVPageStore& pages,
+                                    KVAddressSpaceHandle address,
+                                    std::span<const qwen3_6::detail::PressureKVDecision> changes) {
+        for (const qwen3_6::detail::PressureKVDecision& action : changes) {
+            if (action.kind == qwen3_6::detail::PressureKVDecisionKind::DropHostDuplicate) {
+                const std::uint32_t mapped = addresses.mapped_pages(address);
+                if (action.begin_page > mapped || action.page_count > mapped - action.begin_page) {
+                    return false;
+                }
+                for (std::uint32_t offset = 0; offset < action.page_count; ++offset) {
+                    host_releases.push_back(HostKVPageReplicaRelease{
+                        .pages = &pages,
+                        .page  = addresses.logical_page(address, action.begin_page + offset),
+                    });
+                }
+            } else if (action.kind == qwen3_6::detail::PressureKVDecisionKind::DemoteToHost) {
+                host_layouts.push_back(plan_host_kv_page_layout(pages.physical_pool().geometry()));
+                host_requests.push_back(
+                    HostKVAllocationRequest{.layout = &host_layouts.back(), .pages = action.page_count});
+            }
+        }
+        return true;
+    };
+    const auto append_eviction_releases = [&](const KVAddressSpaceStore& addresses,
+                                              LogicalKVPageStore& pages,
+                                              KVAddressSpaceHandle address) {
+        const std::uint32_t mapped = addresses.mapped_pages(address);
+        for (std::uint32_t offset = 0; offset < mapped; ++offset) {
+            const LogicalKVPageHandle page = addresses.logical_page(address, offset);
+            if (pages.host_resident(page)) {
+                last_reference_releases.push_back(
+                    HostKVPageReplicaRelease{.pages = &pages, .page = page});
+            }
+        }
+        return true;
+    };
+    const auto append_private = [&](const ContinuationHandle* owner,
+                                    const qwen3_6::detail::PressureDecision& decision) {
+        if (owner == nullptr || ContractAccess::owner(*owner) != this ||
+            !valid_continuation(*owner)) {
+            return false;
+        }
+        const SequenceState& sequence = continuation_states[ContractAccess::index(*owner)];
+        if (!sequence.kv) { return false; }
+        if (decision.evicts_continuation) {
+            return append_eviction_releases(*text_kv_addresses, *text_kv_pages, sequence.kv->text) &&
+                   (sequence.kv->backend == std::nullopt || backend_kv_addresses == nullptr ||
+                    backend_kv_pages == nullptr ||
+                    append_eviction_releases(*backend_kv_addresses, *backend_kv_pages,
+                                             *sequence.kv->backend));
+        }
+        return append_actions(*text_kv_addresses, *text_kv_pages, sequence.kv->text,
+                              decision.main_kv_changes) &&
+               (decision.backend_kv_changes.empty() ||
+                (sequence.kv->backend && backend_kv_addresses && backend_kv_pages &&
+                 append_actions(*backend_kv_addresses, *backend_kv_pages, *sequence.kv->backend,
+                                decision.backend_kv_changes)));
+    };
+    const auto append_shared = [&](const SharedPrefixHandle* owner,
+                                   const qwen3_6::detail::PressureDecision& decision) {
+        if (owner == nullptr || ContractAccess::owner(*owner) != this ||
+            !valid_shared_prefix(*owner)) {
+            return false;
+        }
+        const SharedPrefixState& shared = shared_prefix_states[ContractAccess::index(*owner)];
+        if (!shared.kv) { return false; }
+        if (decision.evicts_continuation) {
+            return append_eviction_releases(*text_kv_addresses, *text_kv_pages, shared.kv->text) &&
+                   (shared.kv->backend == std::nullopt || backend_kv_addresses == nullptr ||
+                    backend_kv_pages == nullptr ||
+                    append_eviction_releases(*backend_kv_addresses, *backend_kv_pages,
+                                             *shared.kv->backend));
+        }
+        return append_actions(*text_kv_addresses, *text_kv_pages, shared.kv->text,
+                              decision.main_kv_changes) &&
+               (decision.backend_kv_changes.empty() ||
+                (shared.kv->backend && backend_kv_addresses && backend_kv_pages &&
+                 append_actions(*backend_kv_addresses, *backend_kv_pages, *shared.kv->backend,
+                                decision.backend_kv_changes)));
+    };
+    for (std::size_t index = 0; index < private_owners.size(); ++index) {
+        if (private_decisions[index] == nullptr ||
+            !append_private(private_owners[index], *private_decisions[index])) {
+            return false;
+        }
+    }
+    for (std::size_t index = 0; index < shared_owners.size(); ++index) {
+        if (shared_decisions[index] == nullptr ||
+            !append_shared(shared_owners[index], *shared_decisions[index])) {
+            return false;
+        }
+    }
+    // A target only needs Host KV allocation when it demotes pages.  Without demotion requests
+    // there is no allocator geometry to satisfy, regardless of what the decisions release.
+    if (host_requests.empty()) { return true; }
+    return host_kv_extents != nullptr &&
+           host_kv_extents->can_allocate_after_page_releases(
+               host_releases, last_reference_releases, host_requests);
+}
+
 bool ProgramImplCore::physical_peak_fits(detail::PhysicalResources peak) const noexcept {
     const detail::PhysicalResources occupied = physical_occupancy();
     const detail::PhysicalResources limits   = admission_capacity();

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <thread>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -271,12 +272,13 @@ struct FakeAdmissionCandidate {
 };
 
 struct FakeTargetDecision {
-    std::uint64_t id                  = 0;
-    std::uint64_t immediate_ns        = 100'000'000;
-    std::uint32_t degradation_units   = 1;
-    std::uint32_t dropped_checkpoints = 0;
-    bool evicts_continuation          = false;
-    bool shared_owner                 = false;
+    std::uint64_t id                   = 0;
+    std::uint64_t immediate_ns         = 100'000'000;
+    std::uint32_t degradation_units    = 1;
+    std::uint32_t dropped_checkpoints  = 0;
+    std::uint64_t host_kv_relief_bytes = 0;
+    bool evicts_continuation           = false;
+    bool shared_owner                  = false;
 
     friend bool operator==(const FakeTargetDecision&, const FakeTargetDecision&) = default;
 };
@@ -655,6 +657,17 @@ public:
     [[nodiscard]] bool
     target_feasible(std::span<const FakeTargetDecision> decisions) const noexcept {
         if (pressure_units(decisions) < required_pressure_actions) { return false; }
+        if (blocked_host_allocation_bytes != 0) {
+            std::uint64_t relief = 0;
+            for (const FakeTargetDecision& decision : decisions) {
+                if (decision.host_kv_relief_bytes >
+                    std::numeric_limits<std::uint64_t>::max() - relief) {
+                    return false;
+                }
+                relief += decision.host_kv_relief_bytes;
+            }
+            if (relief < blocked_host_allocation_bytes) { return false; }
+        }
         const bool has_eviction =
             std::any_of(decisions.begin(), decisions.end(),
                         [](const auto& decision) { return decision.evicts_continuation; });
@@ -979,7 +992,12 @@ public:
     std::optional<std::uint64_t> required_action_id;
     std::uint32_t pressure_assessment_delay_us    = 0;
     std::uint64_t pressure_checkpoint_recovery_ns = 100;
-    bool require_evictions                        = false;
+    // Host KV allocator-geometry block on the candidate: the arena has free bytes but the
+    // requested extent shape cannot be formed.  A target is feasible only once the selected
+    // decisions release at least this many Host KV bytes.
+    std::uint64_t blocked_host_allocation_bytes  = 0;
+    std::uint64_t eviction_host_kv_relief_bytes  = 0;
+    bool require_evictions                       = false;
     bool abort_start                              = false;
     bool abort_progress                           = false;
     bool progress_in_progress_once                = false;
@@ -1113,22 +1131,24 @@ FakePressurePlanningSession::decisions_for(std::uint32_t selected_candidate,
             });
         }
         decisions.push_back(FakeTargetDecision{
-            .id                  = 2000U + owner.private_handle->id,
-            .degradation_units   = 4,
-            .dropped_checkpoints = 1,
-            .evicts_continuation = true,
+            .id                    = 2000U + owner.private_handle->id,
+            .degradation_units     = 4,
+            .dropped_checkpoints   = 1,
+            .host_kv_relief_bytes  = program_->eviction_host_kv_relief_bytes,
+            .evicts_continuation   = true,
         });
     } else {
         decisions.push_back(FakeTargetDecision{
-            .id           = 3000U + owner.shared_handle->id,
-            .shared_owner = true,
+            .id                    = 3000U + owner.shared_handle->id,
+            .shared_owner          = true,
         });
         decisions.push_back(FakeTargetDecision{
-            .id                  = 4000U + owner.shared_handle->id,
-            .degradation_units   = 4,
-            .dropped_checkpoints = 1,
-            .evicts_continuation = true,
-            .shared_owner        = true,
+            .id                    = 4000U + owner.shared_handle->id,
+            .degradation_units     = 4,
+            .dropped_checkpoints   = 1,
+            .host_kv_relief_bytes  = program_->eviction_host_kv_relief_bytes,
+            .evicts_continuation   = true,
+            .shared_owner          = true,
         });
     }
     return decisions;
@@ -1211,34 +1231,105 @@ std::optional<FakePressureTargetHandle> FakePressurePlanningSession::guided_clos
         }
         return decisions;
     };
-    for (int destructive = 0; destructive < 2; ++destructive) {
-        for (const std::size_t owner_index : order) {
-            const auto& alternatives = options_[selected_candidate][owner_index];
-            if (target.choices[owner_index] != 0 || alternatives.empty()) { continue; }
-            const auto found = std::find_if(
-                alternatives.begin(), alternatives.end(), [&](const FakeTargetDecision& decision) {
-                    return decision.evicts_continuation == (destructive != 0);
-                });
-            if (found == alternatives.end()) { continue; }
-            target.choices[owner_index] =
-                static_cast<std::uint16_t>(1U + (found - alternatives.begin()));
-            if (program_->target_feasible(selected_decisions())) {
-                auto existing =
-                    std::find_if(targets_.begin(), targets_.end(),
-                                 [&](const Target& prior) { return same_target(prior, target); });
-                std::uint32_t target_index = 0;
-                if (existing != targets_.end()) {
-                    target_index = static_cast<std::uint32_t>(existing - targets_.begin());
-                } else {
-                    target.stable_ordinal = static_cast<std::uint32_t>(targets_.size());
-                    targets_.push_back(std::move(target));
-                    target_index = static_cast<std::uint32_t>(targets_.size() - 1U);
-                    program_->pressure_target_count_peak =
-                        std::max(program_->pressure_target_count_peak, targets_.size());
-                }
-                return FakePressureTargetHandle{.generation = generation_, .index = target_index};
+    const auto decisions_with = [&](std::size_t override_owner, std::uint16_t override_choice) {
+        std::vector<FakeTargetDecision> decisions;
+        for (std::size_t index = 0; index < owners_.size(); ++index) {
+            const std::uint16_t choice =
+                index == override_owner ? override_choice : target.choices[index];
+            if (choice != 0) {
+                decisions.push_back(options_[selected_candidate][index][choice - 1U]);
             }
         }
+        return decisions;
+    };
+    // Mirror the real session's closure residual: required pressure units plus the candidate's
+    // Host KV allocator-geometry block, which selected decisions relieve by the Host KV pages
+    // they release (the fake approximates the real extent-geometry probe with release bytes).
+    struct Residual {
+        std::size_t units        = 0;
+        std::uint64_t blocked_bytes = 0;
+
+        [[nodiscard]] constexpr bool operator==(const Residual&) const noexcept = default;
+    };
+    const auto residual_for = [&](std::span<const FakeTargetDecision> decisions) {
+        std::size_t units     = program_->pressure_units(decisions);
+        std::uint64_t relief  = 0;
+        for (const FakeTargetDecision& decision : decisions) {
+            if (decision.host_kv_relief_bytes >
+                std::numeric_limits<std::uint64_t>::max() - relief) {
+                relief = std::numeric_limits<std::uint64_t>::max();
+            } else {
+                relief += decision.host_kv_relief_bytes;
+            }
+        }
+        const std::uint64_t blocked = program_->blocked_host_allocation_bytes;
+        return Residual{
+            .units = units >= program_->required_pressure_actions
+                         ? 0U
+                         : program_->required_pressure_actions - units,
+            .blocked_bytes = blocked > relief ? blocked - relief : 0,
+        };
+    };
+    const std::size_t maximum_steps = 16U * std::max<std::size_t>(1, owners_.size()) + 16U;
+    for (std::size_t step = 0; step < maximum_steps; ++step) {
+        if (program_->target_feasible(selected_decisions())) {
+            auto existing =
+                std::find_if(targets_.begin(), targets_.end(),
+                             [&](const Target& prior) { return same_target(prior, target); });
+            std::uint32_t target_index = 0;
+            if (existing != targets_.end()) {
+                target_index = static_cast<std::uint32_t>(existing - targets_.begin());
+            } else {
+                target.stable_ordinal = static_cast<std::uint32_t>(targets_.size());
+                targets_.push_back(std::move(target));
+                target_index = static_cast<std::uint32_t>(targets_.size() - 1U);
+                program_->pressure_target_count_peak =
+                    std::max(program_->pressure_target_count_peak, targets_.size());
+            }
+            return FakePressureTargetHandle{.generation = generation_, .index = target_index};
+        }
+        const Residual residual = residual_for(selected_decisions());
+        std::optional<std::pair<std::size_t, std::uint16_t>> selected;
+        for (int destructive = 0; destructive < 2 && !selected; ++destructive) {
+            for (const std::size_t owner_index : order) {
+                const std::uint16_t current_choice = target.choices[owner_index];
+                const FakeTargetDecision* current =
+                    current_choice == 0
+                        ? nullptr
+                        : &options_[selected_candidate][owner_index][current_choice - 1U];
+                if (current != nullptr && current->evicts_continuation) { continue; }
+                const auto& alternatives = options_[selected_candidate][owner_index];
+                if (alternatives.empty()) { continue; }
+                std::optional<
+                    std::pair<std::uint16_t,
+                              std::tuple<std::size_t, std::uint64_t, std::uint64_t, std::uint64_t>>>
+                    owner_best;
+                for (std::uint16_t choice = 1; choice <= alternatives.size(); ++choice) {
+                    if (choice == current_choice) { continue; }
+                    const FakeTargetDecision& decision = alternatives[choice - 1U];
+                    const std::uint32_t prior_drops =
+                        current == nullptr ? 0 : current->dropped_checkpoints;
+                    const bool adds_destruction =
+                        decision.evicts_continuation || decision.dropped_checkpoints > prior_drops;
+                    if (adds_destruction != (destructive != 0)) { continue; }
+                    const Residual child_residual =
+                        residual_for(decisions_with(owner_index, choice));
+                    if (child_residual == residual) { continue; }
+                    const auto key = std::tuple{
+                        child_residual.units, child_residual.blocked_bytes,
+                        static_cast<std::uint64_t>(decision.degradation_units), decision.id};
+                    if (!owner_best || key < owner_best->second) {
+                        owner_best = std::pair{choice, key};
+                    }
+                }
+                if (owner_best) {
+                    selected = std::pair{owner_index, owner_best->first};
+                    break;
+                }
+            }
+        }
+        if (!selected) { return std::nullopt; }
+        target.choices[selected->first] = selected->second;
     }
     return std::nullopt;
 }
@@ -2424,6 +2515,44 @@ void test_guided_pressure_reaches_deep_retention_before_maximal_fallback() {
             "guided pressure search returned to eager breadth-first assessment");
 }
 
+void test_guided_closure_relieves_allocator_geometry_block() {
+    FakeManager manager = make_manager(1, 3);
+    FakeProgram program;
+    std::array<std::uint32_t, 2> parked_ids{};
+    for (std::size_t index = 0; index < parked_ids.size(); ++index) {
+        const std::uint32_t content = static_cast<std::uint32_t>(61U + index);
+        const ActiveRequest parked =
+            start_active(manager, program, content, make_base(content), index + 1U);
+        parked_ids[index] = parked.sequence.id;
+        (void)finish_active(manager, program, parked);
+    }
+
+    // The candidate is blocked by the Host KV extent allocator (geometry), not by bytes: the
+    // arena has free capacity but the requested extent shape cannot be formed.  Evicting one
+    // whole parked context releases enough Host KV bytes to unblock it, so the guided closure
+    // must relieve the blocked amount by the pressure it has already selected instead of
+    // keeping the original unrelieved residual forever.
+    program.required_pressure_actions    = 1;
+    program.blocked_host_allocation_bytes = 1ULL << 30U;
+    program.eviction_host_kv_relief_bytes = 1ULL << 30U;
+    auto inspection = manager.inspect(program, FakePreparedPrompt{70}, make_base(70), 3);
+    require(inspection.choice.has_value(),
+            "guided pressure search found no plan for an allocator-geometry block");
+
+    program.abort_start = true;
+    (void)manager.reserve_materialization(program, std::move(*inspection.choice),
+                                          FakePreparedPrompt{70}, {});
+    require(program.started_action_ids.size() == 1,
+            "guided closure did not relieve the allocator-geometry block with a single eviction");
+    const bool evicted_parked =
+        std::any_of(parked_ids.begin(), parked_ids.end(), [&](std::uint32_t id) {
+            return std::find(program.started_action_ids.begin(), program.started_action_ids.end(),
+                             2000U + id) != program.started_action_ids.end();
+        });
+    require(evicted_parked,
+            "guided closure did not evict a parked context to relieve the allocator block");
+}
+
 void test_combined_target_reprices_cancelled_pressure_copy() {
     FakeManager manager = make_manager(1, 3);
     FakeProgram program;
@@ -2750,6 +2879,8 @@ int main() {
     run_test("joint two-owner pressure", test_two_owners_jointly_close_pressure);
     run_test("guided deep retention",
              test_guided_pressure_reaches_deep_retention_before_maximal_fallback);
+    run_test("guided closure relieves allocator geometry block",
+             test_guided_closure_relieves_allocator_geometry_block);
     run_test("combined target exact repricing",
              test_combined_target_reprices_cancelled_pressure_copy);
     run_test("in-progress and capture", test_in_progress_adoption_and_private_capture);


### PR DESCRIPTION
## Linked issue and scope

Addresses #144: under concurrent streamed load a rotation over a second cohort of stored contexts re-prefills the last context of every round from `root` (~11 s TTFT, 0 cache hits) once the Host State descriptors saturate, even though Host KV is only half full and evicting one parked context would unblock the request.

## Root cause

`blocked_host_allocation_bytes` is only ever assigned inside `compose_materialization`, and that function requires its input candidate to be unblocked, so every candidate the planner sees carries zero. The previous byte fold in the guided closure and guidance therefore did nothing: **allocator geometry is not representable in the guided residual at all**. When the `DemoteToHost` requests of a pressure target cannot be allocated even though free Host KV bytes are ample, the closure closed immediately on an infeasible target, the exact assessment rejected it, and the bounded search fell back to a root re-prefill. The observed `stop_reason: time_budget`, `targets_evaluated: 12`, `selected_maximal_fallback: false` and a standing parked estate match this path exactly.

## Change

- New `ProgramImplCore::guided_host_allocation_feasible()`: a host-side projection of the candidate plus the selected pressure decisions into allocation requests (`DemoteToHost`) and releases (`DropHostDuplicate` replicas and eviction last-reference pages), answered by the real extent allocator (`can_allocate_after_page_releases`) — not by subtracting bytes.
- The guided closure's per-step residual and the target guidance residual keep a non-zero component while that probe fails, so the closure can drive toward relief (e.g. evicting one whole parked context) instead of closing on a target the allocator rejects; the exact composition still re-validates before any plan is sealed.

## Test

- Resource-manager harness mirrors the probe with release bytes; regression test `guided closure relieves allocator geometry block` asserts a single-owner eviction relieves an allocator-geometry block. Verified: the test fails on the pre-fix closure behavior and passes with the fix; the full `test_resource_manager` suite passes.
- Built in WSL with CUDA 13.3 and run on an RTX 5090 against `qwen3_8_27b_nvfp4` (real weights): `ninfer_qwen3_6_context_store_test`, `prefix_real` scenarios `pressure-resume` and `private-checkpoint-pressure` all pass; the Qwen3.6/3.8 session template instantiations compile cleanly.