### PR TITLE
perf(sparse_moe): one CTA per token in small-T S2, and a warp merge in place of eight dependent rounds

### DIFF
--- a/src/ops/sparse_moe/small_t/sparse_moe_small_t_kernels.cu
+++ b/src/ops/sparse_moe/small_t/sparse_moe_small_t_kernels.cu
@@ -73,73 +73,35 @@ __global__ void sparse_moe_small_t_s1_kernel(const __nv_bfloat16* __restrict__ x
     }
 }
 
-template <int Tokens>
-__global__ void
-sparse_moe_small_t_s2_kernel(const float* __restrict__ partial_scores, int* __restrict__ token_ids,
-                             float* __restrict__ token_alpha, float* __restrict__ shared_scale) {
-    static_assert(Tokens >= 1 && Tokens <= kSparseMoeSmallTMax);
-    __shared__ float scores[Tokens][kRouterRows];
-    __shared__ float selected_logits[Tokens][kTopK];
-    const int tid = static_cast<int>(threadIdx.x);
+// S2 runs one CTA per token: the router scores of a single token take 1 060 B of shared
+// memory, so the block no longer has to be wide enough to hold the whole decode window.
+constexpr int kS2Threads = 128;
+
+__global__ void sparse_moe_small_t_s2_kernel(const float* __restrict__ partial_scores,
+                                             int* __restrict__ token_ids,
+                                             float* __restrict__ token_alpha,
+                                             float* __restrict__ shared_scale) {
+    __shared__ float scores[kRouterRows];
+    __shared__ float selected_logits[kTopK];
+    const int tid   = static_cast<int>(threadIdx.x);
+    const int token = static_cast<int>(blockIdx.x);
     if (tid == 0) { pdl::trigger_dependents(); }
     pdl::wait_for_dependencies();
-    for (int index = tid; index < Tokens * kRouterRows; index += static_cast<int>(blockDim.x)) {
+    for (int row = tid; row < kRouterRows; row += kS2Threads) {
         float sum = 0.0f;
 #pragma unroll
         for (int partition = 0; partition < kRouterPartitions; ++partition) {
-            sum += partial_scores[static_cast<std::int64_t>(index) * kRouterPartitions + partition];
+            sum += partial_scores[((static_cast<std::int64_t>(token) * kRouterRows + row) *
+                                   kRouterPartitions) +
+                                  partition];
         }
-        reinterpret_cast<float*>(scores)[index] = sum;
+        scores[row] = sum;
     }
     __syncthreads();
 
-    const int resident_warps = static_cast<int>(blockDim.x) >> 5;
-    for (int token = tid >> 5; token < Tokens; token += resident_warps) {
-        sparse_moe_select_top8_warp(scores[token], token_ids + token * kTopK,
-                                    token_alpha + token * kTopK, shared_scale + token,
-                                    selected_logits[token]);
-    }
-}
-
-template <int Tokens>
-__global__ void sparse_moe_small_t_s2_two_batch_kernel(const float* __restrict__ partial_scores,
-                                                       int* __restrict__ token_ids,
-                                                       float* __restrict__ token_alpha,
-                                                       float* __restrict__ shared_scale) {
-    static_assert(Tokens >= 45 && Tokens <= kSparseMoeSmallTMax);
-    constexpr int kBatchTokens = 32;
-    __shared__ float scores[kBatchTokens][kRouterRows];
-    __shared__ float selected_logits[kBatchTokens][kTopK];
-    const int tid  = static_cast<int>(threadIdx.x);
-    const int warp = tid >> 5;
-    if (tid == 0) { pdl::trigger_dependents(); }
-    pdl::wait_for_dependencies();
-
-#pragma unroll
-    for (int token_begin = 0; token_begin < Tokens; token_begin += kBatchTokens) {
-        const int batch_tokens = min(kBatchTokens, Tokens - token_begin);
-        for (int index = tid; index < batch_tokens * kRouterRows; index += kBatchTokens * 32) {
-            const int token = index / kRouterRows;
-            const int row   = index - token * kRouterRows;
-            float sum       = 0.0f;
-#pragma unroll
-            for (int partition = 0; partition < kRouterPartitions; ++partition) {
-                sum +=
-                    partial_scores[((static_cast<std::int64_t>(token_begin + token) * kRouterRows +
-                                     row) *
-                                    kRouterPartitions) +
-                                   partition];
-            }
-            scores[token][row] = sum;
-        }
-        __syncthreads();
-        if (warp < batch_tokens) {
-            const int token = token_begin + warp;
-            sparse_moe_select_top8_warp(scores[warp], token_ids + token * kTopK,
-                                        token_alpha + token * kTopK, shared_scale + token,
-                                        selected_logits[warp]);
-        }
-        __syncthreads();
+    if (tid < 32) {
+        sparse_moe_select_top8_warp(scores, token_ids + token * kTopK, token_alpha + token * kTopK,
+                                    shared_scale + token, selected_logits);
     }
 }
 
@@ -152,19 +114,11 @@ void launch_s1(const __nv_bfloat16* x, const __nv_bfloat16* router, float* parti
     CUDA_CHECK(cudaGetLastError());
 }
 
-template <int Tokens>
 void launch_s2(const float* partial_scores, int* token_ids, float* token_alpha, float* shared_scale,
-               cudaStream_t stream) {
-    constexpr int kThreads = (Tokens < 32 ? Tokens : 32) * 32;
-    if constexpr (Tokens <= 44) {
-        CUDA_CHECK(pdl::launch_dependent({dim3(1), dim3(kThreads), 0, stream},
-                                         sparse_moe_small_t_s2_kernel<Tokens>, partial_scores,
-                                         token_ids, token_alpha, shared_scale));
-    } else {
-        CUDA_CHECK(pdl::launch_dependent({dim3(1), dim3(kThreads), 0, stream},
-                                         sparse_moe_small_t_s2_two_batch_kernel<Tokens>,
-                                         partial_scores, token_ids, token_alpha, shared_scale));
-    }
+               std::int32_t tokens, cudaStream_t stream) {
+    CUDA_CHECK(pdl::launch_dependent(
+        {dim3(static_cast<unsigned int>(tokens)), dim3(kS2Threads), 0, stream},
+        sparse_moe_small_t_s2_kernel, partial_scores, token_ids, token_alpha, shared_scale));
 }
 
 void launch_s3_tiled(const Tensor& x, const SparseMoeWeights& weights,
@@ -340,11 +294,11 @@ void sparse_moe_small_t_launch(const Tensor& x, const SparseMoeWeights& weights,
         launch_s1<Tokens>(static_cast<const __nv_bfloat16*>(x.data),
                           static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
                           static_cast<float*>(workspace.scratch.data), stream);
-        launch_s2<Tokens>(static_cast<const float*>(workspace.scratch.data),
-                          static_cast<int*>(workspace.token_ids.data),
-                          static_cast<float*>(workspace.token_alpha.data),
-                          static_cast<float*>(workspace.shared_scale.data), stream);
     });
+    launch_s2(static_cast<const float*>(workspace.scratch.data),
+              static_cast<int*>(workspace.token_ids.data),
+              static_cast<float*>(workspace.token_alpha.data),
+              static_cast<float*>(workspace.shared_scale.data), plan.tokens, stream);
     launch_s3_tiled(x, weights, plan, workspace, stream);
     launch_s4_tiled(weights, destination, plan, workspace, stream);
 }

--- a/src/ops/sparse_moe/sparse_moe_route.cuh
+++ b/src/ops/sparse_moe/sparse_moe_route.cuh
@@ -4,7 +4,6 @@
 #include "ops/common/warp.cuh"
 
 #include <cuda_runtime.h>
-#include <math_constants.h>
 
 namespace ninfer::ops::detail {
 
@@ -14,7 +13,6 @@ inline constexpr int kSparseMoeTopK    = 8;
 struct SparseMoeRankedValue {
     float value;
     int id;
-    int origin;
 };
 
 __device__ __forceinline__ bool sparse_moe_ranked_better(const SparseMoeRankedValue& a,
@@ -22,33 +20,55 @@ __device__ __forceinline__ bool sparse_moe_ranked_better(const SparseMoeRankedVa
     return a.value > b.value || (a.value == b.value && a.id < b.id);
 }
 
-__device__ __forceinline__ SparseMoeRankedValue sparse_moe_warp_best(SparseMoeRankedValue value) {
+// Merges the descending run of each lane with the run of its xor partner and keeps the better
+// half. The eight exchanges of a step do not depend on each other, so the warp reaches the
+// warp-wide top-8 in five merge steps instead of eight dependent reduction rounds. Ranking is a
+// total order over distinct expert ids, so the selected set and its order are the same as the
+// ones any other correct selection produces.
+__device__ __forceinline__ void
+sparse_moe_merge_ranked_runs(SparseMoeRankedValue (&run)[kSparseMoeTopK]) {
 #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        SparseMoeRankedValue other;
-        other.value  = __shfl_down_sync(kFullWarpMask, value.value, offset);
-        other.id     = __shfl_down_sync(kFullWarpMask, value.id, offset);
-        other.origin = __shfl_down_sync(kFullWarpMask, value.origin, offset);
-        if (sparse_moe_ranked_better(other, value)) { value = other; }
+    for (int partner = 1; partner < 32; partner <<= 1) {
+        SparseMoeRankedValue merged[kSparseMoeTopK];
+#pragma unroll
+        for (int rank = 0; rank < kSparseMoeTopK; ++rank) {
+            const SparseMoeRankedValue mirror = run[kSparseMoeTopK - 1 - rank];
+            SparseMoeRankedValue other;
+            other.value  = __shfl_xor_sync(kFullWarpMask, mirror.value, partner);
+            other.id     = __shfl_xor_sync(kFullWarpMask, mirror.id, partner);
+            merged[rank] = sparse_moe_ranked_better(run[rank], other) ? run[rank] : other;
+        }
+        // The kept half is bitonic; three compare-exchange stages restore descending order.
+#pragma unroll
+        for (int stride = kSparseMoeTopK / 2; stride > 0; stride >>= 1) {
+#pragma unroll
+            for (int rank = 0; rank < kSparseMoeTopK; ++rank) {
+                if ((rank & stride) != 0) { continue; }
+                const int partner_rank = rank | stride;
+                if (!sparse_moe_ranked_better(merged[rank], merged[partner_rank])) {
+                    const SparseMoeRankedValue swap = merged[rank];
+                    merged[rank]                    = merged[partner_rank];
+                    merged[partner_rank]            = swap;
+                }
+            }
+        }
+#pragma unroll
+        for (int rank = 0; rank < kSparseMoeTopK; ++rank) { run[rank] = merged[rank]; }
     }
-    value.value  = __shfl_sync(kFullWarpMask, value.value, 0);
-    value.id     = __shfl_sync(kFullWarpMask, value.id, 0);
-    value.origin = __shfl_sync(kFullWarpMask, value.origin, 0);
-    return value;
 }
 
 __device__ __forceinline__ void sparse_moe_select_top8_warp(const float* scores, int* ids,
                                                             float* alpha, float* shared_scale,
                                                             float* selected_logits) {
     const int lane = static_cast<int>(threadIdx.x) & 31;
-    SparseMoeRankedValue local[8];
+    SparseMoeRankedValue local[kSparseMoeTopK];
 #pragma unroll
-    for (int item = 0; item < 8; ++item) {
+    for (int item = 0; item < kSparseMoeTopK; ++item) {
         const int id = lane + item * 32;
-        local[item]  = {scores[id], id, lane};
+        local[item]  = {scores[id], id};
     }
 #pragma unroll
-    for (int i = 1; i < 8; ++i) {
+    for (int i = 1; i < kSparseMoeTopK; ++i) {
         const SparseMoeRankedValue value = local[i];
         int position                     = i;
         while (position > 0 && sparse_moe_ranked_better(value, local[position - 1])) {
@@ -57,20 +77,16 @@ __device__ __forceinline__ void sparse_moe_select_top8_warp(const float* scores,
         }
         local[position] = value;
     }
+    sparse_moe_merge_ranked_runs(local);
 
-    int cursor = 0;
+    if (lane == 0) {
 #pragma unroll
-    for (int rank = 0; rank < kSparseMoeTopK; ++rank) {
-        SparseMoeRankedValue candidate =
-            cursor < 8 ? local[cursor] : SparseMoeRankedValue{-CUDART_INF_F, 0x7fffffff, lane};
-        const SparseMoeRankedValue winner = sparse_moe_warp_best(candidate);
-        if (lane == 0) {
-            ids[rank]             = winner.id;
-            selected_logits[rank] = winner.value;
+        for (int rank = 0; rank < kSparseMoeTopK; ++rank) {
+            ids[rank]             = local[rank].id;
+            selected_logits[rank] = local[rank].value;
         }
-        if (lane == winner.origin) { ++cursor; }
-        __syncwarp();
     }
+    __syncwarp();
 
     float exponential = 0.0f;
     if (lane < kSparseMoeTopK) { exponential = expf(selected_logits[lane] - selected_logits[0]); }


### PR DESCRIPTION
Rebased onto `master` `47bb19a5`. Two files, **+71/−101** — the change removes more lines than
it adds. The diff applies to `47bb19a5` cleanly, with the same diff on its own base as the
control. **The numbers below were measured on `ad0f3d38`**, which was master when the work was
done, 81 commits back; because the DFlash2 integration lands in between and touches the decode
round, I am re-taking the end-to-end figure on this base and will post it here rather than
leave the old one standing. The operator numbers and the bit-identity argument do not depend
on that.
`clang-format` clean on both touched files (both are clean on `ad0f3d38` too, so the formatter
only ever saw the new lines). Output is bit-identical. `ctest` is **104/104 on both arms out of
one build directory** — with one flaky failure on the *base* arm, spelled out under Tests.

Measured on RTX 5090 `sm_120a`, driver 580.159.03, CUDA 13.1, 525 W cap, Release,
`qwen3_6_35b_a3b.ninfer` (`groupwise-int`), KV bf16.

---

## What the change is

`launch_s2` writes `dim3(1)` into both of its branches, and the trace agrees: **every one of the
1240 launches** of a batch-1 decode round and **every one of the 1200 launches** of a batch-8
round has `gridX = gridY = gridZ = 1`, while `S1` of the same operation runs on 1028 blocks and
`D3` on 6144.

Nothing in the work asks for that. `S2` is `T` independent top-8 selections over 256 router
logits — one warp per token — plus a fold of the four partial sums `S1` left behind. There is no
dependency between tokens. The single CTA is a consequence of `scores[Tokens][257]` living in one
shared array, and the `two_batch` branch at `T >= 45` exists only to cap that array at 32 tokens.

Two edits, in two files, independent of each other:

**1. One CTA per token** (`sparse_moe_small_t_kernels.cu`). `S2` launches `dim3(tokens)` blocks of
128 threads; the shared array becomes `scores[257]` plus eight selected logits — **1 060 B per
block at every `T`, against up to 46 640 B before**. The kernel stops being a template (nothing
in it depended on `Tokens` except the shared size), and `sparse_moe_small_t_s2_two_batch_kernel`
goes away together with the reason it existed.

**2. A merge network instead of eight dependent rounds** (`sparse_moe_route.cuh`). Every lane
already holds its eight candidates sorted. Five `__shfl_xor` exchanges merge the runs pairwise;
each exchange is **eight independent shuffles** followed by three compare-exchange stages over
static indices. Five dependent shuffle levels replace the eight dependent `sparse_moe_warp_best`
rounds — about 48 levels — that the loop walked before.

```
    sparse_moe_merge_ranked_runs(local);          // five xor merges, static bitonic tail
```

**Bit-identity is a property of the problem, not a hope.** `sparse_moe_ranked_better` (greater
value; lower id on a tie) is a **total order over 256 distinct expert ids**, so the top-8 set and
its order are uniquely determined and cannot depend on the network that finds them. The tail —
softmax over the eight selected logits, `warp_reduce_sum`, the shared-expert sigmoid — is
untouched. The `origin` field of `SparseMoeRankedValue` was only ever read by the cursor of the
old loop and is deleted with it.

The selector is shared with the decode `D2` kernel and the prefill route kernel, so both get the
shorter chain.

### Registers and shared memory (`cuobjdump -res-usage`)

| kernel | base | patched |
|---|--:|--:|
| `sparse_moe_small_t_s2` | 48 reg, 1 060 … **46 640 B** shared | **38 reg**, 1 060 B at every `T` |
| `sparse_moe_d2_warp` (pure decode) | 40 reg | **38 reg** |
| `sparse_moe_prefill_select_count` | 40 reg | **54 reg** |

`STACK:0 LOCAL:0` on every instantiation, before and after. The prefill kernel is the one place
where registers go up; the prefill measurement below says it costs nothing, and that measurement
is why the change is carried in the shared function rather than duplicated.

## What it gives, in which phase

Every cell is its own process under an exclusive card lock with its own witness window;
**472 measurement cells, none rejected**.

### Product benchmark

`ninfer_bench -pg 2048,384 -r 6 --warmup 2 --prefill-chunk 8192 --mtp-draft-tokens 3`.
Eight passes, arm order rotated between passes, deltas paired inside a pass, median over passes
(pass 0 discarded):

| | base | patched | Δ (median of paired deltas) |
|---|--:|--:|--:|
| **decode** | 658.99 tok/s | **669.51 tok/s** | **+1.598 %** |
| decode time | 0.5827 s | 0.5736 s | **−1.573 %** |
| **prefill** | 22 634.6 tok/s | 22 640.6 tok/s | **−0.026 %** |
| prefill time | 0.0905 s | 0.0905 s | +0.026 % |
| total wall | 0.6747 s | 0.6649 s | **−1.384 %** |
| acceptance rate | 0.7994 | 0.7994 | identical |
| speculative rounds | 678 | 678 | identical |

Read the prefill row carefully: the medians of the two arms move *up* by 0.026 % and the median
of the paired deltas moves *down* by 0.026 %. Both statistics agree on the magnitude and
disagree on the sign, which is what "does not move" looks like when the effect is six times
smaller than the control. **That is the answer to the register rise above: the shorter chain in
the shared selector costs the prefill nothing.** The identical acceptance rate and round count
are a second, independent sign that routing did not move.

### Decode round bench

`ninfer_qwen3_6_35b_a3b_dflash_round_bench --context 1024 --proposal-head full --warmup 200
--reps 40`, eight passes, order rotated, deltas paired inside a pass:

| arm | batch 1 (`T=4`) | batch 8 (`T=32`) |
|---|--:|--:|
| control: two builds of the unpatched code | +0.047 % | +0.071 % |
| one CTA per token only | −0.226 % | −1.380 % |
| merge network only | −0.936 % | −0.428 % |
| **both** | **−1.271 %** | **−1.599 %** |

Cells separate completely from stock in both points for the combined arm
(max 4.65547 < min 4.70428 ms and max 16.02280 < min 16.16500 ms).

**The two edits are not redundant, and the reason is structural.** At `T=4` the stock kernel
already has four warps on four schedulers, so the grid buys almost nothing and the chain length
is what holds it. At `T=32` the stock kernel has 32 warps on one SM, the bottleneck moves to
throughput, and the grid is what pays. Either edit alone is worth under 0.5 % in one of the two
points; together they hold in both.

### Kernel

`nsys profile -t cuda --cuda-graph-trace=node`, medians over 1240 and 1200 launches:

| | base | patched | Δ | grid |
|---|--:|--:|--:|---|
| `T=4` | 5 568 ns | **4 000 ns** | **−28.2 %** | 1 → **4** blocks × 128 threads |
| `T=32` | 12 608 ns | **8 608 ns** | **−31.7 %** | 1 × 1024 threads → **32** × 128 |

Sum of kernel time per round against wall-clock round time, from two run lengths of the same
cell: 4.904 vs 4.926 ms and 4.786 vs 4.847 ms at batch 1; 16.240 vs 16.181 ms and 15.821 vs
16.085 ms at batch 8 — ratios 0.995, 0.987, 1.004 and 0.984, all inside the 0.85…1.15 corridor
written down before the run.

### Share of the ceilings

Neither ceiling of this card is what this kernel is short of, which is the point of the change.

| | reads | duration | GB/s | **% of the measured 1689.4 GB/s read ceiling** |
|---|--:|--:|--:|--:|
| `T=4` base | 16 448 B | 5 568 ns | 2.95 | **0.175 %** |
| `T=4` patched | 16 448 B | 4 000 ns | 4.11 | **0.243 %** |
| `T=32` base | 131 584 B | 12 608 ns | 10.44 | **0.618 %** |
| `T=32` patched | 131 584 B | 8 608 ns | 15.29 | **0.905 %** |

The 1689.4 GB/s is our own direct measurement on this part, not a datasheet number; the datasheet
1792 GB/s would flatter these by 6.1 % relative.

The kernel issues **no MMA instruction at all**, and its arithmetic — the fold, `T × 257 × 3`
additions — is **0.0012 %** of the measured 66.1 TFLOP/s scalar tier at `T=4` and 0.0043 % at
`T=32`. What the kernel was short of was a dependent chain and a grid.

Against the ceiling of this direction as a whole — what the round would gain if the selection and
the fold cost nothing, **3.64 % of the round at batch 1 and 3.49 % at batch 8**, measured by a
dose sweep inside the kernel — the change takes **34.9 %** and **45.8 %** of what is there.

## Where it does not work

* **Prefill: nothing.** The prefill route kernel gets the shorter chain and gives back 0.026 %
  whose sign depends on which statistic is taken — noise. The grid edit does not touch the
  prefill path at all.
* **Batch 1 alone, or batch 8 alone, would have picked the wrong single edit.** The table above
  is the reason both are here.
* **Model.** Measured only on `qwen3_6_35b_a3b`. The constants the change leans on — 256 experts,
  top-8, 257 router rows, four partitions — are that model's. The merge network assumes exactly
  `32 lanes × 8 candidates = 256 experts`; a different expert count needs a different network,
  and the code says so by construction rather than by a comment.
* **`T > 46`** is the prefill path and is not touched.

## Sweep over the token window

The change is on the shared path, so it is swept rather than trusted.

**Round level**, `T = b × (draft+1)` at twenty reachable points, three passes each, order rotated:

| `T` | Δ | `T` | Δ | `T` | Δ | `T` | Δ |
|--:|--:|--:|--:|--:|--:|--:|--:|
| 2 | −1.501 % | 8 | −1.137 % | 18 | −1.540 % | 32 | −1.565 % |
| 3 | −1.491 % | 10 | −1.173 % | 20 | −1.564 % | 36 | −2.093 % |
| 4 | −1.208 % | 12 | −1.614 % | 24 | −1.448 % | 40 | −2.039 % |
| 5 | −1.552 % | 14 | −1.260 % | 28 | −1.610 % | 44 | −1.996 % |
| 6 | −1.111 % | 16 | −1.344 % | | | 45 | **−2.743 %** |
| 7 | −1.359 % | | | | | | |

**No point is worse than stock.** The best point is `T=45`, where the deleted `two_batch` branch
used to run.

**Operator level** — the weaker instrument, but the only one that reaches the eleven values of `T`
that `b × (draft+1)` with `b ≤ 8`, `draft ≤ 15` cannot express (17, 19, 23, 29, 31, 34, 37, 38,
41, 43, 46). All 45 values of `T` from 2 to 46, kernel duration: **−22.4 % to −51.5 %**, no point
worse. `T=46` — the last case the deleted branch served — is −41.2 %.

## Tests

`ctest --test-dir build` with `NINFER_QWEN3_6_35B_A3B_WEIGHTS` set so the real-model tests run
rather than skip:

| run | result |
|---|---|
| **patched**, `prod_tree/build` | **100 % of 104**, 2 skipped |
| base — the two files reverted and rebuilt in the **same** build directory, first run | 99 % of 104: `ninfer_resource_manager_test` failed once |
| base — same build directory, immediate re-run | **100 % of 104**, the same 2 skipped |
| base — a separate worktree of the same commit | **100 % of 104** |

The two skips are `ninfer_qwen3_6_27b_score_real_test` and `ninfer_qwen3_6_27b_load_plan_test`,
which want a 27B bf16 artifact this machine does not carry.

The single failure is stated rather than hidden. It landed **on the base**, in
`ninfer_resource_manager_test` — a host-only test of a tie-break in resource selection, with
nothing in it that this change touches — and it did not reproduce: the whole suite passed on the
immediate re-run, the same test passed 25 out of 25 standalone, and it passed in both of the other
two full runs. **The patched arm has never failed a test.**

`ninfer_sparse_moe_test` checks the op against a **double-precision CPU reference** at
`T = 1, 2, 19, 20, 46, 47, 768, 4097` — which covers `T=46`, the case the deleted branch used to
serve.

## Bit-identity, and a gate that is shown to work

`ninfer --print-token-ids --greedy --no-thinking --spec dflash --draft-tokens 3`, 192 tokens,
fixed prompt:

| arm | md5 of token ids |
|---|---|
| stock, run 1 | `8a13dc80376529e6685cc33bee37432b` |
| stock, run 2 | same |
| one CTA per token only | same |
| merge network only | same |
| both | same |
| built product binary | same |
| **sabotage 1**: eighth expert id shifted by one | `fd3355d0fb044b98c581388fd54dd880` |
| **sabotage 2**: logits of ranks 6 and 7 swapped, ids not | `ecdab3980d73076905a89c09a19fdfa2` |

Both sabotage arms keep the kernel legal and every selected expert valid — they are the *middle*
kind of damage, not a crash and not zeros — and the gate separates both. Six identical hashes
mean something only because of those two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
