### PR TITLE
The RMSNorm weight load moves above the reduction: kernels 0.67x to 0.94x, decode +1.5 to +2.6%, bitwise identical

### DIFF
--- a/bench/ops/rmsnorm_bench.cu
+++ b/bench/ops/rmsnorm_bench.cu
@@ -161,14 +161,14 @@ template <int Block>
 void launch_plain_candidate(const Shape& shape, const void* x, const void* weight, void* out,
                             int rows, cudaStream_t stream) {
     if (shape.d == 128) {
-        ops::rmsnorm_warp_bf16x2_kernel<ops::RmsEpilogue::Plain, Block>
+        ops::rmsnorm_warp_bf16x2_kernel<ops::RmsEpilogue::Plain, Block, false>
             <<<static_cast<unsigned int>((rows + Block / 32 - 1) / (Block / 32)), Block, 0,
                stream>>>(static_cast<const __nv_bfloat162*>(x),
                          static_cast<const __nv_bfloat162*>(weight), nullptr,
                          static_cast<__nv_bfloat162*>(out), shape.d, rows, 1.0e-6f);
     } else if (shape.d == 2048) {
         constexpr int kMaxPairsPerThread = 1024 / Block;
-        ops::rmsnorm_cta_bf16x2_kernel<ops::RmsEpilogue::Plain, Block, kMaxPairsPerThread>
+        ops::rmsnorm_cta_bf16x2_kernel<ops::RmsEpilogue::Plain, Block, kMaxPairsPerThread, false>
             <<<static_cast<unsigned int>(rows), Block, 0, stream>>>(
                 static_cast<const __nv_bfloat162*>(x), static_cast<const __nv_bfloat162*>(weight),
                 nullptr, static_cast<__nv_bfloat162*>(out), shape.d, rows, 1.0e-6f);

--- a/src/ops/kernel/rmsnorm.cuh
+++ b/src/ops/kernel/rmsnorm.cuh
@@ -28,7 +28,7 @@ __device__ __forceinline__ float rmsnorm_epilogue(float x, float inv, float weig
 // Fast geometry for D in {64, 128, 192, 256}. One warp owns one row, keeps the input in
 // registers, and uses only warp shuffles for the reduction. Block is a scheduling choice rather
 // than part of the row geometry.
-template <RmsEpilogue Epilogue, int Block>
+template <RmsEpilogue Epilogue, int Block, bool Prefetch>
 __launch_bounds__(Block) __global__
     void rmsnorm_warp_bf16x2_kernel(const __nv_bfloat162* x, const __nv_bfloat162* weight,
                                     const __nv_bfloat162* z, __nv_bfloat162* out, std::int32_t d,
@@ -44,13 +44,19 @@ __launch_bounds__(Block) __global__
     const int pairs             = d / 2;
     const std::int64_t row_base = row * static_cast<std::int64_t>(pairs);
     __nv_bfloat162 values[kMaxPairsPerLane];
+    __nv_bfloat162 weights[kMaxPairsPerLane];
+    __nv_bfloat162 gates[kMaxPairsPerLane];
     float sum = 0.0f;
 
 #pragma unroll
     for (int k = 0; k < kMaxPairsPerLane; ++k) {
         const int pair = lane + k * kWarpSize;
         if (pair < pairs) {
-            values[k]       = x[row_base + pair];
+            values[k] = x[row_base + pair];
+            if constexpr (Prefetch) {
+                weights[k] = weight[pair];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { gates[k] = z[row_base + pair]; }
+            }
             const float2 xf = __bfloat1622float2(values[k]);
             sum += xf.x * xf.x + xf.y * xf.y;
         }
@@ -65,11 +71,18 @@ __launch_bounds__(Block) __global__
         const int pair = lane + k * kWarpSize;
         if (pair < pairs) {
             const float2 xf = __bfloat1622float2(values[k]);
-            const float2 wf = __bfloat1622float2(weight[pair]);
-            float2 zf{0.0f, 0.0f};
-            if constexpr (Epilogue == RmsEpilogue::Gated) {
-                zf = __bfloat1622float2(z[row_base + pair]);
+            __nv_bfloat162 w_pair;
+            __nv_bfloat162 z_pair{};
+            if constexpr (Prefetch) {
+                w_pair = weights[k];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { z_pair = gates[k]; }
+            } else {
+                w_pair = weight[pair];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { z_pair = z[row_base + pair]; }
             }
+            const float2 wf = __bfloat1622float2(w_pair);
+            float2 zf{0.0f, 0.0f};
+            if constexpr (Epilogue == RmsEpilogue::Gated) { zf = __bfloat1622float2(z_pair); }
             out[row_base + pair] =
                 __floats2bfloat162_rn(rmsnorm_epilogue<Epilogue>(xf.x, inv, wf.x, zf.x),
                                       rmsnorm_epilogue<Epilogue>(xf.y, inv, wf.y, zf.y));
@@ -123,7 +136,7 @@ __launch_bounds__(Block) __global__
 
 // Fast geometry for wide rows. One CTA owns one row and keeps up to MaxPairsPerThread BF16x2
 // values per lane. The launcher admits only widths evenly divisible by the CTA vector span.
-template <RmsEpilogue Epilogue, int Block, int MaxPairsPerThread>
+template <RmsEpilogue Epilogue, int Block, int MaxPairsPerThread, bool Prefetch>
 __launch_bounds__(Block) __global__
     void rmsnorm_cta_bf16x2_kernel(const __nv_bfloat162* x, const __nv_bfloat162* weight,
                                    const __nv_bfloat162* z, __nv_bfloat162* out, std::int32_t d,
@@ -136,13 +149,23 @@ __launch_bounds__(Block) __global__
     const int pairs_per_thread  = pairs / Block;
     const std::int64_t row_base = row * static_cast<std::int64_t>(pairs);
     __nv_bfloat162 values[MaxPairsPerThread];
+    // Neither the weight nor the gate depends on the sum of squares, so under Prefetch both
+    // are issued in the same pass as x and the two trips to memory overlap instead of running
+    // back to back across the reduction. They cost registers, so the launcher turns this off
+    // once the grid is wide enough that occupancy is worth more than the overlap.
+    __nv_bfloat162 weights[MaxPairsPerThread];
+    __nv_bfloat162 gates[MaxPairsPerThread];
     float sum = 0.0f;
 
 #pragma unroll
     for (int k = 0; k < MaxPairsPerThread; ++k) {
         if (k < pairs_per_thread) {
-            const int pair  = static_cast<int>(threadIdx.x) + k * Block;
-            values[k]       = x[row_base + pair];
+            const int pair = static_cast<int>(threadIdx.x) + k * Block;
+            values[k]      = x[row_base + pair];
+            if constexpr (Prefetch) {
+                weights[k] = weight[pair];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { gates[k] = z[row_base + pair]; }
+            }
             const float2 xf = __bfloat1622float2(values[k]);
             sum += xf.x * xf.x + xf.y * xf.y;
         }
@@ -160,11 +183,18 @@ __launch_bounds__(Block) __global__
         if (k < pairs_per_thread) {
             const int pair  = static_cast<int>(threadIdx.x) + k * Block;
             const float2 xf = __bfloat1622float2(values[k]);
-            const float2 wf = __bfloat1622float2(weight[pair]);
-            float2 zf{0.0f, 0.0f};
-            if constexpr (Epilogue == RmsEpilogue::Gated) {
-                zf = __bfloat1622float2(z[row_base + pair]);
+            __nv_bfloat162 w_pair;
+            __nv_bfloat162 z_pair{};
+            if constexpr (Prefetch) {
+                w_pair = weights[k];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { z_pair = gates[k]; }
+            } else {
+                w_pair = weight[pair];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { z_pair = z[row_base + pair]; }
             }
+            const float2 wf = __bfloat1622float2(w_pair);
+            float2 zf{0.0f, 0.0f};
+            if constexpr (Epilogue == RmsEpilogue::Gated) { zf = __bfloat1622float2(z_pair); }
             out[row_base + pair] =
                 __floats2bfloat162_rn(rmsnorm_epilogue<Epilogue>(xf.x, inv, wf.x, zf.x),
                                       rmsnorm_epilogue<Epilogue>(xf.y, inv, wf.y, zf.y));

--- a/src/ops/launcher/rmsnorm.cu
+++ b/src/ops/launcher/rmsnorm.cu
@@ -11,6 +11,14 @@
 namespace ninfer::ops::detail {
 namespace {
 
+// Past this many blocks the gated epilogue gives up its hoisted loads. Below one block per SM the
+// prefetch is the only source of overlap and those kernels run at 0.83x to 0.96x; above it a
+// second resident block already supplies that overlap and only the register cost is left (35 -> 50
+// on the warp kernel), which measures 1.02x to 1.14x. Swept over grid size on both gated shapes
+// the crossing sits between 176 and 192 blocks; this is the 170 SMs of this part, a literal
+// because nothing in the tree queries the device, so it is not portable.
+constexpr std::int64_t kRmsPrefetchBlocks = 170;
+
 template <RmsEpilogue Epilogue>
 void launch_rmsnorm(const Tensor& x, const Tensor& weight, const Tensor* z, Tensor& out,
                     std::int32_t d, std::int64_t rows, float eps, bool aligned2,
@@ -19,6 +27,12 @@ void launch_rmsnorm(const Tensor& x, const Tensor& weight, const Tensor* z, Tens
     const auto* w_bf16 = static_cast<const __nv_bfloat16*>(weight.data);
     const auto* z_bf16 = z != nullptr ? static_cast<const __nv_bfloat16*>(z->data) : nullptr;
     auto* out_bf16     = static_cast<__nv_bfloat16*>(out.data);
+
+    // The hoisted weight and gate cost registers. Measured at 512-thread blocks, only the
+    // gated epilogue loses a block per SM for them: warp 35 -> 50 and the wide row 38 -> 48, both
+    // three blocks to two, while every other instantiation stays at three. So only that epilogue
+    // consults the grid, and the un-prefetched instantiation is compiled only where it is reached.
+    constexpr bool kGateOnGrid = Epilogue == RmsEpilogue::Gated;
 
     if (aligned2 && d == 128 && Epilogue == RmsEpilogue::Plain) {
         // Plain per-head D128 is latency-bound for Q32/KV8 rows. Four rows per CTA follows the
@@ -35,7 +49,17 @@ void launch_rmsnorm(const Tensor& x, const Tensor& weight, const Tensor* z, Tens
         constexpr int kBlock         = 512;
         constexpr int kWarpsPerBlock = kBlock / kWarpSize;
         const auto blocks = static_cast<unsigned int>((rows + kWarpsPerBlock - 1) / kWarpsPerBlock);
-        rmsnorm_warp_bf16x2_kernel<Epilogue, kBlock><<<blocks, kBlock, 0, stream>>>(
+        if constexpr (kGateOnGrid) {
+            if (blocks > kRmsPrefetchBlocks) {
+                rmsnorm_warp_bf16x2_kernel<Epilogue, kBlock, false><<<blocks, kBlock, 0, stream>>>(
+                    reinterpret_cast<const __nv_bfloat162*>(x_bf16),
+                    reinterpret_cast<const __nv_bfloat162*>(w_bf16),
+                    reinterpret_cast<const __nv_bfloat162*>(z_bf16),
+                    reinterpret_cast<__nv_bfloat162*>(out_bf16), d, rows, eps);
+                return;
+            }
+        }
+        rmsnorm_warp_bf16x2_kernel<Epilogue, kBlock, true><<<blocks, kBlock, 0, stream>>>(
             reinterpret_cast<const __nv_bfloat162*>(x_bf16),
             reinterpret_cast<const __nv_bfloat162*>(w_bf16),
             reinterpret_cast<const __nv_bfloat162*>(z_bf16),
@@ -49,14 +73,27 @@ void launch_rmsnorm(const Tensor& x, const Tensor& weight, const Tensor* z, Tens
             reinterpret_cast<const __nv_bfloat162*>(z_bf16),
             reinterpret_cast<__nv_bfloat162*>(out_bf16), rows, eps);
     } else if (aligned2 && d >= 512 && d <= 3072 && d % 512 == 0) {
-        rmsnorm_cta_bf16x2_kernel<Epilogue, 256, 6>
+        // 30 -> 34 registers at Block=256, which is 6 blocks per SM either way under the
+        // 1536-thread cap, so this route pays no occupancy for the prefetch and is not gated.
+        rmsnorm_cta_bf16x2_kernel<Epilogue, 256, 6, true>
             <<<static_cast<unsigned int>(rows), 256, 0, stream>>>(
                 reinterpret_cast<const __nv_bfloat162*>(x_bf16),
                 reinterpret_cast<const __nv_bfloat162*>(w_bf16),
                 reinterpret_cast<const __nv_bfloat162*>(z_bf16),
                 reinterpret_cast<__nv_bfloat162*>(out_bf16), d, rows, eps);
     } else if (aligned2 && d > 3072 && d <= 8192 && d % 1024 == 0) {
-        rmsnorm_cta_bf16x2_kernel<Epilogue, 512, 8>
+        if constexpr (kGateOnGrid) {
+            if (rows > kRmsPrefetchBlocks) {
+                rmsnorm_cta_bf16x2_kernel<Epilogue, 512, 8, false>
+                    <<<static_cast<unsigned int>(rows), 512, 0, stream>>>(
+                        reinterpret_cast<const __nv_bfloat162*>(x_bf16),
+                        reinterpret_cast<const __nv_bfloat162*>(w_bf16),
+                        reinterpret_cast<const __nv_bfloat162*>(z_bf16),
+                        reinterpret_cast<__nv_bfloat162*>(out_bf16), d, rows, eps);
+                return;
+            }
+        }
+        rmsnorm_cta_bf16x2_kernel<Epilogue, 512, 8, true>
             <<<static_cast<unsigned int>(rows), 512, 0, stream>>>(
                 reinterpret_cast<const __nv_bfloat162*>(x_bf16),
                 reinterpret_cast<const __nv_bfloat162*>(w_bf16),

--- a/tests/ops/test_rmsnorm.cpp
+++ b/tests/ops/test_rmsnorm.cpp
@@ -81,6 +81,7 @@ int main() {
     int failures = 0;
     failures += run_case("rmsnorm offset [5120,1]", {5120, 1}, true, 1101U);
     failures += run_case("rmsnorm offset [5120,128]", {5120, 128}, true, 1102U);
+    failures += run_case("rmsnorm offset [5120,1024]", {5120, 1024}, true, 1107U);
     failures += run_case("rmsnorm offset [2048,7]", {2048, 7}, true, 1103U);
     failures += run_case("rmsnorm offset [256,24,7]", {256, 24, 7}, true, 1104U);
     failures += run_case("rmsnorm offset [256,2,1]", {256, 2}, true, 1105U);


### PR DESCRIPTION
The RMSNorm kernels read `x` and accumulate the sum of squares, block-reduce across two barriers,
then read `weight` (and `z` for the gated epilogue) and write the output. The second read is issued
after the barrier although it depends on neither the sum nor `inv`, so its latency is serialised
behind the reduction instead of hidden by it.

```cpp
     for (int k = 0; k < MaxPairsPerThread; ++k) {
         if (k < pairs_per_thread) {
             const int pair = static_cast<int>(threadIdx.x) + k * Block;
             values[k]      = x[row_base + pair];
+            if constexpr (Prefetch) {
+                weights[k] = weight[pair];
+                if constexpr (Epilogue == RmsEpilogue::Gated) { gates[k] = z[row_base + pair]; }
+            }
```

Same values, same summation order, same epilogue: bitwise identical output.

One commit on `master` at `da49c0d6`. No workspace is allocated or resized and shared memory per
kernel is unchanged (1092 B on every 512-thread instantiation, both arms), so this takes nothing
from KV or cached contexts. What it costs is registers, which is what the gate is about.

## The gate, and why it is per epilogue

At 512-thread blocks on this part exactly one epilogue pays a block per SM for the hoisted loads.
`cuobjdump -res-usage`, nvcc 13.1.115, sm_120a; blocks/SM from 65536 registers, an eight-register
granule and the 1536-thread cap:

| instantiation | master | Prefetch=false | Prefetch=true | blocks/SM, false -> true |
|---|--:|--:|--:|---|
| `warp<Gated, 512>` | 35 | **35** | **50** | 3 -> **2** |
| `cta<Gated, 512, 8>` | 38 | **38** | **48** | 3 -> **2** |
| `warp<Offset, 512>` (*) | 31 | 31 | 35 | 3 -> 3 |
| `warp<Plain, 512>` (*) | 31 | 31 | 35 | 3 -> 3 |
| `cta<Offset, 512, 8>` (*) | 32 | 32 | 37 | 3 -> 3 |
| `cta<Plain, 512, 8>` (*) | 32 | 32 | 37 | 3 -> 3 |
| `cta<Offset, 256, 6>` | 30 | - | 34 | 6 -> 6 |
| `cta<Gated, 256, 6>` | 36 | - | 40 | 6 -> 6 |

(*) the `Prefetch=false` column for these four comes from a build that instantiated every epilogue
both ways. The shipped launcher gates through `if constexpr`, so it compiles `false` **only** for
the gated epilogue: those four instantiations do not exist in this branch's binary. No instantiation
spills; `STACK` and `LOCAL` are zero throughout.

Where `Prefetch=false` is compiled it has master's register count exactly, so the gated-off path is
master's kernel rather than an approximation of it.

The 256-thread route is not gated: 30 -> 34 there is six blocks per SM either way, bounded by the
thread cap and not the register file.

With the gate removed entirely, the two gated shapes at T=1024 measure **1.134** and **1.127**.
That is what it is for.

### Where the gate belongs

Two builds differing only in the constant - one that never prefetches, one that always does - swept
over grid size. Both gated shapes are `D=128` on the same warp route, so a block count is the same
work in either: at equal grids they agree to the nanosecond, 384 blocks reading 2080 -> 2272 ns on
both and 512 and 513 blocks reading 2592 -> 2624. The ratio is a function of the grid, not of the
shape.

| blocks | 8 | 32 | 96 | 128 | 170 | 176 | 192 | 224 | 288 | 384 | 448 | 512 | 768 | 1024 |
|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| prefetch / not | **0.826** | **0.848** | **0.870** | **0.915** | **0.959** | **0.981** | 1.019 | 1.037 | 1.038 | 1.092 | **1.136** | 1.012 | 1.093 | 1.090 |

The crossing is between 176 and 192 blocks, and this part has 170 SMs. Below one block per SM the
prefetch is the only source of overlap; above it a second resident block already supplies that
overlap and only the register cost is left. The gate is placed at 170.

An earlier revision of this branch used 512, which is three times too high: it left the whole
192-to-512 band prefetching, where the kernel is 1.02x to 1.14x. With the gate at 170 that band is
master, and the win below it is untouched:

| blocks | 8 | 128 | 170 | 176 | 192 | 256 | 448 | 512 | 768 | 1024 | 2048 |
|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| branch / master | **0.826** | **0.915** | **0.959** | 1.000 | 1.000 | 1.000 | 1.000 | 1.012 | 1.000 | 1.000 | 1.000 |

The 1.012 at 512 blocks is one tick of the instrument on a code path that is byte-identical to
master.

`Prefetch` has no default, so no call site changes behaviour implicitly. The benchmark's two
candidate launch sites name it explicitly as well; with a default, the seven candidate
instantiations they expand to would have moved silently.

## Operator

`ninfer_rmsnorm_bench` under `nsys`, every registered shape, three widths, a warmup capture
discarded and then three ABBA pairs per cell. The number is the kernel's own GPU time, minimum over
the 43k to 90k launches `bench_loop` issues inside a capture and then over the three captures.
`dflash_*` are the controls: their kernels are not touched by this change.

| shape | T | rows | kernel | master ns | branch ns | b/m | master GB/s | branch GB/s |
|---|--:|--:|---|--:|--:|--:|--:|--:|
| `dflash_hidden` | 4 | 4 | `d2048` | 1151 | 1151 | 1.000 | 28 (2%) | 28 (2%) |
| `dflash_hidden` | 64 | 64 | `d2048` | 1280 | 1280 | 1.000 | 410 (23%) | 410 (23%) |
| `dflash_hidden` | 1024 | 1024 | `d2048` | 2720 | 2720 | 1.000 | 3084 (172%) | 3084 (172%) |
| `dflash_q` | 4 | 128 | `d128` | 863 | 863 | 1.000 | 76 (4%) | 76 (4%) |
| `dflash_q` | 64 | 2048 | `d128` | 1119 | 1119 | 1.000 | 937 (52%) | 937 (52%) |
| `dflash_q` | 1024 | 32768 | `d128` | 4576 | 4576 | 1.000 | 3666 (205%) | 3666 (205%) |
| `dflash_k` | 4 | 32 | `d128` | 863 | 863 | 1.000 | 19 (1%) | 19 (1%) |
| `dflash_k` | 64 | 512 | `d128` | 959 | 959 | 1.000 | 273 (15%) | 273 (15%) |
| `dflash_k` | 1024 | 8192 | `d128` | 1728 | 1728 | 1.000 | 2427 (135%) | 2427 (135%) |
| `target_hidden35` | 4 | 4 | `cta<256,6>` | 1535 | 1087 | **0.708** | 21 (1%) | 30 (2%) |
| `target_hidden35` | 64 | 64 | `cta<256,6>` | 1727 | 1152 | **0.667** | 304 (17%) | 455 (25%) |
| `target_hidden35` | 1024 | 1024 | `cta<256,6>` | 3104 | 2592 | **0.835** | 2703 (151%) | 3236 (181%) |
| `target_q35` | 4 | 64 | `warp` | 1439 | 1056 | **0.734** | 46 (3%) | 62 (3%) |
| `target_q35` | 64 | 1024 | `warp` | 1536 | 1151 | **0.749** | 683 (38%) | 911 (51%) |
| `target_q35` | 1024 | 16384 | `warp` | 4096 | 3776 | **0.922** | 4096 (229%) | 4443 (248%) |
| `target_k35` | 4 | 8 | `warp` | 1375 | 991 | **0.721** | 6 (0%) | 8 (0%) |
| `target_k35` | 64 | 128 | `warp` | 1567 | 1119 | **0.714** | 84 (5%) | 117 (7%) |
| `target_k35` | 1024 | 2048 | `warp` | 1600 | 1311 | **0.819** | 1311 (73%) | 1600 (89%) |
| `gated35` | 4 | 128 | `warp` | 1471 | 1216 | **0.827** | 67 (4%) | 81 (5%) |
| `gated35` | 64 | 2048 | `warp` | 1504 | 1376 | **0.915** | 1046 (58%) | 1143 (64%) |
| `gated35` | 1024 | 32768 | `warp` | 6560 | 6560 | 1.000 | 3836 (214%) | 3836 (214%) |
| `gated27` | 4 | 192 | `warp` | 1472 | 1216 | **0.826** | 100 (6%) | 121 (7%) |
| `gated27` | 64 | 3072 | `warp` | 1696 | 1696 | 1.000 | 1391 (78%) | 1391 (78%) |
| `gated27` | 1024 | 49152 | `warp` | 9283 | 9283 | 1.000 | 4066 (227%) | 4066 (227%) |
| `hidden27` | 4 | 4 | `cta<512,8>` | 1856 | 1312 | **0.707** | 44 (2%) | 62 (3%) |
| `hidden27` | 64 | 64 | `cta<512,8>` | 2080 | 1472 | **0.708** | 630 (35%) | 890 (50%) |
| `hidden27` | 1024 | 1024 | `cta<512,8>` | 5409 | 4993 | **0.923** | 3877 (216%) | 4200 (234%) |
| `target_q27` | 4 | 96 | `warp` | 1504 | 1088 | **0.723** | 65 (4%) | 90 (5%) |
| `target_q27` | 64 | 1536 | `warp` | 1600 | 1216 | **0.760** | 983 (55%) | 1293 (72%) |
| `target_q27` | 1024 | 24576 | `warp` | 5441 | 5089 | **0.935** | 4625 (258%) | 4945 (276%) |
| `target_k27` | 4 | 16 | `warp` | 1440 | 1056 | **0.733** | 11 (1%) | 16 (1%) |
| `target_k27` | 64 | 256 | `warp` | 1568 | 1120 | **0.714** | 167 (9%) | 234 (13%) |
| `target_k27` | 1024 | 4096 | `warp` | 1856 | 1632 | **0.879** | 2260 (126%) | 2570 (143%) |

**Control band: every `dflash_*` cell reads 1.000.** The instrument quantises to 32 ns, so at these
kernel sizes one tick is about 2%: a cell within one tick of 1.000 is at its resolution floor, and
one such cell decides nothing on its own. The effects claimed here are not that - the 0.827 cell is
eight ticks apart and the 0.667 cell eighteen - and the gate's boundary is resolved by walking the
grid in the sweep above rather than by trusting a single cell.

**What the operator sweep can and cannot say.** These kernels are far too small to bring this card
out of its idle clock - `nvidia-smi` reads about 200 MHz against a 3105 MHz ceiling while the
benchmark runs, and locking the clock is not permitted in this container - so the table above is
the kernel's own GPU time under `nsys`, taken as the **minimum** over the launches in a capture and
then over the three captures.
That is the most favourable statistic available, chosen because it is the sample where the card had
boosted and it is the same quantity on both arms; the wall clock the benchmark prints moves by 12%
between two runs of the same binary. Control shapes whose kernels this change does not touch are in
the same table.

**Roofline, and why it is not the useful axis here.** RMSNorm moves four bytes per element, six
gated, and does no tensor-core work, so HBM at 1792 GB/s is the only relevant roof. The sweep does
not reach it and does not sit anywhere near it. At T=4 the shapes achieve 0 to 6% of peak: the grid
is a handful of blocks and the kernel is pure latency, which is where this change wins. At T=1024
the same arithmetic gives 73 to 276% of peak, and above 100% it is not a bandwidth figure at all -
the working sets are 2 to 38 MB against 96 MB of L2, so the sweep is measuring L2, not memory. The
decay from 0.67 to 1.00 across those widths is the
mechanism showing itself: latency hiding is worth a third of the kernel when nothing else fills the
machine and worth nothing once the machine is full.

## In a round

`nsys --cuda-graph-trace=node`, Qwen3.6-27B NVFP4, 8k prompt, 512 generated tokens, MTP-3 with the
draft head, int8 KV, chunk 4096. Warmup discarded, then ABAB with six repeats per arm. GPU kernel
time, so host scheduling does not enter it.

| | master | branch | b/m |
|---|--:|--:|--:|
| `rmsnorm_cta_bf16x2_kernel` | 38.61 ms, 3.58 us/launch | 23.14 ms, 2.15 us/launch | **0.599** |
| `rmsnorm_warp_bf16x2_kernel` | 22.40 ms, 3.48 us/launch | 17.61 ms, 2.73 us/launch | **0.786** |
| norm pool | 61.01 ms | 40.75 ms | **-33.2%** |
| every kernel in the run | 1695.50 ms | 1677.06 ms | **-1.09%** |

Repeat spread is 0.17% and 0.57% on the pool, 0.11% and 0.34% on the run: the pool effect is about
58 times its spread, the run effect about 3 times its. Launch counts are identical on both arms
(10776 and 6440), which is what makes the columns comparable at all.

The norm pool is 3.60% of this run on master, so -33.2% of it predicts -1.20% and the run moved
-1.09%. The 1.8 ms difference is the rest of the run measuring 0.11% slower on the branch, inside
its own 0.34% spread.

## Throughput, all five points measured

Warmup discarded, then ABAB with twelve repeats per arm, pinned to the least busy cores. Greedy
output is byte-identical on every point, so both columns describe the same generation.

| point | master | branch | mean | median | A / B spread |
|---|--:|--:|--:|--:|---|
| 27B decode, MTP-3 | 177.26 | 179.90 tok/s | **+1.49%** | +1.64% | 0.08% / 1.17% |
| 27B decode, no speculation | 84.52 | 86.37 tok/s | **+2.18%** | +2.11% | 1.38% / 2.04% |
| 35B-A3B decode, MTP-3 | 567.39 | 579.32 tok/s | **+2.10%** | +2.63% | 0.11% / 4.10% |
| 64k prefill, chunk 4096 | 7086.81 | 7127.87 tok/s | +0.58% | +0.47% | 2.35% / 0.29% |
| 64k prefill, chunk 8192 | 7185.30 | 7163.68 tok/s | **-0.30%** | -0.04% | 0.32% / 1.17% |

**Decode gains 1.5 to 2.6 per cent; prefill gains nothing.** The two prefill points straddle zero -
+0.58% at chunk 4096 against a 2.35% spread on master, and -0.30% at chunk 8192 - so the honest
reading is no effect, and I am not going to pick the positive one. That follows from the same
arithmetic as everything else here: a prefill chunk is thousands of rows, the norms are about 1.3%
of that work rather than 3.6%, and every norm launch is on the wide, occupancy-bound side where the
kernel table above reads 0.82 to 1.00 rather than 0.67.

Speculation off gains more than speculation on, which is the same effect seen from the other side:
a shorter round carries the same fixed norm cost over fewer tokens.

### Where the decode gain comes from

`ninfer_bench --profile-measured` brackets only the measured repetition with
`cudaProfilerStart/Stop`; captured under `nsys` with `--capture-range=cudaProfilerApi`, so artifact
load, graph construction and warmup stay out of it. Qwen3.6-27B groupwise-int, `tg128`, no
speculation, CUDA Graph decode. One decode step is 745 kernel launches and 11.45 ms of kernel time,
which is 96% of the 11.92 ms step at the 83.9 tok/s this machine measures.

| kernel | launches | master | branch | b/m |
|---|--:|--:|--:|--:|
| `cta<Offset, 512, 8>`, hidden state | 129 | 3015 ns | 1519 ns | **0.504** |
| `warp<Gated, 512>`, GDN gate | 48 | 1827 ns | 1375 ns | **0.752** |
| `warp<Offset, 512>`, q and k | 32 | 2297 ns | 1122 ns | **0.488** |
| norm pool | 209 | 550.1 us | 297.8 us | **0.541** |
| every kernel in the step | 745 | 11.448 ms | 11.191 ms | **0.9775** |

The launch counts are the model: 64 layers x 2 hidden norms plus the final one is 129, the 48 GDN
layers contribute one gated norm each, and the 16 attention layers contribute q and k.

The norms are **4.81%** of the step and the branch takes 45.9% off them, which predicts **2.21%**;
the step itself moved **2.25%** and the throughput point above is **+2.18%**. Nothing else moves -
the six largest non-norm kernels differ by less than 0.15% between the arms.

Decode never reaches the gate: its gated grids are 3 blocks and its widest norm grid is 129, so the
same capture taken with the threshold at 512 instead of 170 gives 298.8 us against 298.7 us on the
norm pool.

## Numerics

Bitwise by construction: the reduction loop is untouched and the epilogue consumes the same pairs,
out of registers instead of out of memory. Corroborated end to end, same prompt, `--greedy`,
512 tokens:

| | master | branch |
|---|--:|--:|
| generated text | 885 bytes | **byte-identical** |
| MTP rounds | 70 | 70 |
| drafted / accepted tokens | 210 / 115 | 210 / 115 |
| acceptance rate | 54.76% | 54.76% |

Stated at its real strength: greedy acceptance compares token ids, so it would survive a small
non-identical change and this is corroboration rather than proof. The proof is the diff.

## Tests

`rmsnorm offset [5120,1024]` is added; the suite stopped at 128 rows on that route.

**The threshold branch has no unit coverage, on either side.** I wrote gated cases either side of
it and removed them, because they fail - on `master` as well as here. The gated criterion's
`gross_relative_to_max_reference` is 2.8e-3, but a correctly rounded bf16 near the maximum of the
tensor can sit 3.9e-3 from the double reference: the spacing at 16.x is 0.125, half of it 0.0625,
and the allowance there 0.0454. Two seeds gave two different indices, both rejecting the **nearer**
bf16 - `actual=-16.25 reference=-16.1951` and `actual=-16.125 reference=-16.1712` - and both
reproduce on `master` with only the test file changed. The gated route reaches its un-prefetched
instantiation past 2720 rows on the warp path and past 170 rows on the wide-row path, and at the
widths those routes admit either is far over a million elements, which is where one element lands
in the gap. I did not touch the criterion; that is a separate question.

So the gate is currently exercised only end to end, where every 4096-token prefill chunk is 12288
gated warp blocks and therefore runs the un-prefetched kernel, with byte-identical output.

`cd build && ctest -j1`, run twice in the same build directory in the same session: **`master` at
da49c0d6 passes 97 of 98 and this branch passes the same 97**. The one failure is `ninfer_qwen3_6_frontend_test` (Subprocess aborted)
and it is identical on both arms.

## Not checked

- **The threshold is placed by measurement; its portability is not.** 170 is this part's SM count,
  written as a literal because nothing in the tree queries the device. On a part with a different
  count the boundary moves and this constant does not follow it.
- **The grid sweep stops at 1024 blocks per shape.** Past that the un-gated ratio stays between
  1.00 and 1.09 and never goes below 1, but I did not walk it further.
- **The gate has no unit coverage on either side**, for the oracle reason under Tests.
- The register counts are nvcc 13.1.115 output, not derived. Another toolchain can move them, and
  the gate's justification moves with them.
- No `ncu` counters: `RmProfilingAdminOnly` is set on this host.
- One card, sm_120a.
- The multimodal path was neither changed nor measured.

RTX 5090, sm_120a, driver 580.126.09, CUDA 13.1.115, Release,
`-DCMAKE_CUDA_ARCHITECTURES=120a`. Two machines: the round and throughput tables come from one at a
575 W limit, the operator table, the grid sweep and the decode profile from a second at 510 W. The
cell they share, `gated35` at T=64, reads 1503 -> 1375 ns on the first and 1504 -> 1376 ns on the
second. Within each table both arms are built in the same directory in the same session and every
ratio is between them.

