### PR TITLE
feat(serve): automatic shared-prefix write at the system/developer frontier

### DIFF
--- a/src/serve/openai_common.cpp
+++ b/src/serve/openai_common.cpp
@@ -144,8 +144,25 @@ void apply_openai_prompt_cache_policy(GenerationRequest& request, OpenAIPromptCa
     const bool automatic_enabled =
         policy.automatic != OpenAIPromptCacheAutomatic::Disabled && automatic_target != nullptr;
     const bool automatic_merges_explicit = automatic_enabled && automatic_target->has_value();
-    const std::size_t explicit_write_slots =
+    // Issue #142: the leading-instruction automatic candidate is a distinct
+    // marker when the leading run is unmarked, so it consumes one of the four
+    // frontend marker slots (frontend.cpp rejects more than four).
+    std::size_t leading_instruction = static_cast<std::size_t>(-1);
+    if (policy.auto_system_shared_prefix) {
+        for (std::size_t index = 0; index < request.messages.size(); ++index) {
+            const ChatRole role = request.messages[index].role;
+            if (role != ChatRole::System && role != ChatRole::Developer) { break; }
+            leading_instruction = index;
+        }
+    }
+    const bool system_candidate =
+        policy.auto_system_shared_prefix && automatic_enabled &&
+        leading_instruction != static_cast<std::size_t>(-1) &&
+        !request.messages[leading_instruction].cache_boundary_after.has_value();
+    const std::size_t base_slots =
         !automatic_enabled || automatic_merges_explicit ? 4U : 3U;
+    const std::size_t explicit_write_slots =
+        base_slots - (system_candidate ? 1U : 0U);
     const std::size_t first_selected = explicit_boundaries.size() > explicit_write_slots
                                            ? explicit_boundaries.size() - explicit_write_slots
                                            : 0U;
@@ -169,6 +186,18 @@ void apply_openai_prompt_cache_policy(GenerationRequest& request, OpenAIPromptCa
             automatic_target->value().evidence |= evidence;
         } else {
             *automatic_target = CacheBoundary{.evidence = evidence};
+        }
+        // Issue #142: a second automatic candidate at the leading
+        // system/developer frontier (agent siblings share the long head).
+        // Mark the end of the contiguous leading instruction run so requests
+        // sharing both system and developer turns reuse the whole prefix.
+        if (policy.auto_system_shared_prefix &&
+            leading_instruction != static_cast<std::size_t>(-1)) {
+            ChatTurn& turn = request.messages[leading_instruction];
+            if (!turn.cache_boundary_after) {
+                turn.cache_boundary_after = CacheBoundary{
+                    .evidence = ninfer::SharedCandidateEvidence::DefaultAutomatic};
+            }
         }
     }
     // OpenAI already defines the automatic/explicit write policy for every request. Existing

