### PR TITLE
feat(serve): report timings during prompt progress

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -250,11 +250,15 @@ cases report finite zero rates rather than `NaN` or infinity. Speculative reques
 include terminal `draft_n` and `draft_n_accepted` when draft work occurred.
 
 Set top-level `timings_per_token: true` on a streaming request to attach the latest cumulative
-timing snapshot to each visible reasoning or content chunk. This does not enable terminal timings,
-which are always present. A model commit that is temporarily hidden by UTF-8, stop-string,
-reasoning, or tool-call buffering still advances the cumulative token count; the next visible chunk
-observes that committed frontier. The option increases response serialization and transport volume
-and is off by default.
+timing snapshot to each visible reasoning or content chunk and, when `return_progress` is also
+enabled, to each prompt-processing chunk. During prompt processing that snapshot is prompt-only:
+`predicted_n`, `predicted_ms`, `predicted_per_token_ms`, and `predicted_per_second` remain zero
+until the first output commit, `prompt_ms` is the elapsed wall time since committed admission, and
+the prompt rates span the processed suffix (`processed - cache`) tokens rather than the complete
+prompt. This does not enable terminal timings, which are always present. A model commit that is
+temporarily hidden by UTF-8, stop-string, reasoning, or tool-call buffering still advances the
+cumulative token count; the next visible chunk observes that committed frontier. The option
+increases response serialization and transport volume and is off by default.
 
 Set top-level `return_progress: true` together with `stream: true` to receive prompt-processing
 chunks:
@@ -266,9 +270,25 @@ chunks:
     "cache": 4096,
     "processed": 6144,
     "time_ms": 41
