### PR TITLE
feat(serve): support ignore_eos on Chat Completions

### DIFF
--- a/src/serve/openai_chat_request.cpp
+++ b/src/serve/openai_chat_request.cpp
@@ -753,6 +753,7 @@ void parse_parallel_tool_calls(const Json& body, const GenerationRequest& output
 }
 
 void parse_stop(const Json& body, GenerationRequest& output) {
+    output.ignore_eos = get_bool(body, "ignore_eos", false);
     if (!body.contains("stop") || body.at("stop").is_null()) { return; }
     output.stop_strings_apply_to_reasoning = true;
     const Json& stop                       = body.at("stop");

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -178,6 +178,10 @@ struct GenerationRequest {
     ToolChoice tool_choice;
     std::vector<std::string> stop_strings;
     bool stop_strings_apply_to_reasoning = false;
+    // Benchmark/serving extension shared with vLLM, SGLang and llama.cpp: suppress the
+    // checkpoint's default stop tokens so generation runs to the requested token budget.
+    // Caller-supplied stop tokens and stop strings still apply.
+    bool ignore_eos = false;
     int max_tokens                       = 0; // resolved budget; zero means immediate output limit
     std::optional<bool> enable_thinking;      // unset => use the server default
     std::optional<std::uint32_t> thinking_budget;

--- a/src/serve/translate.cpp
+++ b/src/serve/translate.cpp
@@ -306,6 +306,7 @@ ninfer::RequestOptions to_request_options(const GenerationRequest& request,
     options.output.raw                     = false;
     options.output.preserve_special_tokens = request.uses_tools() || request.has_tool_history();
     options.output.tool_name_max_length = static_cast<std::uint32_t>(request.tool_name_max_length);
+    options.stop.include_model_defaults = !request.ignore_eos;
     options.stop.strings.reserve(request.stop_strings.size() *
                                  (request.stop_strings_apply_to_reasoning ? 2U : 1U));
     for (const std::string& stop : request.stop_strings) {


### PR DESCRIPTION
ninfer-serve accepts the ignore_eos field and ignores it, so a request generates the checkpoint's own number of tokens rather than max_tokens. With max_tokens 512 and ignore_eos true, a chat completion that stops naturally after 267 tokens should run to 512, which is what SGLang returns for the same request; ninfer returned 267 with finish_reason "stop". Any cross-engine throughput comparison then measures decode rates over windows of different lengths.

StopPolicy already carries include_model_defaults (include/ninfer/types.h:234), and merge_stop_policy (src/targets/qwen3_6/impl/frontend/frontend.cpp:389) appends the tokenizer's default stop tokens only when it is set. The serve layer had no way to clear it.

Add a bool ignore_eos to GenerationRequest, parse it with the existing get_bool helper in parse_stop, and map it in to_request_options as options.stop.include_model_defaults = !request.ignore_eos. Caller-supplied stop strings and stop token ids are unaffected: only the checkpoint's own defaults are suppressed, which is the documented meaning of the field in vLLM, SGLang and llama.cpp.

The default is false, so a request that does not send the field behaves exactly as before, and only the OpenAI Chat Completions path is touched (/v1/messages and /v1/responses are not).

Verified on the box against the same server and prompt: ignore_eos=true gives completion_tokens=512 and finish_reason length; ignore_eos=false gives 267 and stop, unchanged.