--- a/src/serve/openai_common.h
+++ b/src/serve/openai_common.h
@@ -20,6 +20,11 @@ enum class OpenAIPromptCacheAutomatic : std::uint8_t {
 
 struct OpenAIPromptCachePolicy {
     OpenAIPromptCacheAutomatic automatic = OpenAIPromptCacheAutomatic::Default;
+    // Issue #142: additionally publish a shared-prefix candidate at the
+    // leading system/developer frontier so agent sibling sessions share a
+    // long head even without a client marker. The last-content implicit
+    // candidate stays untouched.
+    bool auto_system_shared_prefix = true;
 };
 
 [[nodiscard]] bool parse_openai_prompt_cache_breakpoint(const nlohmann::json& value,

--- a/src/serve/openai_responses.h
+++ b/src/serve/openai_responses.h
@@ -34,6 +34,10 @@ struct OpenAIResponsesPromptRequest {
     std::vector<nlohmann::json> input_items;
     std::optional<std::string> instructions;
     std::optional<std::string> previous_response_id;
+    // Applied after prompt resolution assembles generation.messages (the
+    // policy needs the resolved system/developer turns to place the
+    // leading-instruction candidate).
+    std::optional<OpenAIPromptCachePolicy> cache_policy;
 };
 
 struct OpenAIResponsesCreateRequest {
@@ -72,7 +76,9 @@ struct BuiltOpenAIResponse {
 };
 
 OpenAIResponsesCreateRequest parse_openai_responses_create_request(const nlohmann::json& body,
-                                                                   const RequestLimits& limits);
+                                                                   const RequestLimits& limits,
+                                                                   bool auto_system_shared_prefix =
+                                                                       true);
 
 OpenAIResponsesPromptRequest
 parse_openai_responses_input_tokens_request(const nlohmann::json& body,

--- a/src/serve/openai_responses_http.cpp
+++ b/src/serve/openai_responses_http.cpp
@@ -245,7 +245,8 @@ void HttpServer::handle_responses(const httplib::Request& req, httplib::Response
     try {
         RequestLimits limits;
         limits.default_max_tokens = options_.default_max_tokens;
-        request = parse_openai_responses_create_request(parse_json_body(req), limits);
+        request = parse_openai_responses_create_request(
+            parse_json_body(req), limits, options_.auto_system_shared_prefix);
         validate_openai_model(request.prompt.model, public_model_id_);
         resolved = resolve_openai_responses_prompt(request.prompt, openai_responses_store_, id,
                                                    request.store);

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -1158,16 +1158,21 @@ void validate_common_top_level(const Json& body, bool create) {
 } // namespace
 
 OpenAIResponsesCreateRequest parse_openai_responses_create_request(const Json& body,
-                                                                   const RequestLimits& limits) {
+                                                                   const RequestLimits& limits,
+                                                                   bool auto_system_shared_prefix) {
     require_object(body);
     validate_common_top_level(body, true);
     reject_unsupported_platform_fields(body);
-    const OpenAIPromptCachePolicy cache_policy = parse_openai_prompt_cache_policy(body);
+    OpenAIPromptCachePolicy cache_policy = parse_openai_prompt_cache_policy(body);
+    cache_policy.auto_system_shared_prefix = auto_system_shared_prefix;
 
     ParsedPromptFields parsed = parse_prompt_fields(body, limits);
-    apply_openai_prompt_cache_policy(parsed.prompt.generation, cache_policy);
     OpenAIResponsesCreateRequest out;
     out.prompt              = std::move(parsed.prompt);
+    // The prompt policy is applied after resolution assembles
+    // generation.messages (resolve_openai_responses_prompt), because at parse
+    // time the leading instructions/input turns are not yet in messages.
+    out.prompt.cache_policy = cache_policy;
     out.tools               = std::move(parsed.wire_tools);
     out.tool_choice         = std::move(parsed.wire_tool_choice);
     out.tool_identities     = std::move(parsed.tool_identities);

--- a/src/serve/openai_responses_state.cpp
+++ b/src/serve/openai_responses_state.cpp
@@ -1,3 +1,4 @@
+#include "serve/openai_common.h"
 #include "serve/openai_responses.h"
 #include "serve/request_validation.h"
 
@@ -178,6 +179,12 @@ resolve_openai_responses_prompt(const OpenAIResponsesPromptRequest& request,
     resolved.generation.messages.insert(resolved.generation.messages.end(),
                                         std::make_move_iterator(context.begin()),
                                         std::make_move_iterator(context.end()));
+
+    // The prompt cache policy needs the resolved leading instructions/input
+    // turns, so it is applied here rather than at parse time.
+    if (request.cache_policy) {
+        apply_openai_prompt_cache_policy(resolved.generation, *request.cache_policy);
+    }
 
     if (response_id) {
         if (parent_record) {

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -79,7 +79,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8|fp8] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] [--default-thinking-budget N] "
            "[--vision] [--no-cuda-graph] [--no-prefix-reuse] "
-           "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
+           "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--no-auto-system-shared-prefix] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
            "       serves OpenAI Responses/Chat Completions and Anthropic Messages endpoints\n"
@@ -281,6 +281,8 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
             options.allow_prefix_reuse = false;
+        } else if (arg == "--no-auto-system-shared-prefix") {
+            options.auto_system_shared_prefix = false;
         } else if (arg == "--lm-head-draft") {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -47,6 +47,9 @@ struct ServeOptions {
     bool enable_vision      = false;
     bool use_cuda_graph     = true;
     bool allow_prefix_reuse = true;
+    // Issue #142: publish a shared-prefix candidate at the leading
+    // system/developer frontier (default on for agent workloads).
+    bool auto_system_shared_prefix = true;
     bool enable_thinking =
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
     bool preserve_thinking = false;


### PR DESCRIPTION
Closes #142

## What

Agent clients (Hermes, OpenCode, Pi, etc.) rarely send `prompt_cache_breakpoint`; on master they always miss the shared system/tools head. This adds **one automatic write candidate at the leading system/developer frontier** so the existing shared-prefix machinery can publish a prefix those clients actually share.

- Keeps the OpenAI explicit-breakpoint contract and the existing last-content implicit candidate (both writes coexist).
- Opt-out flag `--no-auto-system-shared-prefix` (extra write on by default) for the Responses path; the Chat path currently uses the default-on policy value (consistent with the issue discussion; wiring the flag into the Chat parse signature was deliberately left out to keep the diff minimal).
- No second store, no new catalog, no engine changes - the planner's existing `shared_stable_prefix` path does the work.

## Per-file rationale (8 files, +65/-7, serve layer only)

1. **`src/serve/openai_common.h`** (+5) - `OpenAIPromptCachePolicy` gains `auto_system_shared_prefix` (default `true`). The policy is the single switch that reaches both Chat and Responses without threading a new parameter through every parser.
2. **`src/serve/openai_common.cpp`** (+31/-1) - the actual feature:
   - Locates the **end of the contiguous leading system/developer run** (not the first turn): requests that share both a system and a developer turn reuse the whole instruction prefix.
   - Publishes the `DefaultAutomatic` candidate on that last leading turn when unmarked (the existing explicit-breakpoint contract is untouched).
   - **Reserves one of the four frontend marker slots** for the new candidate (`frontend.cpp` rejects >4 markers); the explicit-write selection shrinks by one when the candidate is distinct, so a request with 3 explicit breakpoints + both automatic writes stays at 4.
3. **`src/serve/serve_options.h`** (+3) - `ServeOptions` gains `auto_system_shared_prefix = true`.
4. **`src/serve/serve_options.cpp`** (+4/-1) - parses `--no-auto-system-shared-prefix` and documents it in the usage text.
5. **`src/serve/openai_responses.h`** (+8/-1) - `OpenAIResponsesPromptRequest` carries the parsed `cache_policy` so the policy can be applied **after** prompt resolution (at parse time the leading turns are still in `input_turns`/`instructions`, not in `generation.messages`).
6. **`src/serve/openai_responses_request.cpp`** (+11/-3) - stores the policy on the prompt instead of applying it to the empty message list; the parser signature gains the opt-out bool from the HTTP layer.
7. **`src/serve/openai_responses_state.cpp`** (+7) - `resolve_openai_responses_prompt` applies the policy once `generation.messages` is assembled (instructions + input turns), which is the earliest point the leading-instruction candidate can be placed correctly. (Fixes the review finding that Responses requests saw no system/developer turns.)
8. **`src/serve/openai_responses_http.cpp`** (+3/-1) - passes `options_.auto_system_shared_prefix` into the parser; without this one line the flag would exist but never reach Responses requests.

## Verification

- Build: clean on master `da49c0d` (WSL2, CUDA 13.3, sm_120a).
- Serve smoke: sibling Chat requests sharing a long system head reuse the published prefix without any client breakpoint; Responses requests place the candidate after the resolved leading instructions.
- `--no-auto-system-shared-prefix` restores strict OpenAI-implicit behavior on the Responses path.

## Follow-ups agreed with the issue author (#142 discussion, not blockers)

- **Frontier**: if the Qwen template renders tools before the system block, the candidate should sit after the combined tools+system prefix. Open to folding in.
- **Floor**: skip the extra write below ~256 tokens of shared head.
- @steve8697 offered to re-run the 16k sibling probe against this patch.