### PR TITLE
fix(frontend): salvage qwen tool calls per top-level block

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -565,7 +565,12 @@ Function arguments use `response.function_call_arguments.delta` and `.done`. IDs
 and content indices remain stable, and concatenated deltas equal the terminal Item. Responses SSE
 does not emit the Chat Completions `[DONE]` sentinel. With tools enabled, ordinary answer text still
 streams immediately; only an ambiguous `<tool_call>` suffix or the structured tool region is held.
-Malformed tool markup is flushed back as ordinary text without losing bytes.
+At terminal time, well-formed declared calls in the held region are emitted as function calls and
+every block that cannot be represented — an undeclared or invalid name, a duplicate parameter, or
+unparseable markup — is restored verbatim while the remaining calls in the region commit; a
+rejected block's `<tool_call>` envelope balances only on a closing marker outside parameter text,
+so a literal `</tool_call>` inside a parameter value stays value text and the envelope is one
+verbatim span whose nested markers are not emitted as calls.
 
 ### Local response state and resources
 
@@ -847,7 +852,9 @@ the template has no tiered default. A preparation rejection always leaves the re
 call count, empty non-string arguments omitted during normalization, schema-mismatched arguments
 preserved for consumer validation, and a stable text-fallback reason. Fallback reasons are `none`,
 `malformed_structure`, `duplicate_parameter`, `invalid_tool_name`, `undeclared_tool`, and
-`trailing_content`. These counters contain no tool arguments or generated text.
+`trailing_content`. A region falls back only when no block in it commits a call; the reason then
+classifies the first block-level failure. These counters contain no tool arguments or generated
+text.
 
 `request_done.materialization` is the immutable decision committed for that request. It reports predicted immediate,
 future-loss and total nanoseconds; evaluated targets and projection work; planning/search nanoseconds; stop reason;

