### PR TITLE
perf(frontend): store the BPE merge rules in a flat open-addressed table

### DIFF
--- a/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
+++ b/src/targets/qwen3_6/impl/frontend/tokenizer.cpp
@@ -322,12 +322,15 @@ std::uint64_t merge_pair_key(int left, int right) noexcept {
            static_cast<std::uint32_t>(right);
 }
 
-std::unordered_map<std::uint64_t, BpeMergeRule>
-load_bpe_merge_rules(const Json& model, std::string_view label,
-                     const std::unordered_map<std::string, int>& token_to_id) {
+BpeMergeTable load_bpe_merge_rules(const Json& model, std::string_view label,
+                                   const std::unordered_map<std::string, int>& token_to_id) {
     const Json& merges = require_array_field(model, "merges", label);
-    std::unordered_map<std::uint64_t, BpeMergeRule> rules;
-    rules.reserve(merges.size());
+    BpeMergeTable rules;
+    rules.reset(merges.size());
+    // Rank order matters here and is not incidental: linear probing lets the first claimant keep
+    // a slot, and a low rank is a merge the encoder performs often, so walking model.merges in
+    // order hands the frequent rules their home slot. Filling the table out of an unordered
+    // container instead is measurably slower.
     int rank = 0;
     for (const Json& item : merges) {
         std::string left;
@@ -357,9 +360,9 @@ load_bpe_merge_rules(const Json& model, std::string_view label,
             throw std::invalid_argument("model.merges references a symbol outside model.vocab in " +
                                         std::string(label));
         }
-        const auto [_, inserted] =
-            rules.emplace(merge_pair_key(left_id->second, right_id->second),
-                          BpeMergeRule{.rank = rank++, .result = result_id->second});
+        const bool inserted =
+            rules.insert(merge_pair_key(left_id->second, right_id->second),
+                         BpeMergeRule{.rank = rank++, .result = result_id->second});
         if (!inserted) { throw std::invalid_argument("duplicate merge pair in model.merges"); }
     }
     return rules;
@@ -546,7 +549,7 @@ std::array<int, 256> load_byte_token_ids(const std::unordered_map<std::string, i
 }
 
 bool append_normalized_bpe_ids(std::vector<int>& ids, std::string_view normalized,
-                               const std::unordered_map<std::uint64_t, BpeMergeRule>& merge_rules,
+                               const BpeMergeTable& merge_rules,
                                const std::array<int, 256>& byte_token_ids, std::size_t max_tokens,
                                std::vector<std::size_t>* token_ends = nullptr,
                                std::vector<BpeWordEnd>* word_ends   = nullptr) {
@@ -576,15 +579,15 @@ bool append_normalized_bpe_ids(std::vector<int>& ids, std::string_view normalize
             if (left < 0 || !nodes[static_cast<std::size_t>(left)].live) { return; }
             const int right = nodes[static_cast<std::size_t>(left)].next;
             if (right < 0) { return; }
-            const auto rule =
+            const BpeMergeEntry* rule =
                 merge_rules.find(merge_pair_key(nodes[static_cast<std::size_t>(left)].symbol,
                                                 nodes[static_cast<std::size_t>(right)].symbol));
-            if (rule == merge_rules.end()) { return; }
+            if (rule == nullptr) { return; }
             queue.push(BpeCandidate{
-                .rank             = rule->second.rank,
+                .rank             = rule->rank,
                 .left             = left,
                 .right            = right,
-                .result           = rule->second.result,
+                .result           = rule->result,
                 .left_generation  = nodes[static_cast<std::size_t>(left)].generation,
                 .right_generation = nodes[static_cast<std::size_t>(right)].generation,
             });
@@ -638,7 +641,7 @@ struct IndexedByteBoundary {
 
 bool append_ordinary_text(BoundaryEncodedText& encoded, std::string_view text,
                           std::size_t text_offset, std::span<const IndexedByteBoundary> boundaries,
-                          const std::unordered_map<std::uint64_t, BpeMergeRule>& merge_rules,
+                          const BpeMergeTable& merge_rules,
                           const std::array<int, 256>& byte_token_ids, std::size_t max_tokens) {
     const std::size_t token_base = encoded.input_ids.size();
     if (text.empty()) {

--- a/src/targets/qwen3_6/impl/frontend/tokenizer.h
+++ b/src/targets/qwen3_6/impl/frontend/tokenizer.h
@@ -54,6 +54,70 @@ struct BpeMergeRule {
     int result = -1;
 };
 
+struct BpeMergeEntry {
+    std::uint64_t key = 0;
+    int rank          = 0;
+    int result        = -1;
+};
+
+// Merge table of the BPE encoder, open addressed with linear probing.
+//
+// Every adjacent symbol pair of every word is looked up here, and the lookup dominates
+// Tokenizer::encode, so the table is stored flat: one power-of-two array of 16-byte entries
+// instead of a bucket array plus one heap node per rule. A hit reads a single cache line
+// rather than following a pointer chase, and the whole structure is smaller than the
+// equivalent std::unordered_map even at a load factor below one half.
+//
+// The invariant that makes an empty slot recognisable is result < 0. Token ids come from
+// parse_token_id, which rejects anything negative, so a stored rule always has result >= 0.
+class BpeMergeTable {
+public:
+    // Sizes the table for rule_count rules. Capacity is the smallest power of two above
+    // twice that count, so at least half of the slots stay empty and every probe chain ends.
+    void reset(std::size_t rule_count) {
+        std::size_t capacity = 1;
+        while (capacity < rule_count * 2U) { capacity <<= 1U; }
+        slots_.assign(capacity, BpeMergeEntry{});
+        mask_ = capacity - 1U;
+    }
+
+    // Returns false when the key is already present, which is how the loader detects a
+    // duplicate pair in model.merges.
+    bool insert(std::uint64_t key, BpeMergeRule rule) {
+        std::uint64_t index = mix(key) & mask_;
+        while (slots_[index].result >= 0) {
+            if (slots_[index].key == key) { return false; }
+            index = (index + 1U) & mask_;
+        }
+        slots_[index] = BpeMergeEntry{.key = key, .rank = rule.rank, .result = rule.result};
+        return true;
+    }
+
+    [[nodiscard]] const BpeMergeEntry* find(std::uint64_t key) const noexcept {
+        std::uint64_t index = mix(key) & mask_;
+        while (true) {
+            const BpeMergeEntry& entry = slots_[index];
+            if (entry.result < 0) { return nullptr; }
+            if (entry.key == key) { return &entry; }
+            index = (index + 1U) & mask_;
+        }
+    }
+
+private:
+    // splitmix64 finalizer. A key is two token ids packed into one word, so its low bits
+    // alone would cluster badly across a power-of-two slot count.
+    static std::uint64_t mix(std::uint64_t key) noexcept {
+        key += 0x9e3779b97f4a7c15ULL;
+        key = (key ^ (key >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+        key = (key ^ (key >> 27U)) * 0x94d049bb133111ebULL;
+        return key ^ (key >> 31U);
+    }
+
+    // One empty slot by default, so find() on a default-constructed table terminates.
+    std::vector<BpeMergeEntry> slots_ = std::vector<BpeMergeEntry>(1);
+    std::uint64_t mask_               = 0;
+};
+
 struct TokenBoundaryResult {
     // exact_frontier is present when the byte marker is also a boundary in the complete token
     // stream. stable_frontier retains only a normalization- and pre-tokenization-complete prefix.
@@ -93,7 +157,7 @@ private:
     std::vector<bool> valid_token_ids_;
     std::vector<bool> special_token_ids_;
     std::unordered_map<std::string, int> vocab_token_to_id_;
-    std::unordered_map<std::uint64_t, BpeMergeRule> bpe_merge_rules_;
+    BpeMergeTable bpe_merge_rules_;
     std::array<int, 256> byte_token_ids_{};
     std::vector<AddedToken> added_tokens_;
     std::array<std::vector<std::size_t>, 256> added_token_candidates_;


### PR DESCRIPTION
## Base

Base `origin/master` @ **`487f8977`**. Rebased onto `master` `487f8977`; the diff applies to it cleanly, with the same diff on its own base as the control. **The measurements below were taken on `ad0f3d38`**, which was master when the work was done, 83 commits back. I have not re-taken them here and I say so rather than implying they are fresh.

The work was done on `ad0f3d38` (`chore: add project funding information`),
checked **2026-09-05** with `git ls-remote https://github.com/Neroued/ninfer.git
refs/heads/master` rather than through a clone's `origin`, which can point at a stale local
mirror. The branch has been rebased across every intervening head - `a140e7ae` -> `b8786751`
(2026-09-04) -> `ad0f3d38` (2026-09-05) - with **no conflict at either step** and
`patch-id --stable` of the change unchanged throughout. `ctest` on the bare `b8786751` is
**104 of 104, 0 failed**, with the same six artifact-gated tests skipped;
`tests/CMakeLists.txt` is byte-identical on all three bases, so the registered count does not
move. Note that `master` and `dev` no longer agree: `dev` is one commit behind, at `863aa8a5`.

The two commits added since `b8786751` are `863aa8a5` (`fix(dflash): allow vision prompts`) and
`ad0f3d38` (`chore: add project funding information`). Nothing in them is re-measured here, and
that is settled by a line of source rather than by the commit subject: everything the DFlash fix
adds is allocated under `if (layout.spec.enable_dflash)`
(`src/targets/qwen3_6/impl/state/round_state.cpp:176`), behind a speculative backend whose
default is `SpeculativeBackend::None` in every entry point (`include/ninfer/types.h:78`,
`src/serve/serve_options.h:46`), reachable only through an explicit `--spec dflash` that no
measurement in this report passes.

**Why the measurements carry across the two rebases, for a change of this shape.** Everything
timed in this report runs on the host: a harness that links `Tokenizer` and calls
`Tokenizer::encode`, with no engine, no device and no server in the process. So the question is
only whether the intervening commits touch the tokeniser, and they do not:
`git diff --stat a140e7ae b8786751` is eight files - one maintainer document, five headers under
`src/targets/qwen3_6/impl/runtime/` and two tests - and neither of the two files this change edits,
`src/targets/qwen3_6/impl/frontend/tokenizer.{cpp,h}`, is among them. The two commits after it are a
DFlash/vision fix and a funding file. Stronger than the file list, and checkable in one command:
both edited files have the **same blob** on the `a140e7ae`-based head and on the `b8786751`-based
head (`eb04f3cd…` and `c9de941d…`), so the tree that was measured and the tree being submitted are
byte-identical where it matters. A GPU-side stock-against-stock control was taken for the packages
in this queue that use `ninfer_bench`; it is not quoted here, because it would be evidence about an
instrument this report never uses.

## Where this is worth something, and where it cannot be seen at all

Stated first, because it decides which numbers below are worth reading.

**Where it works.** Host-side tokenisation: `Tokenizer::encode`, reached through
`Frontend::tokenize_text` (`src/targets/qwen3_6/impl/frontend/frontend.cpp:1575-1578`), which is
called from `src/runtime/engine/engine.cpp:334` and `apps/perplexity/main.cpp:234`. In serving that
means request preparation — every request, before any device work — and it is largest on a warm
prefix, where the device has little left to do and the host share of the turn is at its highest.

**Where it cannot be seen.** `ninfer_bench` **never calls the encoder**. It reads a corpus of token
**ids** (`bench/targets/qwen3_6_27b/ninfer_bench.cpp:79` -> `prepare_tokens(prompt_slice(corpus, …))`,
`ninfer_bench_support.cpp:458` -> `load_corpus_ids`) and hands them to `Frontend::prepare_tokens`
(`frontend.cpp:1551-1573`), which validates ids and lays out positions. There is no `encode` on that
path. So an end-to-end `ninfer_bench` figure for this change is not merely small — it is a
**structural zero**, and I would be misleading you if I offered one. I built the stack this change
belongs to and ran that benchmark anyway, precisely to check: it moves nothing, for this reason.

Two consequences for how to read the rest of this report. The host-side ratio in *Measurement* is
the real measurement and it is direct. The serving figures under *End to end* are **projections**
onto a request log, they are labelled as such where they appear, and no benchmark in this repository
can confirm or refute them as they stand.


`Tokenizer::encode` looks a merge rule up once for every adjacent symbol pair of every word.
Until now every one of those lookups went through `std::unordered_map<std::uint64_t, BpeMergeRule>`:
a bucket array, then one separately allocated node per rule, so a hit is an indirection into memory
the loader scattered across the heap. The rules never change after load and their count is known
before the first insert, so the container that fits is a flat one.

This replaces that map with `BpeMergeTable`: a power-of-two array of 16-byte entries with linear
probing, sized to twice the rule count so it stays below half full. **The map is replaced, not
supplemented** — the member, both helper signatures and the loader now carry the table, and no
intermediate map is built at load: the table is filled straight from `model.merges`.

**Two files, +82 −15.** Nothing else in the tree names the merge rules
(`git grep -n 'BpeMergeRule\|bpe_merge_rules\|merge_pair_key\|load_bpe_merge_rules'` hits only these
two files).

## Design

* An empty slot is marked by `result < 0`. That is sound rather than lucky: token ids come from
  `parse_token_id`, which rejects negatives, so a stored rule always has `result >= 0`.
* Capacity is the smallest power of two above twice the rule count, so at least half the slots stay
  empty and every probe chain terminates. A default-constructed table holds one empty slot, so
  `find()` on it returns `nullptr` rather than spinning.
* `insert` returns `false` when the key is already present, which is how the loader keeps rejecting
  a duplicate pair in `model.merges` — the same contract `emplace().second` gave it before.
* Keys are two token ids packed into one word, so they are put through a splitmix64 finaliser before
  they select a slot; their low bits alone cluster badly across a power-of-two slot count.
* **Fill order is load-bearing and is commented as such in the loader.** With linear probing the
  first claimant keeps a slot, and a low rank is a merge the encoder performs often, so walking
  `model.merges` in order hands the frequent rules their home slot. A build that differs from this
  one in nothing but filling the same table out of an unordered container is **10.7 % slower**
  (15 cells, median 1.1068). This is easy to lose in a later refactor, hence the comment.

## Measurement

Measured on the tree's own `Tokenizer::encode`, with the product tokeniser read out of a
`qwen3_6_35b_a3b.ninfer` artifact (248 044 tokens, 247 587 merge rules), on five chat fixtures
including the exact prompt the server builds. Arms live in separately linked binaries, alternate run
by run, and each ratio is taken from an **adjacent pair of runs**, not from per-arm averages.
40 timed repeats per run, three rounds per cell, three independent passes on three different cores.

| pair Y/X | cells | min | median | max |
|---|--:|--:|--:|--:|
| **base → this change** | **45** | **0.7460** | **0.7636** | **0.8035** |
| base → the same source under another file name | 30 | 0.9844 | 1.0021 | 1.0195 |
| base → base + a dead function, code shifted (small) | 30 | 0.9406 | 0.9851 | 0.9967 |
| small shift → large shift | 30 | 0.9682 | 0.9958 | 1.0165 |
| this change → the same source under another file name | 15 | 0.9862 | 1.0022 | 1.0211 |

**Encode is 0.746…0.804 of base, median 0.764.** The floor it is read against is **105 control
cells that do identical work**, spanning 0.9406…1.0211. The worst mechanism cell clears the best
floor cell by **13.7 points**, with no overlap.

The 105 are not all of one kind, and the difference matters. **Forty-five of them have a true ratio
of exactly 1.000 by construction**: the two rename rows, where the arm is the same source compiled
under a different file name, so its object md5 differs while its `.text` is byte-identical. The
other sixty do the same work under a *different code layout*, which is a real difference and not a
null - and they are in the floor deliberately, because that is where its lower edge comes from. An
earlier revision of this line called all 105 "exactly 1.000", which contradicted the very next
paragraph; the correction widens what the floor is admitting, not what it measures.

The last rename row repeats that control **on the patched side**, because the change touches the
header and therefore the harness object differs between arms; it says the harness contributes
neither sign nor size.

**The floor is not symmetric noise, and the mechanism is read against its edge for that reason.**
The two rows that shift code rather than rename it sit systematically below 1.000 - the small-shift
row has a median of 0.9851 over 30 cells, and in the earlier round of this measurement the
large-shift row read 0.977. The two arms are a dead function of 64 and of 320 operations
respectively; earlier revisions of this table gave the shifts as "1 438 B" and "8 901 B", and since
I no longer hold the object dump those byte figures came from, they are not quoted. Moving this code in the binary is worth one to two per cent on
its own, always in the same direction, and that - not run-to-run jitter - is what sets the floor's
lower edge at 0.9406. It is the reason the claim above compares the **worst** mechanism cell with
the **best** floor cell instead of comparing medians: a systematic layout term of that size would
otherwise be free to hide inside a median.

Every timed repeat carries an in-band clock witness — a fixed dependent-ALU chain that touches no
memory, so its duration tracks core frequency and nothing else. Repeats whose witness is more than
3 % off the best of the run are dropped. That filter is not cosmetic: on this host the witness
caught the core dropping by a factor of 1.78…2.00 inside runs.

**But it does not move this table, and an earlier revision of this line claimed it did.** That
revision read: *"without the filter the floor widens from ±3 % to about ±10 %"*. Recomputing every
one of the 105 floor cells and all 45 mechanism cells from the unfiltered per-repeat minima gives
**the same numbers to four decimals** - floor 0.9406…1.0211, mechanism 0.7460…0.8035. The reason is
structural: each ratio is taken over the *minimum* repeat of a run, and a filter that drops slow
repeats cannot move a minimum. The ±10 % figure was carried over from an earlier round of this
measurement and describes that round, not this table. The witness is still worth keeping - it is
what makes the minimum a defensible statistic rather than a lucky one - but it earns no credit
here.

By fixture the gain follows how many merges a word needs: English prose 0.755, ASCII chat 0.762,
the server's own prompt 0.764, Russian chat 0.795. Chinese and source code were not re-measured
here; on the earlier, weaker variant of this table they were the weakest fixtures.

## Memory

| | |
|---|--:|
| flat table | 524 288 slots × 16 B = **8.00 MiB**, load factor 47.2 % |
| the map it replaces | 256 279 buckets × 8 B + 247 587 nodes × 32 B = **9.51 MiB** |
| **live heap held by a constructed `Tokenizer`** | 48 088 kB → 46 536 kB = **−1 552 kB = −1.516 MiB** |
| same figure, second construction in the same process | −1 552 … −1 553 kB |
| `sizeof(Tokenizer)` | 7 432 → 7 408 B |
| peak RSS | 154 848 → 155 360 kB, **+0.33 %** |

The instrument is `mallinfo2` sampled immediately before and immediately after the constructor,
twice per process, 18 processes. The first-construction figure is the same in all 18 to the
kilobyte; the second-construction figure varies by 1 kB between fixtures (−1 552 and −1 553), which
is why it is printed as a range.

**Peak RSS does not show this and must not be used for it.** Freeing the 12.8 MB `tokenizer.json`
leaves arena that the table then reuses, so the arm that holds 1.5 MiB *less* reads 0.33 % *higher*
on peak RSS. That is noise, not a regression, and it is the reason the number above comes from the
allocator rather than from `/proc`.

## Output is unchanged, and the check was shown to be able to fail

Two independent digests over the id vector (FNV-1a over the bytes, and a polynomial over the values
with position mixed in) agree on **every paired cell** of all passes, with equal token counts.

A digest that always matches proves nothing, so five deliberately damaged builds of this same table
were run against the base arm as truth, over five fixtures each:

| corruption | fires | expected |
|---|--:|---|
| every rank shifted by the same constant — merge **order** unchanged | **0/5** | must **not** fire, and does not |
| `rank ^ 0x3F`, wide rank scramble | 5/5 | fires |
| exactly one rule of 247 587 returns a wrong result id | 3/5 | fires on the fixtures that use it |
| exactly one rule of 247 587 behaves as absent | 3/5 | fires on the fixtures that use it |
| `rank ^ 1`, two adjacent ranks swapped | 0/5 | **does not fire — stated, not hidden** |

Two of these deserve spelling out. On the wrong-result-id rung the **token count does not move** on
any of the three fixtures that catch it (8753 = 8753, 8401 = 8401, 8473 = 8473) while the digest
does, so the check is sharper than a length comparison. And the adjacent-rank swap is a real blind
spot: two rules neighbouring in rank almost never compete inside one word, so their relative order
does not reach the output. The damaged rules that go undetected on a given fixture are the ones that
fixture never exercises. Both single-rule rungs damage **rank 0**, the hottest rule of the
247 587, so "3 of 5" means "every fixture that touches rank 0 at all", not "60 % of faults of this
kind"; the ladder says nothing about a corrupted rule at, say, rank 200 000. It also says nothing
about a corrupted *lookup*: all five rungs damage what the loader writes into the table (`rank`,
`result`), and none of them damages `mix()`, the mask or the probe chain. What covers the lookup is
the coverage probe under *Tests*, not this ladder.

## Tests

**104/104 on `e1bf7a15`, tree `757a904401fae0a116d9c23ab03003bdeacc1fde`, base `a140e7ae`** — and
104/104 on the bare base as well, with the same six tests skipped (four `_real_` ones plus
`ninfer_qwen3_6_27b_load_plan_test` and `ninfer_qwen3_6_35b_a3b_dflash_load_plan_test`, which want
model weights this bench does not have for 27B). Release build, `BUILD_TESTING=ON`,
`CMAKE_CUDA_ARCHITECTURES=120a`, both arms built in turn in the same tree so the comparison is not
between two configurations.

That number alone would say nothing about this change, so coverage was checked rather than assumed.
A one-line probe branch makes `BpeMergeTable::find` return `nullptr` before it looks at a single
slot, so the table this change introduces is never consulted and no merge is ever applied. Under it
the suite goes to **103/104**, and the test that falls is `ninfer_qwen3_6_frontend_test`, which
names what it guards:

```
priority BPE changed rank or leftmost merge semantics
boundary-aware tokenizer changed crossing-token or result-order semantics
```

So exactly one test of the 104 covers this code, and it checks rank order, leftmost-merge semantics
and result order — which is what this change could plausibly have broken. The probe branch is not
part of this PR.

One coverage detail worth stating rather than hiding: the bench also has the 35B product artifact,
so the three weighted `35b_a3b` tests were run too. They pass on the change, on the base **and under
the probe** — they exercise the built engine but do not look at the ids the merge loop produces, so
they add runtime confidence and no coverage of this change.

`ninfer_qwen3_6_27b_prefix_real_test` is skipped here for want of 27B weights and so was not
observed on this bench either way; it is unrelated to this change and is not touched. It used to
fail on the bare `a140e7ae` on hosts that do carry that artifact; on `b8786751` it **passes**, that
commit having rewritten the machinery and touched 264 lines of
`tests/targets/qwen3_6_27b/test_engine_prefix_real.cpp`. There is therefore no known-red test on
the base this branch sits on.

> **Retracted.** An earlier revision of this line read: *"`ninfer_qwen3_6_27b_prefix_real_test`,
> which fails on upstream itself, is skipped here…"*. True on `a140e7ae`, stale on `b8786751`.

## The second model

This file is the shared frontend of both registered targets, so the table is built for
`Qwen3.6-27B` as well, and the gain depends on two properties of that model's rule set: how many
rules there are (it fixes the capacity and the load factor) and the order of their ranks (10.7% of
the gain rides on it, see *Design*). Neither had been read anywhere, so I read them out of the
artifacts rather than argue about them.

The tokenizer resource of the two artifacts is **the same file**. `frontend/tokenizer.json` is
12 807 982 bytes in `qwen3_6_27b_nvfp4.ninfer` and in `qwen3_6_35b_a3b.ninfer`, md5
`7b6074791b84e7ce3a5fc12746b82d48` in both, and it parses to **248 044 vocabulary entries, 247 587
merge rules and 26 added tokens** on both. The rules, their ranks and their order are therefore
identical, and so is everything this change derives from them: capacity 524 288 slots, 8.00 MiB,
load factor 47.2%, the same fill order, the same probe chains.

So the second model is not a risk that needs a measurement — it is the same input. What is **not**
claimed: the encode ratio itself was measured on one host with the 35B artifact loaded, and I did
not re-run the timing under the 27B artifact. Given a byte-identical tokenizer that would be a
measurement of the host, not of the model.

## Limits

* The end-to-end figures below are **projections, not measurements**: the serve binary could not be
  rebuilt on the same bench for lack of space. There is also no benchmark in this repository that
  could turn them into measurements as they stand — see *"Where this is worth something"* above.
* All numbers come from one host (AMD EPYC 7B12, `acpi-cpufreq`, `schedutil`, steps 2250/1900/1500
  plus boost). On a host with a pinned clock the frequency picture will differ; the byte-identical
  controls do not depend on it.
* A 8-byte entry (rank and result only, key re-checked by a second look at the vocabulary) would
  halve both the memory and the cache misses. That was **not** measured and is not proposed here.

## End to end

Both regimes are projected from a raw request log of the **unpatched** server (2 928 requests,
12 segments of 244, warm prefix) multiplied by the ratio above, measured on the very
prompt that server built.

| regime | tokenise share of the run | **of the run** | of TTFT |
|---|--:|--:|--:|
| **warm prefix, 64 generated tokens — an ordinary dialogue turn** | 4.0…4.5 % | **−0.95 … −1.05 %** | −6.3 … −9.5 % |
| warm prefix, `max_tokens=1` — token counting, scoring, guardrails | 67.8…77.0 % | **−16.0 … −18.2 %** | −16.0 … −18.2 % |

The dialogue figure is the honest headline: in a turn that generates, host tokenisation is about
4 % of the run and this is worth about one percent of it. The `max_tokens=1` regime is where the
change is large, and it is a real traffic shape rather than a benchmark artefact.

### How this sits next to the ASCII-NFC change

There is a companion change to `normalize_nfc` in `src/text/unicode.cpp` that skips utf8proc for
pure-ASCII text. It is deliberately a **separate** submission: one mechanism per change, different
file, different operator, and each stands or falls on its own numbers. They are worth naming
together only because they land in the same place — request preparation on a warm prefix — and they
compose rather than overlap. Neither measurement was taken with the other applied, so the combined
effect is expected to compose but has not been measured that way.

> **Removed rather than repeated.** An earlier revision of this paragraph read: *"profiling that
> turn shows the BPE merge loop at 53.5 % of TTFT and NFC normalisation at 10.2 %, so between them
> they account for just under two thirds of it."* Those two shares are not in any log I still hold,
> so I am not quoting them. What survives is the share this report does measure, from the request
> log in the table above: host tokenisation is 4.0…4.5 % of an ordinary generating turn and
> 67.8…77.0 % of a `max_tokens=1` turn.

One caveat on the projection. With generation, `tokenize` in the log reads 13.9…15.3 ms rather than
the 6.4 ms of the shortest `max_tokens=1` segment. The likeliest reason is that the host thread
spends most of a generating turn idle and the core falls to a lower P-state, but the log carries no
frequency column, so that is an explanation and not a reading. The ratio 0.764 is a ratio of work
and does not depend on frequency, so applying it there is legitimate either way; the saving is
**larger in milliseconds** (3.3…3.6 against 1.5…2.7) and **smaller as a share**. One
`max_tokens=1` segment reads 11.4 ms rather than 6.4 and is the one that carries the 2.7 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
