### PR TITLE
Fall back to a preset of the same weights format when no (model, weights) row matches: prefill-cost prediction goes from 3.1x to 1.15x on a registered artifact

### DIFF
--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -923,6 +923,10 @@ struct RuntimeStats {
 enum class ContextCostPresetSource : std::uint8_t {
     GenericDefault,
     CompiledDefault,
+    // Compiled coefficients measured for another model in the same weight format, not for this
+    // one. Reported apart from CompiledDefault so a reader can tell a borrowed profile from a
+    // measured one.
+    CompiledWeightsFallback,
     External,
 };
 
@@ -933,6 +937,8 @@ context_cost_preset_source_name(ContextCostPresetSource source) noexcept {
         return "generic-default";
     case ContextCostPresetSource::CompiledDefault:
         return "compiled-default";
+    case ContextCostPresetSource::CompiledWeightsFallback:
+        return "compiled-weights-fallback";
     case ContextCostPresetSource::External:
         return "external";
     }

--- a/src/runtime/engine/context_cost.cpp
+++ b/src/runtime/engine/context_cost.cpp
@@ -212,6 +212,14 @@ const ContextPrefillPreset* find_prefill(const ContextCostMachinePreset& machine
     return found == machine.prefill.end() ? nullptr : &*found;
 }
 
+const ContextPrefillPreset* find_prefill_by_weights(const ContextCostMachinePreset& machine,
+                                                    std::string_view weights_id) noexcept {
+    const auto found =
+        std::find_if(machine.prefill.begin(), machine.prefill.end(),
+                     [&](const auto& preset) { return preset.weights_id == weights_id; });
+    return found == machine.prefill.end() ? nullptr : &*found;
+}
+
 void validate_presets(const std::vector<ContextCostMachinePreset>& presets,
                       std::string_view context) {
     for (std::size_t machine_index = 0; machine_index < presets.size(); ++machine_index) {
@@ -572,6 +580,12 @@ resolve_context_machine_cost(const ContextCostIdentity& identity,
         if (const ContextPrefillPreset* prefill =
                 find_prefill(*machine, identity.model_id, identity.weights_id)) {
             model.prefill  = prefill->cost;
+            prefill_source = ContextCostPresetSource::CompiledDefault;
+        } else if (const ContextPrefillPreset* by_weights =
+                       find_prefill_by_weights(*machine, identity.weights_id)) {
+            // A registered model with no row of its own is closer to another model in the same
+            // weight format than to the generic profile, which is the slowest measured one.
+            model.prefill  = by_weights->cost;
             prefill_source = ContextCostPresetSource::CompiledDefault;
         }
     }

--- a/src/runtime/engine/context_cost.cpp
+++ b/src/runtime/engine/context_cost.cpp
@@ -586,7 +586,7 @@ resolve_context_machine_cost(const ContextCostIdentity& identity,
             // A registered model with no row of its own is closer to another model in the same
             // weight format than to the generic profile, which is the slowest measured one.
             model.prefill  = by_weights->cost;
-            prefill_source = ContextCostPresetSource::CompiledDefault;
+            prefill_source = ContextCostPresetSource::CompiledWeightsFallback;
         }
     }
 

--- a/tests/test_context_cost.cpp
+++ b/tests/test_context_cost.cpp
@@ -275,6 +275,46 @@ void test_schema_validation() {
         "empty machine cost entry was accepted");
 }
 
+void test_weights_fallback() {
+    // A registered model with no row of its own resolves to the row of another model in the same
+    // weight format, and an exact (model, weights) row still wins over it.
+    constexpr const char* kMachine = "nvidia-geforce-rtx-5090-sm120";
+    const auto resolve             = [](std::string model, std::string weights) {
+        return ninfer::runtime::resolve_context_machine_cost(ninfer::runtime::ContextCostIdentity{
+                        .hardware_class = kMachine,
+                        .model_id       = std::move(model),
+                        .weights_id     = std::move(weights),
+        });
+    };
+
+    const auto nvfp4_row      = resolve("qwen3.8-27b", "nvfp4");
+    const auto int_row        = resolve("qwen3.6-27b", "groupwise-int");
+    const auto fallback       = resolve("qwen3.6-27b", "nvfp4");
+    const auto unknown_format = resolve("qwen3.6-27b", "unmeasured-weights");
+
+    expect(nvfp4_row.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault &&
+               int_row.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault &&
+               !(nvfp4_row.model.prefill == int_row.model.prefill),
+           "the two compiled rows this test compares are not distinguishable");
+
+    expect(
+        fallback.model.prefill == nvfp4_row.model.prefill &&
+            fallback.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault,
+        "a model with no row of its own did not take the coefficients of the same weights format");
+
+    expect(!(fallback.model.prefill == int_row.model.prefill),
+           "the weights fallback picked a row of a different weight format");
+
+    expect(int_row.model.prefill.chunk_ns != nvfp4_row.model.prefill.chunk_ns &&
+               resolve("qwen3.6-27b", "groupwise-int").model.prefill == int_row.model.prefill,
+           "an exact (model, weights) row no longer wins over the same-weights fallback");
+
+    expect(unknown_format.summary.prefill_source ==
+                   ninfer::ContextCostPresetSource::GenericDefault &&
+               !(unknown_format.model.prefill == nvfp4_row.model.prefill),
+           "an unregistered weight format must still fall through to the generic profile");
+}
+
 void test_resolution_and_atomic_upserts() {
     const std::filesystem::path directory =
         std::filesystem::temp_directory_path() /
@@ -363,6 +403,7 @@ int main() {
     test_exact_evaluation();
     test_kv_physical_work();
     test_schema_validation();
+    test_weights_fallback();
     test_resolution_and_atomic_upserts();
     if (failures == 0) { std::cout << "ok\n"; }
     return failures == 0 ? 0 : 1;

--- a/tests/test_context_cost.cpp
+++ b/tests/test_context_cost.cpp
@@ -277,7 +277,7 @@ void test_schema_validation() {
 
 void test_weights_fallback() {
     // A registered model with no row of its own resolves to the row of another model in the same
-    // weight format, and an exact (model, weights) row still wins over it.
+    // weight format, and an unregistered format still reaches the generic profile.
     constexpr const char* kMachine = "nvidia-geforce-rtx-5090-sm120";
     const auto resolve             = [](std::string model, std::string weights) {
         return ninfer::runtime::resolve_context_machine_cost(ninfer::runtime::ContextCostIdentity{
@@ -297,16 +297,21 @@ void test_weights_fallback() {
                !(nvfp4_row.model.prefill == int_row.model.prefill),
            "the two compiled rows this test compares are not distinguishable");
 
-    expect(
-        fallback.model.prefill == nvfp4_row.model.prefill &&
-            fallback.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault,
-        "a model with no row of its own did not take the coefficients of the same weights format");
+    expect(fallback.model.prefill == nvfp4_row.model.prefill &&
+               fallback.summary.prefill_source ==
+                   ninfer::ContextCostPresetSource::CompiledWeightsFallback,
+           "a model with no row of its own did not take the coefficients of the same weights "
+           "format");
 
     expect(!(fallback.model.prefill == int_row.model.prefill),
            "the weights fallback picked a row of a different weight format");
 
-    expect(int_row.model.prefill.chunk_ns != nvfp4_row.model.prefill.chunk_ns &&
-               resolve("qwen3.6-27b", "groupwise-int").model.prefill == int_row.model.prefill,
+    // Precedence is asserted through the source rather than through the coefficients. No weight
+    // format carries two compiled rows, so both lookups return the same row and comparing costs
+    // could not tell them apart; the reported source can, and it moves the moment the fallback is
+    // consulted first.
+    expect(nvfp4_row.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault &&
+               int_row.summary.prefill_source == ninfer::ContextCostPresetSource::CompiledDefault,
            "an exact (model, weights) row no longer wins over the same-weights fallback");
 
     expect(unknown_format.summary.prefill_source ==


### PR DESCRIPTION
> **Base: `origin/master` @ `487f8977`.** Rebased onto `master` `487f8977`; the diff applies to it cleanly, with the same diff on its own base as the control. **The measurements below were taken on `ad0f3d38`**, which was master when the work was done, 83 commits back. I have not re-taken them here and I say so rather than implying they are fresh.
>
> Originally checked on `ad0f3d38` 2026-09-05 with
> `git ls-remote https://github.com/Neroued/ninfer.git refs/heads/master` rather than
> through a clone's `origin`. This branch was written against `a140e7ae` and has been rebased
> straight onto `ad0f3d38` across every intervening head: **no conflict**, and
> `patch-id --stable` of the change is unchanged. Head `fb925985` -> **`05f4f4a9`**, 1 commit(s)
> above the base.
>
> The two commits added since `b8786751` are `863aa8a5` (`fix(dflash): allow vision
> prompts`) and `ad0f3d38` (`chore: add project funding information`). Nothing here is
> re-measured because of them, and that is settled by a line of source rather than by the
> commit subject: everything the DFlash fix adds is allocated under
> `if (layout.spec.enable_dflash)` (`src/targets/qwen3_6/impl/state/round_state.cpp:176`),
> behind a speculative backend whose default is `SpeculativeBackend::None` in every entry
> point (`include/ninfer/types.h:78`, `src/serve/serve_options.h:46`), reachable only
> through an explicit `--spec dflash` that no measurement here passes.
>
> Note that `master` and `dev` no longer agree: `dev` is one commit behind, at `863aa8a5`.

## Scope

One mechanism, four lines: when the compiled context-cost table has no row for an artifact's
`(model_id, weights_id)` pair, fall back to a row of the same `weights_id` before falling through to
the generic profile.

**This corrects the prediction, not the throughput.** Time to first token does not move; the
evidence for that is below, and the report does not claim performance.

**It improves one of the three unmatched combinations.** The other two are unchanged by construction
- the paragraph on that is first, because it is the thing worth knowing before reading anything else.

## Environment

- One RTX 5090, `sm_120a`, driver 580.105.08, CUDA 13.1.115, gcc 13.3, Ubuntu 24.04, Release,
  `-DCMAKE_CUDA_ARCHITECTURES=120a`. Dedicated host, no other tenant.
- Base `a140e7ae` (`origin/master` at the time of writing). `context_cost.cpp` and
  `context_cost_defaults.cpp` are untouched between that commit and the branch point.
- Artifact `Qwen3.6-27B` NVFP4 (`model_id` `qwen3.6-27b`, `weights_id` `nvfp4`).
- Stock `ninfer-serve` with `--request-log-jsonl`. **Both arms are built in the same run from a
  clean tree** - `origin/master` and this one-file commit, nothing else applied - and each arm is
  measured twice with the arms alternated.

## Observation

`find_prefill` (`src/runtime/engine/context_cost.cpp:210`) matches on both fields:

```cpp
return preset.model_id == model_id && preset.weights_id == weights_id;
```

The compiled table (`context_cost_defaults.cpp`) holds two rows:

| `model_id` | `weights_id` | `chunk_ns` |
|---|---|--:|
| `qwen3.6-27b` | `groupwise-int` | 40 813 570 |
| `qwen3.8-27b` | `nvfp4` | 14 672 989 |

The targets register five combinations (`src/targets/*/impl/package.cpp`):

| combination | row |
|---|---|
| `qwen3.6-27b` + `groupwise-int` | present |
| `qwen3.8-27b` + `nvfp4` | present |
| **`qwen3.6-27b` + `nvfp4`** | **absent** |
| `qwen3.8-27b` + `groupwise-int` | absent |
| `qwen3.6-35b-a3b` + `groupwise-int` | absent |

An unmatched pair keeps `generic_context_prefill_cost()`, whose five coefficients are byte-identical
to the `qwen3.6-27b` + `groupwise-int` row. So an artifact on NVFP4 weights is costed with the
integer-weight profile, which the table itself puts at 2.78x the measured NVFP4 one.

The comment calls the generic profile a conservative estimate for an unknown model, which is
reasonable. The model here is not unknown: the combination is registered and supported
(`src/targets/qwen3_6_27b/impl/package.cpp:92`); it simply has no row.

Measured consequence on the stock binary, means over 27 requests, two runs:

| quantity | predicted | actual | error |
|---|--:|--:|--:|
| `predicted_now_ns` (this prefill step) | 240.6 / 240.4 ms | **78.2 / 76.3 ms** | **3.08x / 3.15x** |
| `predicted_total_ns` | 1259 / 1251 ms | - | - |

That 3.1x agrees with the 2.78x ratio between the two profiles' coefficients, which is what makes
the substituted profile the explanation rather than a coincidence.

The same shape appears on a second artifact: `qwen3.6-35b-a3b` has no row either, and its prediction
reads 139.7 ms against 24.7 ms actual (5.7x). Different model, different machine, same mechanism.

## Root cause

The lookup key is a pair; the table is populated on a diagonal. Two of the five registered
combinations are covered, and the fallback for the rest is not neutral - it is one of the two
measured profiles, the slower one.

## Change

`find_prefill_by_weights` returns the first row whose `weights_id` matches, and
`resolve_context_machine_cost` consults it only after the exact pair misses:

```cpp
if (const ContextPrefillPreset* prefill = find_prefill(*machine, model_id, weights_id)) {
    ...
} else if (const ContextPrefillPreset* by_weights = find_prefill_by_weights(*machine, weights_id)) {
    model.prefill  = by_weights->cost;
    prefill_source = ContextCostPresetSource::CompiledDefault;
}
```

Exact matches still win. An artifact whose weights format has no row at all still receives the
generic profile.

## Correctness evidence

**What changes, and what provably does not.**

| gap | costed today with | costed after with | change |
|---|---|---|---|
| `qwen3.6-27b` + `nvfp4` | generic (= integer profile) | `qwen3.8-27b` + `nvfp4` row | **3.14x -> 1.15x** |
| `qwen3.8-27b` + `groupwise-int` | generic | `qwen3.6-27b` + `groupwise-int` row - **identical coefficients** | none |
| `qwen3.6-35b-a3b` + `groupwise-int` | generic | same row - **identical coefficients** | none |

The two unchanged rows are not a measurement but a reading of the table: all five coefficients of
`generic_context_prefill_cost()` equal the `qwen3.6-27b` + `groupwise-int` row exactly, so the new
path substitutes the same numbers those combinations already receive. **The change cannot make any
registered combination worse.**

**The one combination it corrects**, same artifact, same probe, two runs per arm, arms alternated,
means over 27 requests each:

| arm | `predicted_now_ns` | actual prefill | error |
|---|--:|--:|--:|
| `origin/master`, run 1 | 240.6 ms | 78.2 ms | 3.08x |
| `origin/master`, run 2 | 240.4 ms | 76.3 ms | 3.15x |
| **this change, run 1** | **87.8 ms** | 76.3 ms | **1.15x** |
| **this change, run 2** | **87.8 ms** | 76.3 ms | **1.15x** |

`predicted_total_ns` falls from 1251-1259 ms to 456 ms. The corrected arm reproduces to the first
decimal across both runs, because the prediction is a function of the coefficients and the prompt,
not of the machine's state.

**Time to first token does not move.** Same runs, shared-prefix traffic, three prefix sizes:
69.4 vs 69.4 ms at 150 tokens, 83.3 vs 83.2 at 400, 122.2 vs 122.1 at 800. The materialization
planner's selection is empty on this traffic either way (`stop_reason: time_budget`,
`last_selection.frontier_tokens: 0`), so a corrected cost does not change what it picks. That is
reported because it bounds the claim, and because the opposite would have been the natural thing to
assume.

`ctest`: **104 tests, 104 passed, 0 failed** on `36a3cb04`. The submitted commit `fb925985` differs
from it in the commit message only - both have tree `5a6f6c4b97ce7e6d4f385dd365d8e071f4c7bd3f` and
the same `patch-id` `5bc6da3418d9`, so the tested tree is the submitted tree. The suite is run one
test at a time -
build, run, delete - because the test executables are ~184 MB each and 104 of them do not fit
beside the model artifact on this host's 32 GB disk. Four of the 104 registered names are
variants of two parent executables (`ninfer_kv_cache_append_{k8v4,nvfp4}_test`,
`ninfer_softmax_attention_{k8v4,nvfp4}_test`) and are built through their parent target.

## Tradeoffs

- **The heuristic's limit, stated plainly.** Matching on weights format alone assumes two models of
  the same format have comparable per-token cost. That holds for today's table, where both
  `groupwise-int` entries are identical. It would not hold between a dense model and a sparse one of
  the same format: `qwen3.6-35b-a3b` is MoE with about three billion active parameters,
  `qwen3.6-27b` is dense. If a measured MoE row is ever added, the nearest profile should be chosen
  by weights format **and** architecture class together. This change does not create that situation,
  but it does not prevent it either.
- **Three consumers. Under load, none of them changes its decisions.** `ResolvedContextMachineCost`
  reaches the materialization planner, the shared-capture planner, and `resource_manager.h`, where
  it supplies `rebuild_ns` - the cost of rebuilding a dropped checkpoint, which feeds retention and
  eviction. That last one is the one to worry about: an over-predicted prefill makes checkpoint
  rebuild look three times more expensive than it is. It was measured, and it does not move.

  Four long shared prefixes with varying tails, 96 requests, at `--max-concurrency` 1, 4 and 8 -
  8 being the ceiling the server itself enforces (`--max-concurrency must be in [1,8]`), so this is
  the whole range the engine allows. Two passes per arm, arms alternated, both binaries built in the
  same run. Counters are summed across the server's stats windows, because the `throughput` event
  reports **per-interval** deltas rather than running totals.

  | concurrency | `predicted_now` base -> fix | `checkpoints_dropped` | `private_owners_evicted` | `searches` | `captures` | req/s |
  |--:|---|--:|--:|--:|--:|---|
  | 1 | 346.1 -> **126.7 ms** | 194 / 194 | 97 / 97 | 98 / 98 | 103 / 103 | 3.347 / 3.339 |
  | 4 | 346.3 -> **126.9 ms** | 102 / 102 | 91 / 91 | 96 / 96 | 19 / 19 | 5.653 / 5.663 |
  | 8 | 346.2 -> **126.8 ms** | 94 / 94 | 83 / 83 | 93 / 93 | 19 / 19 | 6.381 / 6.383 |

  **The prediction changes by 2.73x and not one pressure counter moves by one event.** The only
  disagreement anywhere is `private_owners_degraded` 3 against 4 in one of the four runs at
  concurrency 4 - within that arm's own run-to-run spread, since the other three runs at that point,
  including both base runs, all read 4. Base against base agrees exactly on every counter, so the
  noise floor on these quantities is zero and the agreement is a statement rather than an inability
  to tell them apart.

  **The counters do respond to something, and it is not the cost.** Between concurrency 1 and 8
  dropped checkpoints halve, captures fall fivefold, three counters that are zero at 1 become
  non-zero at 8, and the degradation-unit distribution shifts from `{0:1, 1:1, 3:97}` to
  `{0:6, 1:7, 2:81, 3:5}`. So the instrument is not stuck.

  Which part of concurrency does that, I tested and could not confirm. Setting
  `--device-state-slots` to 8 and then 16 at concurrency 1 - the same checkpoint capacity the
  engine gives itself at concurrency 8 - raises reserved memory by a gigabyte per step, and leaves
  `checkpoints_dropped` and `private_owners_evicted` at exactly 194 and 97, unchanged from the
  default. **I had predicted, in writing before the run, that this knob would move them; it does
  not.** What it does move is the planner's regime: `budget_exhausted` goes from 95 requests to 0,
  `stop_reason` from `time_budget` to `queue_exhausted`, and the enumerated candidate set from 558
  targets to 256. So checkpoint capacity changes how the planner searches without changing what
  gets evicted, and whatever concurrency carries that does move eviction is something else.

  **That failed prediction strengthens the arms comparison rather than weakening it.** Base and fix
  agree exactly at every one of those slot settings too - including the regime where the search
  exhausts its queue instead of its clock. The obvious objection to the original table, that the
  price never had time to act because every search ran out of budget, is answered by measurement:
  with `budget_exhausted = 0` the answer is still identical.

  **The planner is working, and that makes the agreement stronger.** It evaluates 400-600 targets
  per request (`targets_evaluated`) and selects one, at 3 degradation units on 97 requests of 99.
  The cost model's own output does change with this patch - `predicted_future_loss_ns` drops from a
  maximum of 1.59 s to 0.58 s, the same ~2.7x - while the selected degradation distribution and
  every pressure counter stay identical. So this is not a case of a planner that never runs; it is
  a planner whose inputs move and whose choices do not.

  The constant 3 is not a ceiling. `degradation_units`
  (`src/targets/qwen3_6/impl/runtime/pressure_planner.h:129`) is a tally of the consequences of a
  decision already taken - evicted continuation, plus state, KV and checkpoint changes - and no term
  in it comes from the cost model. It decomposes exactly: at concurrency 1 the units sum to 292 over
  99 requests, and the independently reported counters give 97 evictions plus 194 checkpoint drops
  plus one state change, which is 292. Three units is "evict one continuation and drop its two
  checkpoints", repeated because the traffic is uniform.

  **Why it does not move, read in the code rather than inferred.** `rebuild_ns` is genuinely read
  from this cost model (`resource_manager.h:1908`, `:1966`, feeding `baseline_saving` in
  `context_portfolio_value.h:69`), so it is not a dead computation. But it *prices* an outcome
  rather than choosing it: the victim's `disposition` arrives already decided in
  `assessment.owner_outcomes`, and the planner only folds its consequences into a candidate cost
  (`materialization_planner.h:857`). And the quantity that looks like the outcome of that
  comparison is not one: `degradation_units` is a tally, as shown above. The planner's
  own search budget cannot move either: `min(5 ms, incumbent.cost.total_ns / 20)` binds at 5 ms
  whenever `total_ns >= 100 ms`, and both arms are far above it (1875 ms and 686 ms).

  **A second consequence, and it is about the clamp rather than about this change.** The budget is
  written as a proportion of the incumbent's cost with a ceiling: `total_ns / 20`, capped at 5 ms.
  The proportional half only has an effect below `total_ns = 100 ms`. With the prediction inflated
  threefold, the cap is saturated on every request measured here - 1875 ms - so the proportional
  term never takes effect at all. Corrected, it is still saturated on this artifact (686 ms), but
  the distance to the point where the proportion begins to act is three times shorter. **Where a
  correct preset puts the prediction under 100 ms, that term would take effect for the first
  time.** I have not measured that regime and this artifact cannot reach it; it is named because
  whoever measures the three missing rows will reach it before anyone else, and should look.

  **A note on why nothing is reused here, since the logs invite the wrong conclusion.** Across all
  twelve runs `context_cache.selections.root` is 99 of 99 and `reused_prompt_tokens` is 0, on
  traffic built from four repeated prefixes. That is expected, not a defect: this probe drives the
  OpenAI chat endpoint with no cache markers, and `docs/serving.md:696` states that block-level
  `cache_control` is what "creates explicit shared-prefix candidates". Reuse that needs no marker
  is turn closure, and it works - a separate multi-turn probe on the same stock binary reports
  `reused_prompt_tokens = 38` and `private_turn_closure = 4`. So the zero above measures a probe
  that did not ask for caching, and it carries no claim about the engine.

  **What this does not establish.** That cost never affects eviction. Only that on this traffic, at
  this cache geometry, across the whole concurrency range the engine permits, a threefold change in
  the predicted cost changes no decision.
- **No new coefficients.** The change adds no measured numbers, so it carries none of this host's
  hardware into the product. Filling the three missing rows properly is a separate job and belongs
  on the maintainer's hardware; the tooling for it already exists in the tree
  (`bench/context_cost/`, target `ninfer_context_cost_bench`, emitting
  `ninfer_context_cost_calibration`).
- **Workspace, memory, kernels:** untouched. This is host-side cost resolution at startup.

## Reproduction

No patch is needed to see the defect - it reproduces on a stock build:

```bash
ninfer-serve models/qwen3_6_27b_nvfp4.ninfer --port 18080 --max-context 40960 \
  --prefill-chunk 8192 --max-concurrency 1 --greedy --no-thinking \
  --request-log-jsonl /tmp/req.jsonl
# send any request, then:
python3 -c "
import json
for line in open('/tmp/req.jsonl'):
    o = json.loads(line)
    m, t = o.get('materialization'), o.get('timings_seconds')
    if m and t:
        print(m['predicted_now_ns']/1e6, 'ms predicted vs', t['prefill']*1000, 'ms actual')
"
```

`--context-cost-presets FILE` does not mask this in normal operation: `docs/serving.md:766`
describes it as an *optional* runtime registry whose default is "generic + compiled defaults", and
the repository ships no such file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
