### PR TITLE
fix(frontend): contain malformed UTF-8 in the request instead of terminating the engine

### DIFF
--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -37,6 +37,7 @@ namespace fi = frontend_internal;
 
 constexpr std::size_t kPatchFeatures   = 1536;
 constexpr std::string_view kThinkClose = "</think>";
+constexpr std::string_view kReplacementCharacter = "\xef\xbf\xbd";
 constexpr std::string_view kThinkingControl =
     "\n\n Considering the limited time by the user, I have to give the solution based on the "
     "thinking directly now.\n</think>\n\n";
@@ -399,7 +400,12 @@ void append_delta(PublishedOutput& output, OutputChannel channel, std::string te
     }
 }
 
-std::size_t valid_utf8_prefix_size(std::string_view bytes) {
+struct Utf8Prefix {
+    std::size_t size = 0;
+    bool malformed    = false;
+};
+
+Utf8Prefix valid_utf8_prefix_size(std::string_view bytes) {
     std::size_t offset = 0;
     while (offset < bytes.size()) {
         const auto lead         = static_cast<unsigned char>(bytes[offset]);
@@ -422,24 +428,37 @@ std::size_t valid_utf8_prefix_size(std::string_view bytes) {
             codepoint = lead & 0x07U;
             minimum   = 0x10000U;
         } else {
-            throw std::invalid_argument("invalid UTF-8 leading byte in generated token stream");
+            return Utf8Prefix{.size = offset, .malformed = true};
         }
-        if (offset + length > bytes.size()) { return offset; }
+        if (offset + length > bytes.size()) {
+            // The sequence runs past what we hold, so it may simply be split across tokens.
+            // The continuation bytes that ARE present still have to be well formed: if one of
+            // them is not, the sequence is malformed now and no later token can repair it.
+            // Without this check a malformed lead byte is indistinguishable from a truncated
+            // one, so the decoder waits for bytes that never arrive and terminalize discards
+            // the buffer -- dropping any valid text that followed the bad byte.
+            for (std::size_t index = offset + 1; index < bytes.size(); ++index) {
+                const auto byte = static_cast<unsigned char>(bytes[index]);
+                if ((byte & 0xc0U) != 0x80U) {
+                    return Utf8Prefix{.size = offset, .malformed = true};
+                }
+            }
+            return Utf8Prefix{.size = offset};
+        }
         for (std::size_t index = 1; index < length; ++index) {
             const auto byte = static_cast<unsigned char>(bytes[offset + index]);
             if ((byte & 0xc0U) != 0x80U) {
-                throw std::invalid_argument(
-                    "invalid UTF-8 continuation byte in generated token stream");
+                return Utf8Prefix{.size = offset, .malformed = true};
             }
             codepoint = (codepoint << 6U) | (byte & 0x3fU);
         }
         if (codepoint < minimum || (codepoint >= 0xd800U && codepoint <= 0xdfffU) ||
             codepoint > 0x10ffffU) {
-            throw std::invalid_argument("invalid UTF-8 codepoint in generated token stream");
+            return Utf8Prefix{.size = offset, .malformed = true};
         }
         offset += length;
     }
-    return offset;
+    return Utf8Prefix{.size = offset};
 }
 
 std::size_t longest_suffix_prefix(std::string_view text, std::string_view marker,
@@ -604,11 +623,25 @@ void feed_token_bytes(DecoderState& state, std::string_view bytes, const StopPol
                       PublishedOutput& emitted, std::uint32_t committed_tokens,
                       StopMatch* best_match) {
     state.utf8_pending.append(bytes);
-    const std::size_t valid = valid_utf8_prefix_size(state.utf8_pending);
-    if (valid == 0) { return; }
-    const std::string text = state.utf8_pending.substr(0, valid);
-    state.utf8_pending.erase(0, valid);
-    feed_decoded_text(state, text, policy, emitted, committed_tokens, best_match);
+    for (;;) {
+        const Utf8Prefix prefix = valid_utf8_prefix_size(state.utf8_pending);
+        if (prefix.size != 0) {
+            const std::string text = state.utf8_pending.substr(0, prefix.size);
+            state.utf8_pending.erase(0, prefix.size);
+            feed_decoded_text(state, text, policy, emitted, committed_tokens, best_match);
+            if (best_match != nullptr && best_match->found) { return; }
+            if (state.utf8_pending.empty()) { return; }
+            continue;
+        }
+        if (!prefix.malformed) { return; }
+
+        // Drop the malformed sequence's lead byte. Any following byte is re-evaluated as the
+        // start of a new sequence, so valid ASCII and independent malformed bytes are preserved.
+        state.utf8_pending.erase(0, 1);
+        feed_decoded_text(state, kReplacementCharacter, policy, emitted, committed_tokens,
+                          best_match);
+        if (best_match != nullptr && best_match->found) { return; }
+    }
 }
 
 void terminalize(DecoderState& state, const StopPolicy& policy, PublishedOutput& emitted,
@@ -618,7 +651,7 @@ void terminalize(DecoderState& state, const StopPolicy& policy, PublishedOutput&
         // Publish the standard replacement character rather than an invalid
         // UTF-8 suffix; the logical token prefix remains exact.
         state.utf8_pending.clear();
-        feed_decoded_text(state, "\xef\xbf\xbd", policy, emitted, committed_tokens, nullptr);
+        feed_decoded_text(state, kReplacementCharacter, policy, emitted, committed_tokens, nullptr);
     }
     if (state.in_reasoning) {
         feed_channel(state, OutputChannel::Reasoning, state.think_marker_pending, policy, emitted,

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -43,6 +43,7 @@ constexpr std::string_view kThinkingControlGuidance =
 constexpr std::string_view kThinkingControl =
     "\n\n Considering the limited time by the user, I have to give the solution based on the "
     "thinking directly now.\n</think>\n\n";
+constexpr std::string_view kReplacementCharacter = "\xef\xbf\xbd";
 
 int check(bool condition, const char* message) {
     if (condition) { return 0; }
@@ -140,7 +141,9 @@ FrontendResources resources(const std::string& chat_template = thinking_toggle_t
     result.tokenizer_json = nlohmann::json{
         {"model",
          {{"type", "BPE"},
-          {"vocab", {{"x", 0}, {"ä", 10}, {"¸", 11}, {"Ń", 12}}},
+          {"vocab",
+           {{"x", 0}, {"ä", 10}, {"¸", 11}, {"Ń", 12},
+            {"Ģ", 13}, {"À", 14}, {"à", 15}, {"Ã", 16}, {"©", 17}}},
           {"merges", nlohmann::json::array()}}},
         {"added_tokens",
          tokens}}.dump();
@@ -1612,9 +1615,62 @@ int test_thinking_budget_control(const Frontend& frontend) {
 }
 
 int test_utf8_and_hidden_eos(const Frontend& frontend) {
+    const std::string replacement(kReplacementCharacter);
+    int failures = 0;
+
+    auto continuation_prompt  = frontend.prepare_tokens({0});
+    auto continuation_session = frontend.make_output_session(continuation_prompt, {});
+    const auto continuation_decision = continuation_session.preview_model(
+        std::array<ninfer::TokenId, 3>{0, 10, 0}, 4, ninfer::FinishReason::OutputLimit);
+    failures += check(continuation_decision.accepted_tokens == 3 &&
+                          !continuation_decision.finished(),
+                      "malformed UTF-8 continuation ended generation");
+    const auto continuation_output = continuation_session.commit_preview();
+    failures += check(channel_text(continuation_output, ninfer::OutputChannel::Content) ==
+                          std::string("x") + replacement + "x",
+                      "malformed UTF-8 continuation was not replaced and followed by valid text");
+
+    auto leading_prompt  = frontend.prepare_tokens({0});
+    auto leading_session = frontend.make_output_session(leading_prompt, {});
+    const auto leading_decision = leading_session.preview_model(
+        std::array<ninfer::TokenId, 3>{0, 14, 0}, 4, ninfer::FinishReason::OutputLimit);
+    failures += check(leading_decision.accepted_tokens == 3 && !leading_decision.finished(),
+                      "malformed UTF-8 leading byte ended generation");
+    const auto leading_output = leading_session.commit_preview();
+    failures += check(channel_text(leading_output, ninfer::OutputChannel::Content) ==
+                          std::string("x") + replacement + "x",
+                      "malformed UTF-8 leading byte was not replaced and followed by valid text");
+
+    auto codepoint_prompt  = frontend.prepare_tokens({0});
+    auto codepoint_session = frontend.make_output_session(codepoint_prompt, {});
+    const auto codepoint_decision = codepoint_session.preview_model(
+        std::array<ninfer::TokenId, 5>{0, 15, 13, 13, 0}, 6, ninfer::FinishReason::OutputLimit);
+    failures += check(codepoint_decision.accepted_tokens == 5 &&
+                          !codepoint_decision.finished(),
+                      "malformed UTF-8 codepoint ended generation");
+    const auto codepoint_output = codepoint_session.commit_preview();
+    failures += check(channel_text(codepoint_output, ninfer::OutputChannel::Content) ==
+                          std::string("x") + replacement + replacement + replacement + "x",
+                      "malformed UTF-8 codepoint was not replaced and followed by valid text");
+
+    auto split_prompt  = frontend.prepare_tokens({0});
+    auto split_session = frontend.make_output_session(split_prompt, {});
+    const auto split_lead = split_session.preview_model(std::array<ninfer::TokenId, 1>{16}, 3,
+                                                        ninfer::FinishReason::OutputLimit);
+    failures += check(split_lead.accepted_tokens == 1 && !split_lead.finished(),
+                      "split UTF-8 lead byte unexpectedly ended generation");
+    failures += check(split_session.commit_preview().empty(),
+                      "split UTF-8 codepoint was published before completion");
+    const auto split_tail = split_session.preview_model(std::array<ninfer::TokenId, 1>{17}, 2,
+                                                        ninfer::FinishReason::OutputLimit);
+    failures += check(split_tail.accepted_tokens == 1 && !split_tail.finished(),
+                      "split UTF-8 continuation unexpectedly ended generation");
+    const auto split_output = split_session.commit_preview();
+    failures += check(channel_text(split_output, ninfer::OutputChannel::Content) == "é",
+                      "split UTF-8 codepoint was not published when complete");
+
     auto prompt             = frontend.prepare_tokens({0});
     auto session            = frontend.make_output_session(prompt, {});
-    int failures            = 0;
     std::uint32_t remaining = 4;
     for (const ninfer::TokenId token : {10, 11}) {
         const auto decision = session.preview_model(std::array<ninfer::TokenId, 1>{token},


### PR DESCRIPTION
Fixes the engine-termination half of #154.

Requires input from the maintainer on the correct resolution (3 options presented). This PR implements one of them
(per-byte U+FFFD) but I can adjust.

## What it changes

`valid_utf8_prefix_size` threw `std::invalid_argument` on a malformed leading byte,
continuation byte or codepoint. The throw was not request-local: it escaped
`commit_pending`, reached `worker_loop`'s catch-all, and ran `fail_all_locked`, which sets
`failed_` and leaves the process serving HTTP while rejecting every later request with
`service_unavailable`. One malformed byte ended service for every client until restart.

The function now returns a `malformed` flag instead, and `feed_token_bytes` consumes the
offending lead byte, publishes U+FFFD and continues.

Cross-token buffering is unchanged: a sequence whose declared length runs past the buffer
may simply be split across tokens, so it is still retained for the next token.

## Overrun branch validation

A truncated sequence and a malformed one can look identical from the lead byte alone when
the declared length overruns the buffer.  The decoder can end up waiting for continuation bytes that never
arrived and `terminalize` then clears `utf8_pending` wholesale — **silently dropping the
valid text that followed the bad byte.**

So the overrun branch now validates the continuation bytes that *are* present. Any byte
failing `(b & 0xC0) == 0x80` proves the sequence malformed immediately, since no later
token can repair it. Genuine truncation still waits.

`test_utf8_and_hidden_eos` catches this precisely — its continuation case asserts
`"x" + U+FFFD + "x"`, and the naive version produces `"x" + U+FFFD`.

## Verification

- **Deterministic reproduction.** Since the sampler-side trigger is stochastic (eight
  seeded attempts with the original `frequency_penalty` recipe did *not* reproduce it), I
  built a decoder-level one: an artifact copy with two equal-width tokenizer vocabulary
  values transposed, so an ordinarily-emitted token decodes to `0xC0`. Weights and offsets
  untouched. Details are in #154.
  - On master: trigger logs `error invalid UTF-8 leading byte`, and the **next ordinary
    request is rejected 503 `service_unavailable`**.
  - With this branch: trigger completes (`finish=length`, 8192 tokens, three U+FFFD), and
    the follow-up returns normally.
  - Same flags, same request JSON, same artifact; the only difference is the binary.
- **`eval/run_qwen3_8_27b_nvfp4_reasoning.sh text` ran to completion on this branch** —
  4/4 suites, 9 h 30 m, zero `engine is unavailable` and zero decode errors. An earlier
  attempt on master died partway through IFBench, which is what prompted #154's severity
  correction. Scores matched the published figures for the NVFP4 artifact (AIME25 96.67%,
  GPQA-Diamond 90.40% exactly; AIME26 93.33% vs 96.67%, one problem at n=30).

## Notes

- `valid_utf8_prefix_size` is non-throwing now and could be `noexcept`.
- The replacement loop's repeated `erase(0, 1)` is O(n²) on a long malformed run.
- This touches the shared Qwen frontend, so it affects the 35B-A3B route too; I have
  exercised it only on 27B NVFP4.