--- a/src/targets/qwen3_6/impl/frontend/tool_call_parser.cpp
+++ b/src/targets/qwen3_6/impl/frontend/tool_call_parser.cpp
@@ -411,25 +411,114 @@ class QwenToolRegionParser {
 public:
     QwenToolRegionParser(std::string_view text, std::size_t max_name_length,
                          const Contract& contract)
-        : text_(text), max_name_length_(max_name_length), contract_(contract) {}
-
-    FallbackReason parse(std::vector<RawToolCall>& calls) const {
-        std::size_t pos = 0;
-        for (;;) {
-            skip_format_whitespace(text_, pos);
-            if (pos == text_.size()) {
-                return calls.empty() ? FallbackReason::MalformedStructure : FallbackReason::None;
+        : text_(text), max_name_length_(max_name_length), contract_(contract) {
+        // Classify every marker in one forward pass so the terminal parse stays linear in the
+        // region size: envelope scans walk the marker table instead of re-running string finds
+        // over the remaining suffix, and opener/close queries are binary searches.
+        for (std::size_t pos = 0; pos < text_.size(); ++pos) {
+            if (text_[pos] != '<') { continue; }
+            MarkerKind kind{};
+            if (starts_with_at(text_, pos, kToolOpen)) {
+                kind = MarkerKind::kToolOpen;
+            } else if (starts_with_at(text_, pos, kToolClose)) {
+                kind = MarkerKind::kToolClose;
+            } else if (starts_with_at(text_, pos, kParamOpen)) {
+                kind = MarkerKind::kParamOpen;
+            } else if (starts_with_at(text_, pos, kParamClose)) {
+                kind = MarkerKind::kParamClose;
+            } else {
+                continue;
             }
-            if (!starts_with_at(text_, pos, kToolOpen)) {
-                return calls.empty() ? FallbackReason::MalformedStructure
-                                     : FallbackReason::TrailingContent;
-            }
-
-            RawToolCall call;
-            const FallbackReason failure = parse_tool_call(pos, call);
-            if (failure != FallbackReason::None) { return failure; }
-            calls.push_back(std::move(call));
+            markers_.push_back(Marker{.pos = pos, .kind = kind});
+            if (kind == MarkerKind::kToolOpen) { tool_open_positions_.push_back(pos); }
+            else if (kind == MarkerKind::kToolClose) { tool_close_positions_.push_back(pos); }
         }
+        closes_after_.resize(markers_.size());
+        std::size_t running = 0;
+        for (std::size_t index = markers_.size(); index-- > 0;) {
+            closes_after_[index] = running;
+            if (markers_[index].kind == MarkerKind::kToolClose) { ++running; }
+        }
+    }
+
+    // Byte position of the first <tool_call> opener in the region, or npos.
+    std::size_t first_tool_open() const {
+        return tool_open_positions_.empty() ? std::string_view::npos
+                                            : tool_open_positions_.front();
+    }
+
+    // Byte position of the next <tool_call> opener at or after from, or npos.
+    std::size_t next_tool_open(std::size_t from) const {
+        const auto it =
+            std::lower_bound(tool_open_positions_.begin(), tool_open_positions_.end(), from);
+        return it == tool_open_positions_.end() ? std::string_view::npos : *it;
+    }
+
+    // Byte position of the next </tool_call> marker at or after from, or npos.
+    std::size_t next_tool_close(std::size_t from) const {
+        const auto it = std::lower_bound(tool_close_positions_.begin(),
+                                         tool_close_positions_.end(), from);
+        return it == tool_close_positions_.end() ? std::string_view::npos : *it;
+    }
+
+    // Structurally parse the <tool_call> block that starts at pos; on success end is the index
+    // just past the block's closing marker. A non-None result is a block-level structural or
+    // identity failure; the caller restores the block verbatim and keeps scanning the region.
+    FallbackReason try_parse_tool_call(std::size_t pos, RawToolCall& call,
+                                       std::size_t& end) const {
+        if (!consume(pos, kToolOpen)) { return FallbackReason::MalformedStructure; }
+        skip_format_whitespace(text_, pos);
+        const FallbackReason failure = parse_function(pos, call);
+        if (failure != FallbackReason::None) { return failure; }
+        skip_format_whitespace(text_, pos);
+        if (!consume(pos, kToolClose)) { return FallbackReason::MalformedStructure; }
+        end = pos;
+        return FallbackReason::None;
+    }
+
+    // Index just past the closing marker that balances the <tool_call> opener at open_pos.
+    // A closing marker inside unclosed parameter text is literal value bytes and never balances
+    // the envelope. Returns npos when the envelope is not balanced, i.e. truncated or prose.
+    std::size_t find_block_envelope_end(std::size_t open_pos) const {
+        const std::size_t index = static_cast<std::size_t>(
+            std::lower_bound(markers_.begin(), markers_.end(), open_pos,
+                             [](const Marker& marker, std::size_t pos) {
+                                 return marker.pos < pos;
+                             }) -
+            markers_.begin());
+        if (index >= markers_.size() || markers_[index].pos != open_pos ||
+            markers_[index].kind != MarkerKind::kToolOpen) {
+            return std::string_view::npos;
+        }
+        if (closes_after_[index] == 0) { return std::string_view::npos; }
+
+        int depth     = 1;
+        bool in_param = false;
+        for (std::size_t i = index + 1; i < markers_.size(); ++i) {
+            switch (markers_[i].kind) {
+                case MarkerKind::kToolOpen:
+                    ++depth;
+                    break;
+                case MarkerKind::kToolClose:
+                    if (in_param) { break; }
+                    if (depth == 1) { return markers_[i].pos + kToolClose.size(); }
+                    --depth;
+                    break;
+                case MarkerKind::kParamOpen:
+                    in_param = true;
+                    break;
+                case MarkerKind::kParamClose:
+                    in_param = false;
+                    break;
+            }
+            // If the remaining closing markers cannot bring the envelope back to depth 1, the
+            // envelope is truncated; stop the walk instead of scanning markers that cannot
+            // close it.
+            if (closes_after_[i] < static_cast<std::size_t>(depth - 1)) {
+                return std::string_view::npos;
+            }
+        }
+        return std::string_view::npos;
     }
 
 private:
@@ -437,15 +526,6 @@ private:
         if (!starts_with_at(text_, pos, token)) { return false; }
         pos += token.size();
         return true;
-    }
-
-    FallbackReason parse_tool_call(std::size_t& pos, RawToolCall& call) const {
-        if (!consume(pos, kToolOpen)) { return FallbackReason::MalformedStructure; }
-        skip_format_whitespace(text_, pos);
-        const FallbackReason failure = parse_function(pos, call);
-        if (failure != FallbackReason::None) { return failure; }
-        skip_format_whitespace(text_, pos);
-        return consume(pos, kToolClose) ? FallbackReason::None : FallbackReason::MalformedStructure;
     }
 
     FallbackReason parse_function(std::size_t& pos, RawToolCall& call) const {
@@ -535,9 +615,20 @@ private:
         }
     }
 
+    enum class MarkerKind { kToolOpen, kToolClose, kParamOpen, kParamClose };
+
+    struct Marker {
+        std::size_t pos;
+        MarkerKind kind;
+    };
+
     std::string_view text_;
     std::size_t max_name_length_;
     const Contract& contract_;
+    std::vector<Marker> markers_;
+    std::vector<std::size_t> tool_open_positions_;
+    std::vector<std::size_t> tool_close_positions_;
+    std::vector<std::size_t> closes_after_;
 };
 
 GeneratedToolCall normalize_raw_tool_call(const RawToolCall& raw, const Contract& contract,
@@ -598,27 +689,90 @@ build_tool_call_output_contract(std::span<const std::string> tool_jsons, bool en
 ParsedToolCallOutput parse_qwen_tool_call_output(const std::string& text,
                                                  std::size_t max_tool_name_length,
                                                  const ToolCallOutputContract& contract) {
-    const std::size_t first = text.find(kToolOpen);
-    if (first == std::string::npos) { return fallback(text); }
+    const std::string_view view(text);
+    const QwenToolRegionParser region(view, max_tool_name_length, contract);
+    const std::size_t first = region.first_tool_open();
+    if (first == std::string_view::npos) { return fallback(text); }
 
     ParsedToolCallOutput out;
-    out.content                 = rtrim_format_whitespace(std::string_view(text).substr(0, first));
     out.diagnostics.marker_seen = true;
 
-    std::vector<RawToolCall> raw_calls;
-    const std::string_view tool_region = std::string_view(text).substr(first);
-    const QwenToolRegionParser parser(tool_region, max_tool_name_length, contract);
-    const FallbackReason failure = parser.parse(raw_calls);
-    if (failure != FallbackReason::None) {
-        out.diagnostics.fallback_reason = failure;
+    // Per-block salvage: a block whose structure or tool identity cannot be represented is
+    // restored verbatim instead of returning the whole marker region to ordinary content; the
+    // remaining blocks are still parsed. The first block-level failure explains the region if no
+    // block commits.
+    FallbackReason region_failure    = FallbackReason::MalformedStructure;
+    bool saw_block_rejection         = false;
+    std::vector<std::string> verbatim_spans;
+
+    std::size_t pos = first;
+    for (;;) {
+        if (pos == view.size()) { break; }
+
+        if (starts_with_at(view, pos, kToolOpen)) {
+            RawToolCall call;
+            std::size_t block_end = 0;
+            const FallbackReason failure = region.try_parse_tool_call(pos, call, block_end);
+            if (failure == FallbackReason::None) {
+                out.tool_calls.push_back(normalize_raw_tool_call(call, contract, out.diagnostics));
+                pos = block_end;
+                continue;
+            }
+            if (!saw_block_rejection) {
+                region_failure      = failure;
+                saw_block_rejection = true;
+            }
+
+            // Restore the whole <tool_call> envelope verbatim. Nested <tool_call> markers inside
+            // a rejected block are parameter text, not top-level calls, and must not be
+            // promoted; closing markers inside parameter values are literal value bytes, so the
+            // envelope runs to the block's own closing marker.
+            const std::size_t envelope_end = region.find_block_envelope_end(pos);
+            if (envelope_end != std::string_view::npos) {
+                verbatim_spans.emplace_back(view.substr(pos, envelope_end - pos));
+                pos = envelope_end;
+                continue;
+            }
+
+            // Truncated envelope (no balanced closing marker): restore it verbatim up to the
+            // earliest of the next opening marker and the next closing marker so a following
+            // well-formed block keeps its own bytes.
+            const std::size_t search_from = pos + kToolOpen.size();
+            std::size_t span_end          = view.size();
+            const std::size_t next_open   = region.next_tool_open(search_from);
+            if (next_open != std::string_view::npos) { span_end = next_open; }
+            const std::size_t close       = region.next_tool_close(search_from);
+            if (close != std::string_view::npos) {
+                const std::size_t close_end = close + kToolClose.size();
+                if (close_end < span_end) { span_end = close_end; }
+            }
+            verbatim_spans.emplace_back(view.substr(pos, span_end - pos));
+            pos = span_end;
+            continue;
+        }
+
+        // Prose and format whitespace outside any well-formed block.
+        const std::size_t next_open = region.next_tool_open(pos);
+        const std::size_t span_end  = next_open == std::string_view::npos ? view.size() : next_open;
+        verbatim_spans.emplace_back(view.substr(pos, span_end - pos));
+        pos = span_end;
+    }
+
+    if (out.tool_calls.empty()) {
+        out.diagnostics.fallback_reason = region_failure;
         return fallback(text, out.diagnostics);
     }
 
-    out.tool_calls.reserve(raw_calls.size());
-    for (const RawToolCall& raw : raw_calls) {
-        out.tool_calls.push_back(normalize_raw_tool_call(raw, contract, out.diagnostics));
+    std::string complement;
+    for (const std::string& span : verbatim_spans) { complement += span; }
+    if (trim_format_whitespace(complement).empty()) {
+        // Every block in the region committed: the residual inter-block formatting is not content.
+        out.content = rtrim_format_whitespace(view.substr(0, first));
+    } else {
+        // The verbatim spans form an exact partition of the region minus the committed blocks, so
+        // the pre-marker prefix plus the complement restores every non-call byte.
+        out.content = std::string(view.substr(0, first)) + std::move(complement);
     }
-
     out.diagnostics.structured_call_count = static_cast<std::uint32_t>(out.tool_calls.size());
     out.is_tool_call_response             = true;
     return out;
@@ -684,7 +838,9 @@ ToolCallOutputDecoder::Terminal ToolCallOutputDecoder::finish() {
         trailing_whitespace_.clear();
         tool_region_.clear();
         marker_prefix_bytes_ = 0;
-        return Terminal{.content     = {},
+        // The salvaged verbatim spans were held inside the tool region, so they must be
+        // published as terminal content alongside the committed calls.
+        return Terminal{.content     = std::move(parsed.content),
                         .tool_calls  = std::move(parsed.tool_calls),
                         .diagnostics = parsed.diagnostics};
     }

--- a/src/targets/qwen3_6/impl/frontend/tool_call_parser.h
+++ b/src/targets/qwen3_6/impl/frontend/tool_call_parser.h
@@ -67,8 +67,10 @@ parse_qwen_tool_call_output(const std::string& text, std::size_t max_tool_name_l
                             const ToolCallOutputContract& contract);
 
 // Incrementally publishes bytes that are provably outside a possible terminal Qwen tool-call
-// suffix. At terminal time, valid calls are retained structurally; malformed output is restored
-// verbatim.
+// suffix. At terminal time, each well-formed declared call is retained structurally and every
+// unrepresentable block is restored verbatim, keeping the remaining calls in the region; a
+// rejected block's <tool_call> envelope balances only on a closing marker outside parameter
+// text, so literal closing markers and nested markers inside it are not promoted to calls.
 class ToolCallOutputDecoder {
 public:
     struct Terminal {

--- a/tests/test_tool_call_parser.cpp
+++ b/tests/test_tool_call_parser.cpp
@@ -551,10 +551,15 @@ int test_strict_structure_and_active_tool_set() {
         check_rejected(malformed, contract, ninfer::ToolCallParseFallbackReason::MalformedStructure,
                        "missing structural tags were accepted");
 
+    // Trailing prose after a well-formed block does not sink the call: the block commits and the
+    // prose is restored verbatim (per-block salvage, issue #158).
     const std::string suffix = tool_call("configure", {{"value", "x"}}) + "\nextra answer";
-    failures +=
-        check_rejected(suffix, contract, ninfer::ToolCallParseFallbackReason::TrailingContent,
-                       "non-whitespace suffix was accepted");
+    const auto suffix_parsed = fi::parse_qwen_tool_call_output(suffix, 64, contract);
+    failures += check(suffix_parsed.is_tool_call_response && suffix_parsed.tool_calls.size() == 1 &&
+                          suffix_parsed.content == "\nextra answer" &&
+                          suffix_parsed.diagnostics.fallback_reason ==
+                              ninfer::ToolCallParseFallbackReason::None,
+                      "trailing prose after a well-formed call was not restored verbatim");
 
     const std::string missing_parameter_close =
         "<tool_call>\n<function=configure>\n<parameter=value>\nx\n"
@@ -634,12 +639,191 @@ int test_conflicting_duplicate_tool_contracts_use_legacy_normalization() {
     return failures;
 }
 
-int test_all_or_nothing_structural_commit() {
-    const auto contract    = contract_for("configure", Json{{"flag", Json{{"type", "boolean"}}}});
+int test_truncated_trailing_block_salvages_preceding_calls() {
+    const auto contract = contract_for("configure", Json{{"flag", Json{{"type", "boolean"}}}});
     const std::string text = tool_call("configure", {{"flag", "true"}}) +
                              "\n<tool_call>\n<function=configure>\n<parameter=flag>\nfalse\n";
-    return check_rejected(text, contract, ninfer::ToolCallParseFallbackReason::MalformedStructure,
-                          "partially valid tool-call region was partially committed");
+
+    const auto parsed = fi::parse_qwen_tool_call_output(text, 64, contract);
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 1,
+                      "a truncated trailing block sank the preceding valid call");
+    failures += check(
+        parsed.content == "\n<tool_call>\n<function=configure>\n<parameter=flag>\nfalse\n",
+        "the truncated trailing block was not restored verbatim");
+    failures += check(parsed.diagnostics.structured_call_count == 1 &&
+                          parsed.diagnostics.fallback_reason ==
+                              ninfer::ToolCallParseFallbackReason::None,
+                      "salvaged region reported a fallback");
+    if (parsed.tool_calls.size() == 1) {
+        const Json args = Json::parse(parsed.tool_calls.front().arguments_json);
+        failures += check(args.at("flag") == true, "salvaged call arguments changed");
+    }
+    return failures;
+}
+
+int test_mixed_region_salvage() {
+    const auto contract = contract_for("configure", Json{{"flag", Json{{"type", "boolean"}}}});
+    const std::string first = tool_call("configure", {{"flag", "true"}});
+    // The middle block duplicates its flag parameter: a block-level identity failure that no
+    // normalization can represent, restored verbatim while the neighbouring blocks commit.
+    const std::string broken = "<tool_call>\n<function=configure>\n<parameter=flag>\ntrue\n"
+                               "</parameter>\n<parameter=flag>\nfalse\n</parameter>\n</function>\n"
+                               "</tool_call>";
+    const std::string third = tool_call("configure", {{"flag", "false"}});
+    const auto parsed =
+        fi::parse_qwen_tool_call_output(first + "\n" + broken + "\n" + third, 64, contract);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 2,
+                      "one invalid block sank neighbouring valid calls");
+    failures += check(parsed.content == "\n" + broken + "\n",
+                      "invalid block or its surrounding bytes were not restored");
+    failures += check(parsed.diagnostics.structured_call_count == 2 &&
+                          parsed.diagnostics.fallback_reason ==
+                              ninfer::ToolCallParseFallbackReason::None,
+                      "salvaged region reported a fallback");
+    if (parsed.tool_calls.size() == 2) {
+        const Json first_args = Json::parse(parsed.tool_calls[0].arguments_json);
+        const Json third_args = Json::parse(parsed.tool_calls[1].arguments_json);
+        failures += check(first_args.at("flag") == true && third_args.at("flag") == false,
+                          "salvaged call arguments changed");
+    }
+
+    const std::string undeclared = tool_call("other", {{"flag", "true"}});
+    const auto parsed_undeclared =
+        fi::parse_qwen_tool_call_output(first + "\n" + undeclared, 64, contract);
+    failures += check(parsed_undeclared.is_tool_call_response &&
+                          parsed_undeclared.tool_calls.size() == 1 &&
+                          parsed_undeclared.content == "\n" + undeclared,
+                      "undeclared-name block was not isolated from valid calls");
+    return failures;
+}
+
+int test_nested_marker_in_rejected_block_not_promoted() {
+    const std::vector<std::string> definitions = {
+        tool_definition("orchestrate", Json{{"body", Json{{"type", "string"}}}}),
+        tool_definition("bash", Json{{"command", Json{{"type", "string"}}}}),
+    };
+    const auto contract = *contract_from_definitions(definitions);
+    const std::string nested = tool_call("bash", {{"command", "echo nested"}});
+    // The outer block is structurally malformed: body is declared twice. Its second value
+    // carries an otherwise valid <tool_call> block as literal parameter text.
+    const std::string rejected =
+        "<tool_call>\n<function=orchestrate>\n<parameter=body>\nfirst pass\n</parameter>\n"
+        "<parameter=body>\n" +
+        nested + "\n</parameter>\n</function>\n</tool_call>";
+
+    int failures = 0;
+    failures += check_rejected(
+        rejected, contract, ninfer::ToolCallParseFallbackReason::DuplicateParameter,
+        "marker nested in a rejected block was promoted to a call");
+
+    const std::string first = tool_call("bash", {{"command", "echo one"}});
+    const auto parsed = fi::parse_qwen_tool_call_output(first + "\n" + rejected, 64, contract);
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 1 &&
+                          parsed.content == "\n" + rejected,
+                      "rejected envelope was not restored verbatim next to a valid call");
+    return failures;
+}
+
+int test_literal_close_in_rejected_envelope() {
+    const std::vector<std::string> definitions = {
+        tool_definition("orchestrate", Json{{"body", Json{{"type", "string"}}}}),
+        tool_definition("bash", Json{{"command", Json{{"type", "string"}}}}),
+    };
+    const auto contract = *contract_from_definitions(definitions);
+    const std::string nested = tool_call("bash", {{"command", "echo nested"}});
+    // The outer block is structurally malformed: body is declared twice. Its second value
+    // carries a literal </tool_call> closing marker as value bytes; the well-formed block
+    // after the parameter closes is still inside the outer envelope and must not be promoted.
+    const std::string rejected =
+        "<tool_call>\n<function=orchestrate>\n<parameter=body>\nfirst pass\n</parameter>\n"
+        "<parameter=body>\nvalue with literal close: </tool_call>\n</parameter>\n" +
+        nested + "\n</function>\n</tool_call>";
+
+    int failures = 0;
+    failures += check_rejected(
+        rejected, contract, ninfer::ToolCallParseFallbackReason::DuplicateParameter,
+        "a literal closing marker inside a rejected envelope closed the envelope early");
+
+    const std::string first = tool_call("bash", {{"command", "echo one"}});
+    const auto parsed = fi::parse_qwen_tool_call_output(first + "\n" + rejected, 64, contract);
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 1 &&
+                          parsed.content == "\n" + rejected,
+                      "a rejected envelope with a literal closing marker was split before its "
+                      "nested block");
+    return failures;
+}
+
+int test_unmatched_openers_before_valid_call() {
+    const auto contract = contract_for("bash", Json{{"command", Json{{"type", "string"}}}});
+    std::string openers;
+    for (int i = 0; i < 256; ++i) { openers += "<tool_call>"; }
+    const std::string valid = tool_call("bash", {{"command", "echo one"}});
+    const auto parsed =
+        fi::parse_qwen_tool_call_output(openers + "\n" + valid, 64, contract);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 1,
+                      "a well-formed call after unmatched openers was lost");
+    failures += check(parsed.content == openers + "\n",
+                      "unmatched openers were not restored verbatim");
+    if (parsed.tool_calls.size() == 1) {
+        const Json args = Json::parse(parsed.tool_calls.front().arguments_json);
+        failures += check(args.at("command") == "echo one",
+                          "salvaged bash command after unmatched openers changed");
+    }
+    return failures;
+}
+
+int test_prose_latched_marker_salvage() {
+    const auto contract = contract_for("bash", Json{{"command", Json{{"type", "string"}}}});
+    const std::string first  = tool_call("bash", {{"command", "echo one"}});
+    const std::string second = tool_call("bash", {{"command", "echo two"}});
+    const std::string text   = "The model emits <tool_call> blocks.\n" + first + "\n" + second;
+    const auto parsed        = fi::parse_qwen_tool_call_output(text, 64, contract);
+
+    int failures = 0;
+    failures += check(parsed.is_tool_call_response && parsed.tool_calls.size() == 2,
+                      "calls after a prose-latched marker were lost");
+    failures += check(parsed.content == "The model emits <tool_call> blocks.\n\n",
+                      "prose around a spurious marker was not restored verbatim");
+    if (parsed.tool_calls.size() == 2) {
+        const Json first_args  = Json::parse(parsed.tool_calls[0].arguments_json);
+        const Json second_args = Json::parse(parsed.tool_calls[1].arguments_json);
+        failures += check(first_args.at("command") == "echo one" &&
+                              second_args.at("command") == "echo two",
+                          "salvaged bash commands changed");
+    }
+    return failures;
+}
+
+int test_mixed_decoder_salvage() {
+    auto contract = output_contract_for("bash", Json{{"command", Json{{"type", "string"}}}});
+    fi::ToolCallOutputDecoder decoder(std::move(contract), 64);
+    const std::string text = "emits <tool_call> markup.\n" +
+                             tool_call("bash", {{"command", "one"}}) + "\n" +
+                             tool_call("missing", {{"x", "y"}});
+    std::string visible;
+    constexpr std::size_t kChunk = 7;
+    for (std::size_t offset = 0; offset < text.size(); offset += kChunk) {
+        visible += decoder.feed(std::string_view(text).substr(offset, kChunk));
+    }
+    const auto terminal = decoder.finish();
+
+    int failures = 0;
+    failures += check(visible == "emits", "bytes before the first marker leaked or were held");
+    failures += check(terminal.tool_calls.size() == 1,
+                      "valid call next to an undeclared block was lost");
+    failures += check(visible + terminal.content ==
+                          "emits <tool_call> markup.\n\n" + tool_call("missing", {{"x", "y"}}),
+                      "mixed terminal lost or reordered verbatim bytes");
+    if (terminal.tool_calls.size() == 1) {
+        const Json args = Json::parse(terminal.tool_calls.front().arguments_json);
+        failures += check(args.at("command") == "one", "salvaged command arguments changed");
+    }
+    return failures;
 }
 
 int test_incremental_valid_and_boolean() {
@@ -752,7 +936,13 @@ int main() {
     failures += test_strict_structure_and_active_tool_set();
     failures += test_name_limits_and_non_strict_omissions();
     failures += test_conflicting_duplicate_tool_contracts_use_legacy_normalization();
-    failures += test_all_or_nothing_structural_commit();
+    failures += test_truncated_trailing_block_salvages_preceding_calls();
+    failures += test_mixed_region_salvage();
+    failures += test_nested_marker_in_rejected_block_not_promoted();
+    failures += test_literal_close_in_rejected_envelope();
+    failures += test_unmatched_openers_before_valid_call();
+    failures += test_prose_latched_marker_salvage();
+    failures += test_mixed_decoder_salvage();
     failures += test_incremental_valid_and_boolean();
     failures += test_incremental_fallback_preserves_bytes();
     failures += test_incremental_embedded_parameter_markup();


### PR DESCRIPTION
## Summary

Changes the Qwen tool-call output parser from all-or-nothing parsing to per-top-level-block salvage.

Previously, if an assistant output contained multiple `<tool_call>` blocks and any one was malformed or named a tool outside the current OpenAI `tools` contract, the parser rejected the whole output as structured tool calls and preserved everything as assistant content. One bad block suppressed unrelated valid tool calls.

Now each top-level `<tool_call>` block is decoded independently:

- declared, well-formed blocks become structured tool calls;
- blocks whose structure or tool identity cannot be represented (undeclared name, duplicate parameter, unparseable markup) remain verbatim assistant content, and the remaining blocks in the region still commit;
- a rejected block whose `<tool_call>` envelope is balanced is one verbatim span — the envelope balances only on a `</tool_call>` outside parameter text, so a literal closing marker inside a parameter value stays value bytes, and a well-formed block nested in its parameter text is never emitted as a call;
- non-tool-call text (including prose after a committed block) remains verbatim;
- content is assembled as the byte-exact complement of the committed blocks;
- if no block decodes, behavior is the existing whole-region content fallback, and the first block-level failure is reported as the fallback reason.

## Integration with upstream `719d56ef`

While this PR was open, upstream rewrote the same parser (`fix(frontend): preserve structured tool call intent`, `719d56ef`): a decode stage that normalizes arguments against the declared parameter schemas (schema mismatches are stringified and committed, not rejected), a `NormalizationPolicy`/duplicate-contract contract, and a `ToolCallParseDiagnostics` block (`marker_seen`, `structured_call_count`, `empty_arguments_omitted`, `schema_mismatch_arguments`, `fallback_reason`) consumed by the serving layer.

This revision is rebased onto `e3aeaf8c` and built on top of that contract instead of beside it:

- the decode stage is upstream's `normalize_raw_tool_call` verbatim: schema mismatches are normalized and committed (counted in `schema_mismatch_arguments`), and only a structure or identity failure returns a block to verbatim content;
- per-block salvage is applied around that stage: `try_parse_tool_call` returns the upstream `FallbackReason` for the failed block, and the block's envelope is restored verbatim while the region keeps scanning;
- `ParsedToolCallOutput` carries the upstream diagnostics block; `marker_seen` is set whenever a marker is found, and `fallback_reason` stays `None` whenever at least one block commits;
- the region-level `TrailingContent` rejection is superseded by salvage: trailing prose after a committed block is restored verbatim;
- the upstream regression suite is kept as-is, including `test_conflicting_duplicate_tool_contracts_use_legacy_normalization`; three upstream expectations that the salvage semantics intentionally change are re-pinned (schema mismatch no longer rejects, duplicate ambiguous contracts use legacy normalization, trailing prose no longer rejects).

## Implementation

Files changed:

- `src/targets/qwen3_6/impl/frontend/tool_call_parser.cpp`
- `src/targets/qwen3_6/impl/frontend/tool_call_parser.h`
- `tests/test_tool_call_parser.cpp`
- `docs/serving.md`

Key behavior:

1. `QwenToolRegionParser` precomputes a marker table (every tool and parameter marker position) plus reverse-suffix close counts, so envelope scans and opener queries read the table instead of re-running string finds over the remaining suffix for every unmatched opener.
2. `try_parse_tool_call` structurally parses one top-level block (upstream grammar and `parse_function`/`parse_parameter` verbatim) and reports the upstream `FallbackReason` on failure, so a rejected block can be restored verbatim without disturbing its neighbours.
3. A structurally failed block has its `<tool_call>` envelope resolved by `find_block_envelope_end`, which walks the marker table: nested openers raise the depth, a closing marker inside unclosed parameter text is literal value bytes that never balances the envelope, and the walk stops as soon as the remaining close markers cannot bring the depth back to one. When the envelope is balanced, the whole envelope is one verbatim span so markers nested in the rejected block's parameter text are never re-scanned as top-level blocks; when the envelope is unbalanced (truncated block or prose marker), recovery stops at the earliest next-opener/next-closer boundary so a well-formed block following a truncated block is salvaged independently.
4. The content output is the byte-exact complement of the committed blocks: the pre-marker prefix plus the verbatim spans when that complement is non-empty, and the right-trimmed prefix alone when every block in the region committed.
5. `ToolCallOutputDecoder::feed` is unchanged from upstream; `finish` publishes the salvaged verbatim spans as terminal content alongside the committed calls instead of dropping them.
6. Declared-name enforcement stays intact: an undeclared function name is never emitted as a structured tool call.

## Tests

Salvage tests (new, replacing the upstream `test_all_or_nothing_structural_commit`, which asserted the all-or-nothing behavior this PR supersedes):

- `test_truncated_trailing_block_salvages_preceding_calls`: a valid call followed by a truncated block — the call commits and the truncated block is restored verbatim.
- `test_mixed_region_salvage`: valid + duplicate-parameter + valid blocks in one region — the two valid calls commit and the middle block is restored verbatim; an undeclared-name block is isolated the same way.
- `test_nested_marker_in_rejected_block_not_promoted`: a structurally malformed outer block (duplicate parameter) whose second value carries an otherwise valid declared block is restored fully verbatim and the nested marker is never emitted — standalone and next to a valid sibling call.
- `test_literal_close_in_rejected_envelope`: a rejected block (duplicate parameter) whose value carries a literal `</tool_call>` — the envelope closes only at the block's own closing marker, so the well-formed nested block is not promoted; asserted standalone and next to a valid sibling call.
- `test_unmatched_openers_before_valid_call`: 256 bare `<tool_call>` openers followed by a valid declared call — the call is salvaged and the unmatched openers are restored verbatim (also exercises the marker-table early exit).
- `test_prose_latched_marker_salvage`: a prose `<tool_call>` marker that does not open a block no longer discards the later valid blocks (pins the unbalanced-envelope path).
- `test_mixed_decoder_salvage`: incremental `feed`/`finish` path — a valid call next to an undeclared block survives with byte-exact content.

Re-pinned upstream expectations: the strict-structure test now asserts that a valid call with a prose suffix is salvaged instead of being rejected as `TrailingContent`, and `test_schema_mismatches_remain_structured` keeps asserting committed calls with `schema_mismatch_arguments` diagnostics. All other upstream tests are unchanged.

## Validation

- `test_tool_call_parser` built and run green: the parser and its unit test are pure C++ with no CUDA dependency and were compiled standalone under C++20 (MSVC, `/W4`, zero warnings) against the rebased tree. The full repository CMake build additionally requires the Linux CUDA 13.1 toolchain, which is not available on the workstation where this was developed.
- Negative control: the same test suite compiled against the parser with the in-parameter close guard disabled fails exactly the new literal-close test (the envelope closed at the literal marker and the nested block was promoted), confirming the test guards the regression.
- Live OpenAI-compatible serving was checked against the pre-rebase revision of the parser (valid declared call produces `finish_reason=tool_calls`; undeclared block remains verbatim content; mixed outputs salvage the valid calls). This revision's changes are covered by the unit suite and the standalone MSVC build; the live-serving route needs the Linux CUDA build and was not re-run here.

## Notes

This PR does not make NInfer structure or execute undeclared tool names. The parser still enforces the request's declared OpenAI tool contract, and undeclared calls are never fabricated as structured calls. For client-side integrations that declare only a transport tool (for example `run_code`) while exposing additional SDK-only tools inside the prompt, recovering raw markup that names those tools belongs in that client/agent loop, not in NInfer's serving contract.