+  },
+  "timings": {
+    "cache_n": 4096,
+    "prompt_n": 4096,
+    "prompt_ms": 41.5,
+    "prompt_per_token_ms": 0.020263671875,
+    "prompt_per_second": 49349.39759036145,
+    "predicted_n": 0,
+    "predicted_ms": 0.0,
+    "predicted_per_token_ms": 0.0,
+    "predicted_per_second": 0.0
   }
 }
 ```
+
+The `timings` object appears only when `timings_per_token: true` is also set. It reports the same
+prompt-only live snapshot described above: `time_ms` is integral milliseconds while
+`timings.prompt_ms` keeps sub-millisecond precision, and the prompt rates cover the 2,048
+processed suffix tokens so far.
 
 The initial event has `processed == cache`. Later cumulative events are published only after the
 corresponding prefill unit commits, may be coalesced when the consumer is slower than prefill, and

--- a/src/serve/openai_chat.h
+++ b/src/serve/openai_chat.h
@@ -23,7 +23,8 @@ struct OpenAIChatRequest {
     bool include_usage          = false;
     bool output_tokens_explicit = false;
     // llama.cpp-compatible response observations. Final timings remain unconditional;
-    // timings_per_token controls only cumulative timing snapshots on streamed output chunks.
+    // timings_per_token controls cumulative timing snapshots on streamed output chunks and,
+    // together with return_progress, on prompt-progress chunks.
     bool timings_per_token = false;
     bool return_progress   = false;
 };

--- a/src/serve/openai_chat_response.cpp
+++ b/src/serve/openai_chat_response.cpp
@@ -107,6 +107,24 @@ CompletionTimings observation_timings(std::uint32_t prompt_tokens, std::uint32_t
         static_cast<double>(observation.generation_elapsed_ns) * kNanosecondsToMilliseconds);
 }
 
+// Prompt-only live snapshot for prompt-progress chunks: no output token is committed yet, so the
+// predicted fields stay zero and the prompt rates span the processed suffix, not the full prompt.
+CompletionTimings progress_timings(std::uint32_t total_tokens, std::uint32_t cached_tokens,
+                                   std::uint32_t processed_tokens, std::uint64_t elapsed_ns) {
+    constexpr double kNanosecondsToMilliseconds = 1.0e-6;
+    CompletionTimings timings;
+    timings.cache_n        = std::min(cached_tokens, total_tokens);
+    timings.prompt_n       = total_tokens - timings.cache_n;
+    const double prompt_ms =
+        finite_nonnegative(static_cast<double>(elapsed_ns) * kNanosecondsToMilliseconds);
+    const std::uint32_t processed_suffix =
+        processed_tokens > timings.cache_n ? processed_tokens - timings.cache_n : 0;
+    timings.prompt_ms           = prompt_ms;
+    timings.prompt_per_token_ms = milliseconds_per_token(processed_suffix, prompt_ms);
+    timings.prompt_per_second   = tokens_per_second(processed_suffix, prompt_ms);
+    return timings;
+}
+
 Json prompt_progress_json(std::uint32_t total, std::uint32_t cached, std::uint32_t processed,
                           std::uint64_t elapsed_ns) {
     return Json{{"total", total},
@@ -281,6 +299,10 @@ std::string OpenAIChatStream::initial_prompt_progress() {
     if (include_usage_) { payload["usage"] = nullptr; }
     payload["prompt_progress"] =
         prompt_progress_json(prompt_tokens_, cached_tokens_, cached_tokens_, 0);
+    if (timings_per_token_) {
+        payload["timings"] =
+            timings_json(progress_timings(prompt_tokens_, cached_tokens_, cached_tokens_, 0));
+    }
     return event(std::move(payload));
 }
 
@@ -301,6 +323,11 @@ std::string OpenAIChatStream::prompt_progress(const ninfer::PromptProgress& prog
     payload["prompt_progress"] =
         prompt_progress_json(progress.total_prompt_tokens, progress.reused_prompt_tokens,
                              progress.processed_prompt_tokens, progress.elapsed_ns);
+    if (timings_per_token_) {
+        payload["timings"] = timings_json(progress_timings(
+            progress.total_prompt_tokens, progress.reused_prompt_tokens,
+            progress.processed_prompt_tokens, progress.elapsed_ns));
+    }
     return event(std::move(payload));
 }
 

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -708,6 +708,10 @@ int test_stream_observations() {
                   initial["prompt_progress"]["processed"] == 12 &&
                   initial["prompt_progress"]["time_ms"] == 0,
               "initial prompt progress begins at the admitted cache frontier");
+    failures += check(initial["timings"]["prompt_n"] == 20 && initial["timings"]["prompt_ms"] == 0.0 &&
+                          initial["timings"]["prompt_per_second"] == 0.0 &&
+                          initial["timings"]["predicted_n"] == 0,
+                      "initial prompt progress carries a zero prompt-only timing snapshot");
 
     const Json middle = parse_sse(stream.prompt_progress(ninfer::PromptProgress{
         .total_prompt_tokens     = 32,
@@ -718,6 +722,11 @@ int test_stream_observations() {
     failures += check(middle["prompt_progress"]["processed"] == 20 &&
                           middle["prompt_progress"]["time_ms"] == 57,
                       "prompt progress exposes a cumulative completed frontier");
+    failures += check(middle["timings"]["prompt_ms"] == 57.0 &&
+                          middle["timings"]["prompt_per_token_ms"] == 7.125 &&
+                          middle["timings"]["prompt_per_second"] == 1000.0 * 8.0 / 57.0 &&
+                          middle["timings"]["predicted_n"] == 0,
+                      "prompt progress timings observe the processed suffix so far");
     const Json complete = parse_sse(stream.prompt_progress(ninfer::PromptProgress{
         .total_prompt_tokens     = 32,
         .reused_prompt_tokens    = 12,
@@ -727,6 +736,17 @@ int test_stream_observations() {
     failures +=
         check(complete["prompt_progress"]["processed"] == complete["prompt_progress"]["total"],
               "final prompt progress reaches the complete prompt");
+    failures += check(complete["timings"]["prompt_per_token_ms"] == 5.0 &&
+                          complete["timings"]["prompt_per_second"] == 200.0,
+                      "final prompt progress timings span the complete prompt suffix");
+
+    OpenAIChatStream plain(identity(), false, false, true);
+    (void)plain.start();
+    plain.note_start(
+        ninfer::GenerationStart{.prompt = {.prompt_tokens = 8}, .reused_prompt_tokens = 0});
+    const Json plain_progress = parse_sse(plain.initial_prompt_progress());
+    failures += check(!plain_progress.contains("timings"),
+                      "prompt progress omits timings without timings_per_token");
 
     stream.note_timing(ninfer::GenerationTimingObservation{
         .generated_tokens = 1, .prompt_elapsed_ns = 110000000, .generation_elapsed_ns = 0});


### PR DESCRIPTION
Attaches the llama.cpp-compatible `timings` snapshot to Chat Completions prompt-progress chunks when `timings_per_token` is enabled, alongside the existing `prompt_progress` payload.