### PR TITLE
perf(moe): choose the routed gate/up pipeline depth by route, size the grid by work

### DIFF
--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill.h
@@ -92,7 +92,9 @@ SparseMoePrefillWorkspace allocate_sparse_moe_prefill_workspace(Arena& arena,
     const std::int32_t max_route_jobs = assignments / 32 + 256;
     out.route_job_experts             = arena.alloc(DType::I32, {max_route_jobs}, 256);
     out.route_job_columns             = arena.alloc(DType::I32, {max_route_jobs}, 256);
-    out.route_job_count               = arena.alloc(DType::I32, {1}, 256);
+    // [0] is the job count, negative when the scan hands the extent to the decode path;
+    // [1] is how many experts the route touched, which picks the gate/up pipeline depth.
+    out.route_job_count = arena.alloc(DType::I32, {2}, 256);
 
     out.score_storage = arena.alloc(DType::FP32, {kSparseMoeRouterScoreRows, capacity_tokens}, 256);
     out.shared_activation = Tensor(out.score_storage.data, DType::BF16, {512, capacity_tokens});

--- a/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
+++ b/src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu
@@ -215,6 +215,7 @@ __global__ void sparse_moe_prefill_scan_kernel(const int* __restrict__ tile_coun
         scan[expert] += add;
         __syncthreads();
     }
+    const int touched   = __syncthreads_count(count > 0);
     const int job_begin = expert == 0 ? 0 : scan[expert - 1];
     const int jobs      = (count + job_bn - 1) / job_bn;
     for (int job = 0; job < jobs; ++job) {
@@ -224,7 +225,8 @@ __global__ void sparse_moe_prefill_scan_kernel(const int* __restrict__ tile_coun
     if (expert == kExperts - 1) {
         const int jobs = scan[expert];
         // Above 3.5 grouped jobs per token, fixed token work wins by avoiding sparse expert tiles.
-        *route_job_count = adaptive && jobs * 2 > 7 * tokens ? -jobs : jobs;
+        route_job_count[0] = adaptive && jobs * 2 > 7 * tokens ? -jobs : jobs;
+        route_job_count[1] = touched;
     }
 }
 
@@ -274,23 +276,57 @@ sparse_moe_prefill_index_kernel(const int* __restrict__ ids, const int* __restri
     packed_token[packed]     = token;
 }
 
-constexpr int kExpertBM                = 64;
-constexpr int kExpertBN                = 64;
-constexpr int kExpertBK                = 64;
-constexpr int kExpertStages            = 2;
-constexpr int kExpertWarps             = 8;
-constexpr int kExpertThreads           = 32 * kExpertWarps;
-constexpr int kRtx5090SmCount          = 170;
-constexpr int kPrefillBlocksPerSm      = 3;
-constexpr int kPrefillPersistentBlocks = kPrefillBlocksPerSm * kRtx5090SmCount;
+constexpr int kExpertBM     = 64;
+constexpr int kExpertBN     = 64;
+constexpr int kExpertBK     = 64;
+constexpr int kExpertStages = 2;
+// The narrow routed gate/up walks 32 k-tiles per job and stages a 32-column B tile, so six
+// stages still fit the 48 KiB static shared limit (49 152 B exactly). The routed down walks
+// 8 tiles and the wide plan stages 64 columns; neither has room or reason for more, so both
+// keep the two-stage default.
+constexpr int kGateUpNarrowStages = 6;
+constexpr int kExpertWarps        = 8;
+constexpr int kExpertThreads      = 32 * kExpertWarps;
+constexpr int kRtx5090SmCount     = 170;
+// Upper bound on the persistent grid. The routed GEMMs stride their work list by gridDim.x,
+// so any grid is correct; this caps the launch when the work list is long.
+constexpr int kPrefillMaxBlocksPerSm = 32;
+constexpr int kPrefillMaxBlocks      = kPrefillMaxBlocksPerSm * kRtx5090SmCount;
 
-template <int ExpertWarps, int ExpertBN>
+// The narrow routed gate/up ships in both depths and the route picks one. A job is one nonempty
+// column tile of one expert, so more than one job per touched expert means an expert's rows
+// outgrow a tile and its neighbouring jobs re-read the weights it already pulled in. Those reads
+// hit L2, there is no latency left to hide, and the deep pipeline is left paying its 24 KiB of
+// extra shared memory, which cuts the blocks resident on an SM from three to two. Both counts
+// are built on the device by the scan, so the choice is made there: both shapes are launched
+// over the same work list and each leaves at once unless the route picked it. The adaptive path
+// below already dispatches off this same counter.
+enum class GateUpRoute { Any, Spread, Packed };
+// Where the two depths swap is measured, and it is measured on the server rather than on the
+// operator fixture, because the two disagree by about six times. A round-robin fixture that
+// walks the ratio continuously from 1.0 to 2.0 puts the crossing at 1.56 to 1.58 with a warm
+// L2 and at 1.68 to 1.95 with a cold one, over expert counts 64, 96, 128 and 176. The server
+// sits on the cold side: sweeping the threshold through the product at 1.5, 1.5625, 1.625,
+// 1.75 and 2.0, prefill is fastest at 7/4, and the two warm-cache candidates are the worst of
+// the five. Against 2/1 the move is worth 0.10 to 0.17 points of server prefill on prompts below
+// the wide-plan bound, over two four-pass runs, against +0.01 to +0.02 above it, which is the
+// null control the same runs carry.
+constexpr int kGateUpDeepJobsNum = 7;
+constexpr int kGateUpDeepJobsDen = 4;
+
+template <int ExpertWarps, int ExpertBN, int Stages = kExpertStages,
+          GateUpRoute Route = GateUpRoute::Any>
 __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gate_up_kernel(
     const __nv_bfloat16* __restrict__ x, const int* __restrict__ packed_token,
     const int* __restrict__ expert_offsets, const int* __restrict__ route_job_experts,
     const int* __restrict__ route_job_columns, const int* __restrict__ route_job_count,
     const std::uint8_t* __restrict__ codes, const std::uint8_t* __restrict__ scales,
     __nv_bfloat16* __restrict__ activation) {
+    if constexpr (Route != GateUpRoute::Any) {
+        const bool spread =
+            route_job_count[0] * kGateUpDeepJobsDen < kGateUpDeepJobsNum * route_job_count[1];
+        if (spread != (Route == GateUpRoute::Spread)) { return; }
+    }
     constexpr int ExpertThreads = ExpertWarps * 32;
     constexpr int GroupsPerRow  = kHidden / 64;
     constexpr int WarpCols      = ExpertBN / ExpertWarps;
@@ -301,8 +337,8 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
     static_assert(StageIters * ExpertThreads == ExpertBN * StageChunks,
                   "the staging loop is unrolled, so every thread must take the same column count");
     __shared__ __align__(16) __nv_bfloat16 As[kExpertBM * kExpertBK];
-    __shared__ __align__(16) __nv_bfloat16 Bs[kExpertStages][ExpertBN * kExpertBK];
-    __shared__ __align__(16) std::uint8_t Cr[kExpertStages][kExpertBM * 32];
+    __shared__ __align__(16) __nv_bfloat16 Bs[Stages][ExpertBN * kExpertBK];
+    __shared__ __align__(16) std::uint8_t Cr[Stages][kExpertBM * 32];
     __shared__ __align__(16) std::uint8_t Sr[kExpertBM * GroupsPerRow * 2];
 
     const int tid  = static_cast<int>(threadIdx.x);
@@ -401,15 +437,15 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
         stage_scales();
         cp_commit();
 #pragma unroll
-        for (int stage = 0; stage < kExpertStages; ++stage) {
+        for (int stage = 0; stage < Stages; ++stage) {
             stage_inputs(stage, stage);
             cp_commit();
         }
 
 #pragma unroll 1
         for (int kt = 0; kt < kHidden / kExpertBK; ++kt) {
-            const int stage = kt & 1;
-            cp_wait<kExpertStages - 1>();
+            const int stage = kt % Stages;
+            cp_wait<Stages - 1>();
             __syncthreads();
             decode_weight(stage);
             __syncthreads();
@@ -469,7 +505,7 @@ __global__ __launch_bounds__(ExpertWarps * 32, 3) void sparse_moe_prefill_q4_gat
             }
 
             __syncthreads();
-            const int next = kt + kExpertStages;
+            const int next = kt + Stages;
             if (next < kHidden / kExpertBK) { stage_inputs(stage, next); }
             cp_commit();
         }
@@ -1203,6 +1239,17 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
 
         const bool wide_plan   = tokens >= kSparseMoePrefillWideMin;
         const int route_job_bn = wide_plan ? 64 : 32;
+        // The scan emits one route job per nonempty column tile of an expert, so it cannot
+        // emit more than one job per full tile of assignments plus one tail per expert --
+        // the same bound the workspace is sized by. Each job expands into row blocks, and
+        // sizing the grid from that product keeps a persistent block on one work item while
+        // there are fewer work items than the cap, instead of a fixed count that has to
+        // iterate. The exact job count only exists on the device.
+        const int max_route_jobs     = assignments / route_job_bn + kExperts;
+        const int routed_gate_work   = max_route_jobs * (kIntermediate / (kExpertBM / 2));
+        const int routed_down_work   = max_route_jobs * (kHidden / kExpertBM);
+        const int routed_gate_blocks = std::min(routed_gate_work, kPrefillMaxBlocks);
+        const int routed_down_blocks = std::min(routed_down_work, kPrefillMaxBlocks);
         sparse_moe_prefill_scan_kernel<<<1, kExpertThreads, 0, stream>>>(
             tile_counts, tile_bases, offsets, route_job_experts, route_job_columns, route_job_count,
             route_tiles, route_job_bn, tokens, adaptive);
@@ -1237,12 +1284,17 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         if (routed_gate_up_q4) {
             if (wide_plan) {
                 sparse_moe_prefill_q4_gate_up_kernel<8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<routed_gate_blocks, 8 * 32, 0, stream>>>(
                         input, packed_token, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             } else {
-                sparse_moe_prefill_q4_gate_up_kernel<4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                sparse_moe_prefill_q4_gate_up_kernel<4, 32, kExpertStages, GateUpRoute::Packed>
+                    <<<routed_gate_blocks, 4 * 32, 0, stream>>>(
+                        input, packed_token, offsets, route_job_experts, route_job_columns,
+                        route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
+                sparse_moe_prefill_q4_gate_up_kernel<4, 32, kGateUpNarrowStages,
+                                                     GateUpRoute::Spread>
+                    <<<routed_gate_blocks, 4 * 32, 0, stream>>>(
                         input, packed_token, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_gate_codes, routed_gate_scales, routed_activation);
             }
@@ -1276,13 +1328,13 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         case QType::Q5G64_F16S:
             if (wide_plan) {
                 sparse_moe_prefill_qx_down_kernel<Q5DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<routed_down_blocks, 8 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
             } else {
                 sparse_moe_prefill_qx_down_kernel<Q5DownMma, 4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                    <<<routed_down_blocks, 4 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
@@ -1291,13 +1343,13 @@ void sparse_moe_prefill_launch(const Tensor& x, const SparseMoeWeights& weights,
         case QType::Q6G64_F16S:
             if (wide_plan) {
                 sparse_moe_prefill_qx_down_kernel<Q6DownMma, 8, 64>
-                    <<<kPrefillPersistentBlocks, 8 * 32, 0, stream>>>(
+                    <<<routed_down_blocks, 8 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);
             } else {
                 sparse_moe_prefill_qx_down_kernel<Q6DownMma, 4, 32>
-                    <<<kPrefillPersistentBlocks, 4 * 32, 0, stream>>>(
+                    <<<routed_down_blocks, 4 * 32, 0, stream>>>(
                         routed_activation, offsets, route_job_experts, route_job_columns,
                         route_job_count, routed_down_codes, routed_down_high, routed_down_scales,
                         grouped_io);


### PR DESCRIPTION
> ### Rebased onto `487f8977`. Where the numbers below come from
>
> **Base.** This package was written against `ad0f3d38` and now targets upstream **`487f8977`**
> (`perf(sparse_moe): one CTA per token in small-T S2, and a warp merge in place of eight
> dependent rounds`), 83 commits further on. `ad0f3d38` and the earlier heads still named
> throughout this report are the commits the work was **done and measured on**. They are left
> standing rather than rewritten, so that every number below stays attached to the tree it was
> actually taken from.
>
> **Provenance of every number.** Every timing, ratio, percentage, bandwidth, TFLOP/s figure,
> register and shared-memory count and `ctest` line in this report was measured on `ad0f3d38`, or
> on an earlier head named at the point of use. **Nothing here has been re-measured on
> `487f8977`.** Two changes to the instrument itself bear on that, and are stated once here
> instead of being repeated at every table:
>
> * **The engine context cache changed sides.** On `487f8977` `ninfer_bench` switches it off
>   itself - `engine_options.context_cache.enabled = false`,
>   `bench/targets/qwen3_6_27b/ninfer_bench.cpp:157`, introduced upstream by `385b30ce`. On
>   `ad0f3d38` that line does not exist at all, so the bench inherited the engine default
>   `ContextCacheOptions::enabled = true` (`include/ninfer/types.h:130` there, `:132` here) and
>   every end-to-end run behind this report was taken with the cache **constructed**. Two bounds
>   on how far that reaches, both stated because the difference has **not** been measured. From
>   above: a live context cache can serve a prefix and shorten a prefill, which for prefill and
>   TTFT would be a first-order difference rather than a rounding one. From below: the bench also
>   sets `options.execution.allow_prefix_reuse = false` on every request
>   (`bench/targets/qwen3_6_27b/ninfer_bench.cpp:65`) - **byte-identical on both bases** - so no
>   request in these runs was eligible for a prefix hit at all, and what the old configuration
>   carried was a constructed-but-unused cache (host state slots and pinned host KV) rather than
>   served prefixes. Which bound is nearer the truth is an open question here; until it is
>   measured, read the prefill and TTFT figures as taken in a configuration the current bench no
>   longer builds.
> * **The bench flag was renamed.** `--mtp-draft-tokens` no longer exists anywhere in the tree.
>   The current spelling is `--spec mtp --draft-tokens N`
>   (`bench/targets/qwen3_6_27b/ninfer_bench_support.cpp:356-359`), the same pair the product CLI
>   takes (`apps/cli/options.cpp:141-145`). Every reproduction line below has been rewritten to the
>   current spelling; the runs behind the numbers used the old one. One trap in that rename is
>   worth naming: `--spec mtp --draft-tokens 0` is **rejected** - `validate_speculative_cli_options`
>   requires `[1,5]` for MTP (`src/product/speculative_options.h:41`) - so the zero-draft arm,
>   written `--mtp-draft-tokens 0` throughout the old text and called `mtp0` below, is spelled on
>   the current bench by passing **neither** flag, which is already the default
>   (`SpeculativeBackend::None`).
>
> **Registered tests.** `tests/CMakeLists.txt` moved as well. The suite that registered **104**
> targets on `ad0f3d38` registers **114** on `487f8977` (+10 targets), and one more of them is
> artifact-gated: **20** named targets now carry an explicit `SKIP_RETURN_CODE 77` against
> **19** on `ad0f3d38`, on top of the blanket rule inside `ninfer_add_op_test` that marks
> every op test skippable. The addition is `ninfer_qwen3_8_27b_dflash2_real_test`, gated on
> weights like the rest, so one further test skips on a host that carries none. Every `ctest` count printed below is consequently a
> statement about `ad0f3d38` or an earlier head, not about the current base; the counts are left
> in place rather than restated, with the base each belongs to named beside it.
>
> **No `ctest` run in this report has been repeated on `487f8977`, and no round "114 of 114" is
> claimed for it.** Two facts forbid that claim. `ninfer_attn_input_proj_test` is **red on the
> bare base** - an upstream defect, filed as issue #196, not something this branch introduces.
> And `ctest` and a direct run of the same test binary have been observed to disagree on this
> host, so a green `ctest` is not by itself evidence of anything. The only formulation this
> package will stand behind on the new base is the exact one: **the arm's result matched the
> base, and the single failure reproduces on bare `487f8977`.**

## What this is worth, everywhere it was measured

End to end through `ninfer-serve`, server-side prefill time, this is **negative in all 23 length
bins the probe covers**, weighted mean **−2.25%**: −3.3% at 60–72 prompt tokens, −4.0% at
124–135, −3.1% at 250–269, −1.7% at 467–479, −2.0% at 602–628, −2.0% at 720–746, −2.3% at
903–928, −2.4% at 1020–1045. On the operator benchmark the whole MoE prefill operation drops
**19.2%** at a 256-token chunk, 18.2% at 512, 15.8% at 640, 6.3% at 1024 and 5.5% at 4096; a
routing concentrated onto 8 experts is **2.4% faster**, not slower.

**The operator figures are on the benchmark's own fixture, and that fixture never reaches the
threshold this change turns on.** An instrumented scan prints both counters straight out of the
benchmark's own routing (`raw_v3/fixture_route.txt`): 208/208 jobs per touched expert at 128 tokens,
**262/245 = 1.069** at 256, 299/256 = 1.168 at 512, **316/256 = 1.234** at 640, and 64/8 = 8.000
for the routing concentrated on 8 experts. So every narrow-plan cell of the benchmark sits
between **1.000 and 1.234**, the concentrated one at **8.000**, and **nothing of it lies between
1.234 and 8.000** — which is the entire interval any candidate threshold can live in. The
operator column is therefore invariant to the constant: it reads the same at the old threshold
2/1 and at the shipped 7/4, cell for cell.

The model does reach that interval, and that is the whole reason the predicate exists. The
instrumented run records 1160 layer calls over 29 prompt lengths, 40 calls each. At 241 prompt
tokens the model touches 88 experts with 129 jobs (**1.47**); at **386** tokens the median layer
call sits at **1.733**, with 45% of that group's 40 calls inside [1.75, 2.0); at **431** it is
**1.828**, at **473** it is **1.920**, and at **533** it is **2.005**.

> **Corrected.** This read: *"at **467** tokens the median layer call sits at **1.75** with 45% of
> its 40 layer calls inside [1.75, 2.0); at 533 tokens it is **1.99**."* There is no 467-token
> group in the recorded statistics - the probe covered 29 lengths and 467 is not one of them - and
> the group whose histogram puts 45% of its calls in [1.75, 2.0) is **386**, median 1.733. At 533
> the median is **2.005**, above 2.0 rather than a hundredth below it; what that does to the
> argument for moving the constant is corrected where the argument is made. The 241-token line is
> unchanged: 88 experts and 129 jobs are the medians of that group's 40 calls.

**The end-to-end column above is the number to plan with; the operator column is what
the kernel can do on a route shaped like the fixture's.**

The mechanism is a roofline gap inside one operation, not a FLOP saving. The third of the three
changes below exists because the first one is only worth its price on part of the route space,
and which part was measured rather than guessed.

## The gap

Per-kernel census of the MoE prefill operation, `nsys -t cuda --cuda-graph-trace=node`, cold
cache, 20 repeats, median, trace-like routing at 256 tokens on `qwen3_6_35b_a3b` with the `q4-q5`
routed codec (`raw/nsys_base_T256_kern_cuda_gpu_kern_sum.csv`; the byte model and the two
derived tables are in `raw/head_b4c1cfcf/table_roofline.txt`, taken on the same unmodified
`master` binary in an earlier round of this campaign):

| kernel | µs | share of the operation |
|---|--:|--:|
| `q4_gate_up<4, 32>` | **420.1** | **69.5%** |
| `qx_down<Q5DownMma, 4, 32>` | 116.7 | 19.4% |
| everything else (7 kernels) | 66.1 | 11.0% |

The CSV lists ten kernels; the tenth is `ninfer::bench::detail::fill_f16_kernel`, which is the
benchmark filling its inputs and is not part of the operation, so it is excluded from both the
row and the percentage.

The largest kernel is the one that waits. Against **ceilings we measured on this card** rather
than vendor or benchmark constants — 1689.4 GB/s for pure reads, 253.4 TFLOP/s for `mma_bf16`
with an f32 accumulator, each from two independent runs agreeing to within 0.2%:

| kernel | weight stream | % of the read ceiling | % of the `mma_bf16` tier |
|---|--:|--:|--:|
| `q4_gate_up` | 649.8 GB/s | **38.5%** | 8.1% |
| `qx_down` | 1445.0 GB/s | **85.5%** | 14.5% |

Two kernels of the same operation, launched over the same route jobs on the same card, differ by
2.2x in how well they use the memory system, and neither is anywhere near the compute tier. Both
issue `mma_bf16` and nothing else — the Q4/Q5 codes are unpacked into bf16 before the MMA — so
253.4 TFLOP/s is the correct denominator for both.

> **Corrected.** Both tier columns and this sentence divided by **257.9 TFLOP/s**, called a ceiling
> this project measured. There is no such measurement: the measured `mma_bf16` tier with an f32
> accumulator is **253.4 TFLOP/s**, and that is what the companion issue for this change already
> used. The tier percentages here and in the operation-wide table below are recomputed at 253.4
> (7.9% -> 8.1%, 14.3% -> 14.5%); the conclusion - both kernels far below the tier, the memory side
> deciding - is untouched. The two scripts that printed them carried the same wrong constant and
> are corrected with them.

The bandwidth denominator is a lower bound and is stated exactly: one read of each touched
expert's `gate_up` or `down` matrices and their scales (1 114 112 B and 688 128 B per expert,
245 experts touched on this route), counting neither the gathered activation tile the gate/up
re-stages for every row block nor the output it writes. Both kernels are understated by the same
convention, and their ratio is not.

## What changes

Three things, two files, **+80 −26**.

> **Corrected.** This line read *"two files, +74 −26"*. That is the diffstat of the head this
> branch had before the threshold moved from 2/1 to 7/4; the submitted head reads +80 −26
> (`git diff --stat` against the base). No measured number changes with it - the 7/4 arm is the one
> every table below was taken on.

**1. Six `cp_async` stages in the narrow routed gate/up, instead of two.** It walks 32 k-tiles per
job against a 32-column B tile, so six stages fit the 48 KiB static shared limit *exactly*:
8192 (`As`) + 6·4096 (`Bs`) + 6·2048 (`Cr`) + 4096 (`Sr`) = **49 152 B**. The stage count becomes a
template parameter. The routed `down` walks 8 k-tiles and the wide plan stages 64 columns with no
room past three stages, so both keep the two-stage default.

**2. The routed grid is sized from the number of work items** instead of a fixed
`3 * kRtx5090SmCount` = 510 blocks. The scan emits one route job per nonempty column tile of an
expert, so it cannot emit more than `assignments / job_bn + kExperts` jobs — the same bound the
workspace is already allocated by — and each job expands into `kIntermediate / (kExpertBM/2)` row
blocks for the gate/up and `kHidden / kExpertBM` for the down. The exact job count exists only on
the device; that product bounds it on the host. The launch is capped at 32 blocks per SM. Both
kernels stride their work list by `gridDim.x` already, so any grid size is correct.

**3. The depth is chosen by the route.** The narrow gate/up is instantiated at both depths, both
are launched over the same work list, and each leaves immediately unless the route picked it. The
predicate is on the device because that is where the route is: the scan already produces the job
count, and it now also produces the number of experts the route touched. A job is one nonempty
32-column tile of one expert, so **more than one job per touched expert** means an expert's rows
outgrow a tile and its neighbouring jobs re-read weights that are already resident; those reads
hit L2, there is no latency left to hide, and the deep pipeline is left paying its extra 24 KiB
of shared memory, which drops the blocks resident on an SM from three to two. This is the same
device-side dispatch the `adaptive` path in this file already uses, where the scan writes a
negative job count and the kernels that must not run return on it.

## Where the two depths swap, measured

Operator benchmark with the depth and the grid driven from the environment so that one binary
covers every point, `q4-q5`, warm cache, two passes with the cell order reversed between them,
every cell its own capture of the card with its own witness window and verdict. `jobs/E` is route
jobs per touched expert, which is what the shipped predicate compares. Raw:
`raw/map_*.csv`, `raw/map2_*.csv` → `raw/table_signmap.txt`.

| jobs/E | touched experts | tokens | jobs | 2 stages, µs | 6 stages, µs | Δ |
|---:|---:|---:|---:|---:|---:|---:|
| 1.00 | 64 | 128 | 64 | 194.6 | 185.5 | **−4.7%** |
| 1.00 | 64 | 256 | 64 | 207.7 | 197.1 | **−5.1%** |
| 1.00 | 96 | 256 | 96 | 279.2 | 235.2 | **−15.8%** |
| 1.00 | 128 | 128 | 128 | 327.9 | 278.1 | **−15.2%** |
| 1.00 | 128 | 256 | 128 | 338.8 | 287.6 | **−15.1%** |
| 1.00 | 128 | 384 | 128 | 352.1 | 301.1 | **−14.5%** |
| 1.00 | 128 | 512 | 128 | 362.2 | 319.2 | **−11.9%** |
| 1.00 | 192 | 256 | 192 | 463.3 | 377.6 | **−18.5%** |
| **1.00** | **192** | **704** | **192** | 522.2 | 446.5 | **−14.5%** |
| 1.00 | 256 | 256 | 256 | 589.9 | 474.1 | **−19.6%** |
| 1.00 | 256 | 512 | 256 | 609.8 | 495.6 | **−18.7%** |
| 1.23 | 256 | 640 (`trace-like`) | 316 | 618.2 | 521.8 | **−15.6%** |
| 1.50 | 128 | 512 (mixed counts) | 192 | 379.4 | 368.6 | **−2.8%** |
| 2.00 | 32 | 256 | 64 | 155.9 | 174.3 | **+11.8%** |
| 2.00 | 48 | 256 | 96 | 186.4 | 206.8 | **+11.0%** |
| 2.00 | 64 | 384 | 128 | 231.4 | 258.0 | **+11.5%** |
| 2.00 | 64 | 512 | 128 | 251.9 | 282.6 | **+12.2%** |
| 2.00 | 107 | 635 | 214 | 347.9 | 380.5 | **+9.4%** |
| 2.00 | 111 | 753 | 222 | 394.4 | 432.3 | **+9.6%** |
| **2.00** | **128** | **704** | **256** | 415.3 | 457.7 | **+10.2%** |
| 2.01 | 107 | 635 (mixed counts) | 215 | 384.4 | 397.1 | **+3.3%** |
| 8.00 | 8 | 256 | 64 | 155.9 | 172.8 | **+10.9%** |

The job count and the touched-expert count in every row are read from the same CSV row as the
time, not computed from the fixture's parameters. **All thirteen shapes at or below 1.5 jobs per
touched expert gain, between 2.8% and 19.6%; all nine at or above 2.0 lose, between 3.3% and
12.2%.** The pair marked in bold is the control the predicate needed: the same 704 tokens gain
14.5% at one job per touched expert and lose 10.2% at two, so the token extent decides nothing on
its own and the host cannot make this choice from what it knows. Nor does the job count alone —
the 8-expert and the 64-expert fixtures at 256 tokens both run exactly 64 jobs and fall on
opposite sides (+10.9% and −5.1%).

### Where exactly, and why the fixture cannot answer that

The table above has **no point at all between 1.5 and 2.0**, and that is where the constant
lives. A second fixture was built for that interval alone. A round-robin assignment walks the
ratio continuously: at `8T` just above `32E` every expert holds 32 or 33 rows, the ratio is
`1 + (8T − 32E)/E`, and one token moves it by `8/E`. Forty-seven cells over expert counts 64, 96,
128 and 176 — steps of 0.125, 0.083, 0.0625 and 0.045 — two passes with the depth order reversed
between them, each cell its own capture of the card with its own witness window, pass-to-pass
spread **0.01–0.60%**. The two depths are separate instantiations selected on the host, so no
branch enters the hot body.

With a **warm** L2 the crossing is the same for all four expert counts:

| touched experts | last ratio the deep pipeline wins | first ratio it loses |
|---:|---:|---:|
| 64 (T = 256…264) | 1.5000, −1.6% | 1.6250, **+6.7%** |
| 96 (T = 384…396) | 1.5000, −0.3% | 1.5833, **+3.5%** |
| 128 (T = 512…528) | 1.5625, −1.1% | 1.6250, **+0.4%** |
| 176 (T = 704…726) | 1.5455, −1.9% | 1.5909, **+0.3%** |

The four brackets intersect in **[1.5625, 1.5833)** — one crossing, unchanged while the token
count goes from 256 to 726. With a **cold** L2 the four brackets are (1.63, 1.75), (1.68, 1.73),
(1.75, 1.81) and (1.92, 2.00) and **do not intersect at all**, so no single constant is
defensible from that side of the fixture either.

### The constant comes from the server, because the fixture and the server disagree

Five thresholds were run through the product itself — one binary, each threshold its own pair of
instantiations, chosen once per process — against master, 23 length bins, two passes with the arm
order reversed. Weighted means: **−1.95% at 3/2, −1.99% at 25/16, −2.09% at 13/8, −2.09% at 2/1,
−2.13% at 7/4.** The two values the warm crossing would suggest are the **worst of the five**.
The product therefore sits on the cold side of the fixture, and that is a measurement, not an
argument about whether a layer's experts fit in L2.

Two four-pass ABBA runs then pin the move from 2/1 to 7/4: one over the three shipped binaries
(master, 2/1, 7/4) and one over four thresholds inside a single binary. They give **−0.17 and
−0.10 percentage points** of server prefill below the wide-plan bound, against **+0.02 and
+0.01** above it — above the bound the depth is not chosen at all, so those bins are the null
control the same runs carry. The optimum is a plateau: **15/8 measures the same as 7/4 to 0.00
points**, 27/16 gives −0.07, and only below 13/8 does the sign turn. **7/4 is taken over 15/8
because the product cannot tell them apart while both fixture regimes prefer the lower one.**

Read back onto the operation: at ratio 1.75 the warm fixture says the wrong depth costs
+3.6…+9.9% and the cold fixture −2.1…+1.3%. In the 467–479-token bin, whose prompts sit between
the 431- and 473-token route groups where about half of the layer calls move, the product shows
0.23 points of prefill, which is roughly 2% of the operation on the calls that moved. **The warm fixture overstates by about five times; the cold one is about right.**

### Is the mean ratio enough

Not entirely, and the shortfall was measured rather than assumed. Holding the token count, the
expert count, the job count and the ratio **all fixed** — 512 tokens, 128 experts, 192 jobs,
ratio 1.5 — six different row splits run from **−3.6% to 0.0%** without changing sign. Two of
them (8/56 and 56/8) are the **same multiset of rows** and differ by **2.1 points** purely in
which half of the experts is the heavy one: a property of the work-list order, not of any
quantity the scan could count. At fixed row split the effect is monotone in the token count
(−0.7%, +0.4%, +2.6% at 512, 576 and 640 tokens), but the crossing itself does not move with the
token count — the round-robin sweep holds it inside 0.02 across a 2.8× range of T. **A second
counter is therefore not proposed**: it would cost the hot path and could not describe the part
of the variance that is left.

The shipped constant is "deep while `4 · jobs < 7 · touched`".

## What the model's own routing looks like

The scan was instrumented to print its job and touched-expert counts, and `ninfer-serve` was
driven over 28 requested prompt lengths, which the tokenizer turned into **29** distinct token
counts (`raw/routestats_lines.txt`, 1 160 lines = 29 × 40); 40 MoE layers per forward, so each
row below is the median of 40 calls. **The table stops at 753 tokens because that is where
the narrow plan stops:** past 768 the wide plan runs with 64-column job tiles, the job count is
not comparable, and the depth choice is not compiled into that kernel at all.

The median of an even number of calls is a midpoint, so half-integers are printed as they come
out and not rounded:

| prompt tokens | touched experts | route jobs | jobs per touched expert |
|---:|---:|---:|---:|
| 76 | 77.5 | 83 | 1.07 |
| 153 | 81 | 104 | 1.28 |
| 241 | 88 | 129 | 1.47 |
| 331 | 98 | 159 | 1.62 |
| 431 | 101.5 | 186 | 1.83 |
| 533 | 107 | 213 | 1.99 |
| 635 | 107.5 | 239.5 | 2.23 |
| 753 | 111 | 270.5 | 2.44 |

Over the eighteen narrow-plan lengths the real route touches **77.5–117.5** of 256 experts and
crosses the shipped threshold of 7/4 at roughly **400 tokens**, two jobs per touched expert at
roughly 540. The eight rows above are a monotone sample of those eighteen; the widest routes of
the narrow plan sit at 672 tokens (117.5 experts) and are not in the table, and over the eleven
wide-plan lengths the count goes on rising to 137.5. It is not the expert count that turns over —
that rises throughout — it is the ratio.

> **Corrected.** This read *"crosses the shipped threshold of 7/4 at roughly **460 tokens**"*. Read
> off the same two columns the table above prints - the median job count over the median touched
> count, group by group in `raw/routestats_lines.txt` - the ratio is **1.71** at 386 tokens
> (174 / 101.5) and **1.83** at 431 (186 / 101.5), so the 7/4 crossing falls between those two
> groups, at roughly **400 tokens** and not 460; there is no recorded group at 460 at all. The
> per-call distribution turns over in the same place: the shipped predicate `jobs * 4 >= touched * 7`
> holds for **19 of the 40** calls at 386 and **26 of 40** at 431, so the majority crosses just
> under 400 as well. The second half of the sentence is unchanged and correct - the 2.0 crossing
> falls between 533 (1.99 = 213 / 107) and 563 (2.07 = 220.5 / 106.5), i.e. at roughly 540.

**The group at 533 tokens is why the constant had to move.** Its median layer call is **2.005**
jobs per touched expert - the median of the forty per-call ratios, which is not the statistic the
last column of the table prints: there each of the three numbers is a median in its own right, and
213 / 107 = 1.99. Its forty calls straddle the old threshold of 2.0 almost exactly: **18 of the 40
fall below it** and took the deep pipeline on the strength of a hundredth either way, **2** land
exactly on it and **20** above. Against the shipped 1.75 the median is **0.26 clear** and 34 of the
40 take the shallow path.
A per-layer histogram from the same instrumented run says the same thing without medians: at
**386** prompt tokens **45%** of the 40 layer calls fall in [1.75, 2.0) and **none** above 2.0; at
**431**, 52% fall in that interval and three calls above it; at **473**, 52% fall in it and 20%
above. Those are the calls the new constant moves, and they are the bins where the end-to-end
table improves.

> **Corrected.** This read: *"At **1.99** jobs per touched expert it sat **one hundredth** below
> the old threshold of 2.0 … at **467** prompt tokens **45%** of the 40 layer calls fall in
> [1.75, 2.0) and none above 2.0 except three; at **521** tokens 55% fall in that interval and 22%
> above it."* The 533-token median is 2.005, not 1.99 - it sits a hundredth **above** the old
> threshold, and what makes the group a knife edge is that half its calls fall on each side, not
> that the median does. (The **1.99** in the table above is a different statistic and is correct
> where it stands: it is the ratio of the two column medians, 213 / 107, not the median of the
> per-call ratios.) The 467- and 521-token groups do not exist in the recorded statistics; the
> measured groups are 386, 431 and 473, and their histograms are the ones now quoted. The
> conclusion - the old constant decided this group by a hundredth and the new one does not - is
> unchanged and is now read off the distribution rather than off one median.

> **Corrected.** The two counts in that paragraph read *"**20 of the 40** fall below it"* and
> *"32 of the 40 take the shallow path"*. Recounted call by call from `raw/routestats_lines.txt`,
> the 533-token group has **18** calls below 2.0, **2** exactly on it and **20** above - 20 is the
> count on the *other* side of the threshold - and the shipped 7/4 predicate, compared in integers
> as `jobs * 4 >= touched * 7`, is satisfied by **34** of the 40, not 32. Both counts were written
> when this paragraph was rewritten around the 2.005 median and neither was recomputed from the
> lines. What the sentence is for - the group is a knife edge for the old constant and is not one
> for the new - is unchanged.

**The benchmark's sampled `trace-like` fixture is not this route, at any length.** At 640 tokens
the fixture touches 256 experts with 316 jobs, that is 1.234 per expert, and so it gains from the
deep pipeline at a length where the product loses. At 256 tokens the fixture is at 245 experts
and 1.069 jobs per expert against the model's 88 and 1.47 — same side of the predicate, but not
the same distance from it. That mismatch is the whole reason the predicate is on the device
rather than a token threshold on the host, and it is also why the operator column at the top of
this description is not a prediction of the end-to-end column.

## The knobs do not separate

Four binaries differing in one `constexpr` each, operator benchmark, warm cache, trace-like
routing, two passes with the arm order reversed (raw: `raw/abl_*.csv`, `raw/table_ablation.txt`):

| arm | 256 tokens, µs | Δ | 4096 tokens, µs | Δ |
|---|--:|--:|--:|--:|
| `master` (2 stages, 510 blocks) | 569.9 | — | 1892.3 | — |
| grid only (2 stages) | 568.9 | **−0.16%** | 1785.9 | **−5.63%** |
| pipeline only (510 blocks) | 531.5 | **−6.74%** | 1893.4 | **+0.05%** |
| both | 456.7 | **−19.86%** | 1790.0 | **−5.41%** |

At 256 tokens the two sum to −6.90% and deliver −19.86%: the 6-stage block asks for 50 176 B as the
dump reports it, so only two of them sit on an SM against the three `__launch_bounds__` allows the
2-stage block, and a fixed 510-block grid then lays out badly over the shortened work list. Only
the grid repays that debt, and only the pipeline creates it.
At 4096 tokens the split is the mirror image — the wide plan runs there, the deeper pipeline is
not compiled into it, and the whole gain is the grid.

## Coverage

Operator benchmark, three binaries measured in one batch under one capture of the card, each cell
with its own witness window, two passes with the arm order reversed, warm cache
(`raw/ops_*.csv`, `raw/table_ops3.txt`). `unconditional` is the same change without the third
item, kept as an arm so the cost of the choice is visible:

| routing | tokens | `master`, µs | unconditional | this branch | unconditional Δ | branch Δ |
|---|--:|--:|--:|--:|--:|--:|
| trace-like | 128 | 491.5 | 409.1 | 411.6 | −16.8% | **−16.3%** |
| trace-like | 256 | 570.0 | 457.2 | 460.8 | −19.8% | **−19.2%** |
| trace-like | 512 | 608.2 | 493.6 | 497.7 | −18.9% | **−18.2%** |
| trace-like | 640 | 622.7 | 521.2 | 524.3 | −16.3% | **−15.8%** |
| trace-like | 1024 | 734.2 | 687.9 | 688.1 | −6.3% | **−6.3%** |
| trace-like | 4096 | 1895.4 | 1779.7 | 1791.0 | −6.1% | **−5.5%** |
| independent | 256 | 582.7 | 475.3 | 479.4 | −18.4% | **−17.7%** |
| all 256 tokens onto 8 experts | 256 | 163.4 | 173.9 | **159.5** | **+6.4%** | **−2.4%** |

The choice costs 0.3–0.7 percentage points wherever the deep pipeline was already right, and
turns the one cell where it was wrong from +6.4% into −2.4%.

**This table is the same at the old threshold and at the shipped one, and that is measured.** The
instrumented scan puts every narrow-plan row of it between 1.000 and 1.234 jobs per touched expert
and the last row at 8.000 (`raw_v3/fixture_route.txt`); 2/1 and 7/4 both fall outside that set, so
no cell changes arm. The benchmark cannot see this constant at all — which is exactly why the
constant was chosen on the server instead.

**Pass-to-pass spread across all 16 cells of `raw/table_ops3.txt` — the eight rows above, warm,
and the same eight cold — is 0.00–1.50%,** and the 1.50% is one cell: 4096 tokens, warm, where
the branch's two passes read 1804.29 and 1777.66 µs against the `unconditional` arm's 1777.66
and 1781.76 on the same two passes. Every other cell, warm and cold, is at or below 0.41%. That one cell is also the only place
where this branch and the `unconditional` arm differ by more than the choice can explain
(−5.5% against −6.1%): at 4096 the wide plan runs, the two arms are the *same* code, and the
difference is the spread. Read the 4096 row as "−6.1%, spread 1.5 points", not as a cost of the
choice.

Roofline of the whole operation from the same rows, against the measured ceilings
(`raw/table_roof3.txt`):

| tokens | routing | `master` | this branch |
|--:|---|---|---|
| 256 | trace-like | 782.4 GB/s, 46.3% of the read ceiling, 10.2% of the `mma_bf16` tier | 967.8 GB/s, **57.3%**, 12.6% |
| 640 | trace-like | 748.0 GB/s, 44.3%, 23.4% | 888.4 GB/s, **52.6%**, 27.8% |
| 4096 | trace-like | 245.7 GB/s, 14.5%, 49.2% | 260.1 GB/s, 15.4%, **52.1%** |
| 256 | 8 experts | 115.2 GB/s, 6.8%, 35.7% | 118.0 GB/s, 7.0%, 36.5% |

At 256 tokens the operation moves from 46.3% to 57.3% of this card's read ceiling and stays at an
eighth of its compute tier: it is still a memory-side operation and there is more left in it. At
4096 tokens it is the other way round — 15.4% of the read ceiling against 52.1% of the compute
tier — which is why a deeper prefetch has nothing to hide there.

## End to end, and the band that used to be flat

`ninfer-serve` on `qwen3_6_35b_a3b.ninfer`, `--prefill-chunk 1024 --no-prefix-reuse --greedy
--max-concurrency 1 --default-max-tokens 4`, server-side `timings_seconds.prefill` from the
request log, prompts grouped by the length **the server reports** rather than by filler word
count, **20 requests per point per pass, four passes with the arm order reversed on the middle
two**, each probe window accepted only after the card witness declared it clean — all twelve arms
clean on the first attempt — `prefix_cache_hit_tokens = 0` on all **4152** logged requests.
Pass-to-pass spread over the 23 tabulated bins **0.22–1.91 points**
(`raw_v3/reqlog_*.jsonl`, `raw_v3/table_e2e_v3.txt`):

| prompt, tokens | `master`, ms | threshold 2/1, ms | shipped 7/4, ms | 2/1 Δ | 7/4 Δ |
|---|--:|--:|--:|--:|--:|
| 30–35 | 17.485 | 17.475 | 17.423 | −0.06% | **−0.36%** |
| 60–72 | 20.225 | 19.559 | 19.564 | −3.30% | **−3.27%** |
| 124–135 | 23.423 | 22.485 | 22.484 | −4.00% | **−4.01%** |
| 181–200 | 25.521 | 24.652 | 24.629 | −3.40% | **−3.50%** |
| 250–269 | 28.121 | 27.243 | 27.240 | −3.12% | **−3.13%** |
| 331–359 | 29.739 | 28.971 | 28.971 | −2.58% | **−2.58%** |
| 399–419 | 32.106 | 31.587 | 31.553 | −1.62% | **−1.72%** |
| 421–441 | 32.695 | 32.190 | 32.146 | −1.54% | **−1.68%** |
| 467–479 | 33.166 | 32.678 | 32.603 | −1.47% | **−1.70%** |
| 480–493 | 33.496 | 33.048 | 32.951 | −1.34% | **−1.63%** |
| 510–538 | 35.089 | 34.578 | 34.500 | −1.46% | **−1.68%** |
| 546–565 | 35.918 | 35.414 | 35.282 | −1.40% | **−1.77%** |
| 570–599 | 36.498 | 35.913 | 35.800 | −1.60% | **−1.91%** |
| 602–628 | 37.246 | 36.660 | 36.507 | −1.57% | **−1.99%** |
| 632–658 | 40.874 | 40.268 | 40.173 | −1.48% | **−1.71%** |
| 660–686 | 41.594 | 40.841 | 40.749 | −1.81% | **−2.03%** |
| 700–716 | 42.817 | 42.056 | 42.012 | −1.78% | **−1.88%** |
| 720–746 | 43.457 | 42.658 | 42.606 | −1.84% | **−1.96%** |
| 780–806 | 45.277 | 44.277 | 44.256 | −2.21% | **−2.26%** |
| 841–866 | 46.544 | 45.483 | 45.517 | −2.28% | **−2.21%** |
| 903–928 | 49.435 | 48.315 | 48.319 | −2.26% | **−2.26%** |
| 990–1016 | 51.821 | 50.586 | 50.594 | −2.38% | **−2.37%** |
| 1020–1045 | 55.139 | 53.823 | 53.843 | −2.39% | **−2.35%** |

Weighted means: **−2.12% at the old threshold, −2.25% at the shipped one**, both negative in all
23 bins. **Twelve consecutive bins improve, 399 through 746 tokens** — exactly the stretch where
the median layer call sits in [1.75, 2.0) — while the five bins above the wide-plan bound, where
the depth is not chosen at all, move by **+0.02 points**. That is the null control: the effect is
localised where the mechanism acts and nowhere else.

**The band 400–750 tokens is still the shallowest part of the curve and the threshold does not
fix that.** It stands at −1.6 to −2.0% against −2.2 to −2.4% above the wide-plan bound. Moving
the threshold closes about a third of that gap and no more, and the gap is present at **every one
of the five thresholds swept, including 3/2, at which the deep pipeline does not run in that band
at all**. So whatever costs those prompts their share is not the depth choice, and this
description does not claim otherwise.

An earlier version of this change took the deep pipeline **unconditionally**. On its own two-pass
run it read flat at 571–653 tokens and **+0.40% at 723–740**; that is the band the choice was
introduced for, and its raw is kept in `raw/head_b4c1cfcf/`. It was not re-measured against the
new constant, and no number of that arm appears in the table above.

**Below 60 prompt tokens nothing is claimed, and the reading there is stated rather than
omitted.** `sparse_moe_uses_prefill` starts this path at 47 tokens. The one bin below 60 in this
run is `30–35`, where the shipped arm reads **−0.36%** at a pass-to-pass spread of **1.50%** —
inside its own spread, and not evidence in either direction.

The same thing seen with the instrument that found the problem — `nsys` over the `ninfer-serve`
process itself, median over the calls captured in the window: **120** for each `q4_gate_up` row,
111 and 9 for the `qx_down` Q5 and Q6 rows respectively (the Q6 row is 9 calls and is quoted for
completeness, not as evidence). Each arm's window accepted only after a clean witness verdict (`raw/nsysserve_*_kern_cuda_gpu_kern_sum.csv`,
`raw/table_serve3.txt`):

| prompt | kernel | `master`, µs | unconditional | this branch |
|---|---|--:|--:|--:|
| 708–735 tokens | narrow `q4_gate_up`, 2 stages | 260.0 | — | **236.1 (−9.2%)** |
| 708–735 tokens | narrow `q4_gate_up`, 6 stages | — | **280.6 (+7.9%)** | 4.5 (left at once) |
| 708–735 tokens | narrow `qx_down` Q5 | 131.2 | 116.4 (−11.2%) | 117.3 (−10.6%) |
| 183–187 tokens | narrow `q4_gate_up`, 6 stages | — | 147.2 (−11.3%) | **146.4 (−11.8%)** |
| 183–187 tokens | narrow `q4_gate_up`, 2 stages | 166.0 | — | 2.8 (left at once) |
| 183–187 tokens | narrow `qx_down` Q5 | 54.0 | 50.1 (−7.2%) | 50.3 (−6.8%) |

**Both of those lengths are ones where the old and the new constant choose the same depth**, so
they measure the cost of the mechanism and not the choice of constant. The constant was profiled
separately, at a length where the two disagree — filler 410 words, **636–673 prompt tokens**,
narrow plan, two passes with the arm order reversed, all four witness windows clean
(`raw_v3/nsysband_*_kern_cuda_gpu_kern_sum.csv`, `raw_v3/table_nsysband.txt`):

| arm | narrow, 2 stages | narrow, 6 stages | narrow total | wide (untouched) |
|---|--:|--:|--:|--:|
| threshold 2/1 | 28 665.8 µs | 10 309.9 µs | **38 975.7 µs** | 22 946.9 µs |
| threshold 7/4 | 32 801.9 µs | 5 901.4 µs | **38 703.3 µs** | 22 955.8 µs |

The work moves from the deep instantiation to the shallow one exactly as intended and the narrow
`q4_gate_up` gets **0.70% faster**, while the wide instantiation — which has no depth choice —
moves by **+0.04%**, the null control inside the same profile. The narrow `q4_gate_up` is
**10.3%** of all kernel time in that window, so 0.70% of it is 0.07 points of the window; the
end-to-end table above reads 0.10–0.17 points of prefill for the same move, and prefill is the
larger share of a window that also contains decode. The two instruments agree.

That is the whole cost of the mechanism, in one number: the instantiation the route did not pick
costs **2.8–4.5 µs** per call. What the choice buys, on the same two rows, is the difference
between the depth it picked and the depth it rejected: **44.5 µs** at 708–735 tokens
(236.1 against the deep 280.6) and **19.6 µs** at 183–187 (146.4 against the shallow 166.0).
Against `master` — which is the shallow depth everywhere — the branch gains 23.9 µs and 19.6 µs
on the same two rows.

## Correctness evidence

**The change does not alter arithmetic.** The order of additions is untouched: the `mma` sequence
over `ki` and `kt`, and the fold of the scales into the accumulator, are exactly as they were.
Only the prefetch depth, the grid size, and which of two instantiations with identical arithmetic
runs can move. So the numeric oracle applies, and it was run rather than argued.

**Numeric oracle (FP64).** `ninfer_sparse_moe_test` with `NINFER_OP_REPORT_STATS=1` reports its
16 cells — `q4+q5` at 1, 2, 46, 47, 768 and 4097 tokens, `q4+q6` at 1, 2, 46, 47 and 768, and
`w8+w8` at 1, 2, 19, 20 and 768 — and all **16 of 16 are byte-identical** to `master`. The arm
being replaced was re-run in the same session: the old threshold 2/1 is also 16 of 16 against
`master`, and the two thresholds are **16 of 16 against each other**, which is what "only the
constant moved" has to mean numerically.

**That set does not cover this change, so it was extended.** None of those 16 runs the narrow plan
with real work: 47 tokens goes to the small-T path, 768 and 4097 to the wide plan. The same test
was extended **locally** to 200, 512 and 700 tokens, which is exactly where the choice lives, and
all **24 of 24 cells are byte-identical** to `master` — again for both thresholds and for the two
against each other. That extension is an instrument, not part of this change; the test file in
this branch is untouched.

**The oracle is shown to be capable of failing.** A deliberately sabotaged build rounds the
accumulator of the routed gate/up to bf16 once per k-tile — the same additions in the same order,
only less precisely. On the 24-cell set it moves **exactly the 11 cells that execute this route**,
every one of them across its criterion limit, and `ninfer_sparse_moe_test` returns
`FAIL sparse_moe correctness`; on the 16-cell shipped set it moves **5**, again all five across
the limit. The other **13 and 11 cells stay byte-identical** in the sabotaged build: the
instrument moves where the change is and nowhere else. The sabotage build is never submitted.

**False-alarm floor.** Running the same binary twice moves **0 of 16**.

**The measured binary is the submitted source.** Every number above was taken on binaries compiled
from the blob this commit carries: `md5` of the built `sparse_moe_prefill_kernels.cu` is
`c7f203e9dfb058c34632fc8d4eb34da1`, and `git show HEAD:…` of the submitted commit gives the same
`md5`. `clang-format` 23.1.0 reports zero violations **on the blobs as committed**, extracted into
a scratch tree rather than checked in place. One comment was corrected after the measurements —
`halves the blocks resident on an SM`, which is a third and not a half — and rather than claim a
comment cannot matter, the SASS was dumped from the binary before and after: **13 927 499 lines,
identical md5** (`raw/sass_compare.txt`). No instruction moved.

**Which ratio the margin is quoted on.** The test reports two, `rel_l2_ratio` and `gross_ratio`,
and fails when either crosses 1. Both were read on all 24 honest cells. The tighter of the two is
`rel_l2_ratio` at **0.9314** on `q4+q5` T=47 — a **1.07x** margin — with `gross_ratio` peaking
slightly lower at 0.9218, on a different cell (`w8+w8` T=768, which this change does not touch
and which sits at that value on `master` too). So the margin above is quoted on the binding
reading, and it is the same 0.9314 on `master`: **this change consumes none of it.**

That margin is thin, and it is thin on `master` — this branch neither improves nor spends it.
The sabotage build crosses on **both** ratios at once (1.65 and 1.39), so the FAIL is
over-determined and does not depend on which one is read.

**End to end, for whatever it is worth.** Greedy generation of 64 tokens through `ninfer-serve`
on 14 prompts of 67 to 1130 tokens, spanning both sides of the depth choice and both plans:
**14 of 14 outputs byte-identical**, no empty responses among the 28 (the empty counter is in the
comparator, not the collector). This line is supplementary and deliberately weak: a bitwise output
check does not see numeric damage — a 12-step corruption ladder I measured on 2026-09-04 found a
sabotage that fails the FP64 oracle four times out of four and still passes a bitwise output
comparison 6/6 and a needle retrieval 40/40. **That ladder is a separate campaign of mine, not
part of this package and not in this repository**, so it is my report and not something a reader
can check from here; its logs can be supplied on request. The
oracle above is the evidence; this is a sanity line.

Raw: `raw/oracle_{base,v2,v2rebuild,sab}.txt`, `raw/oracle_{base,v2,sab}_wide.txt`,
`raw/table_gate3.txt`, `raw/table_gate_wide.txt`, `raw/text_{base,v2}.jsonl`,
`raw/table_text.txt`.

## Resources, tests, format

`cuobjdump --dump-resource-usage` on the linked benchmark binary of each arm, matched by kernel
name and template arguments rather than by mangled symbol (`raw/table_res3.txt`, produced by
`scripts/tab_res3.py`):

| kernel | `master` REG / SHARED / spill | this branch |
|---|---|---|
| narrow `q4_gate_up`, packed route (2 stages) | 124 / 25 600 / 0+0 | 124 / 25 600 / 0+0 |
| narrow `q4_gate_up`, spread route (6 stages) | — | 124 / **50 176** / 0+0 |
| `q4_gate_up<8, 64>` | 80 / 33 792 / 0+0 | 80 / 33 792 / 0+0 |
| `qx_down<Q5DownMma, 4, 32>` | 95 / 23 552 / 0+0 | 95 / 23 552 / 0+0 |
| `qx_down<Q5DownMma, 8, 64>` | 77 / 31 744 / 0+0 | 77 / 31 744 / 0+0 |
| `qx_down<Q6DownMma, 4, 32>` | 96 / 24 576 / 0+0 | 96 / 24 576 / 0+0 |
| `qx_down<Q6DownMma, 8, 64>` | 79 / 32 768 / 0+0 | 79 / 32 768 / 0+0 |
| `scan_kernel` | 40 / 2 048 / 0+0 | 40 / 2 048 / 0+0 |

**Those are the figures the dump prints, and they are 1 024 B above the arrays the source
declares.** The 6-stage instantiation declares 8192 (`As`) + 6·4096 (`Bs`) + 6·2048 (`Cr`) +
4096 (`Sr`) = **49 152 B**, which is the 48 KiB static limit exactly; the dump says 50 176. The
offset is a fixed per-block reservation on this architecture, not something this change
introduces: dumping the *object file* instead of the linked binary
(`raw/head_b4c1cfcf/table_resources.txt`, an earlier round of this campaign) gives 24 576 /
49 152 / 32 768 / 22 528 / 30 720 / 23 552 / 31 744 — **exactly 1 024 B lower on every one of the
six kernel rows present in both dumps** (seven values, because the narrow gate/up appears there at
both depths), `master` and branch alike. So the design fits, and the
comparison between the two arms is unaffected either way.

**The rational threshold costs nothing in resources, and that was re-dumped rather than assumed.**
`cuobjdump` on the binary of the shipped constant and on the binary of the old integer one give
byte-identical rows: 124 / 50 176 and 124 / 25 600 for the two narrow instantiations, 80 / 33 792
for the wide one, 40 / 2 048 for the scan (`raw_v3/resources_v2_v3.txt`). The extra multiply lives
in the early-exit prologue, which executes once per block before any of the loop state is live.

No register change, no spill anywhere; the shared-memory growth is confined to the one
instantiation that wants it. The touched-expert count the scan now writes costs it neither a
register nor a byte of shared memory, and the workspace is unchanged at **10 847 232 B** for a
256-token chunk — the second counter fits inside the 256-byte alignment the job counter already
had, and the benchmark prints the same `workspace_bytes` on all three arms
(`raw/ops_*_T256_trace-like.csv`, column `workspace_bytes`).

**One thing a reviewer will notice and it is left as it stands.** The kernel keeps
`__launch_bounds__(ExpertWarps * 32, 3)`. At 6 stages three blocks per SM are not reachable —
two blocks already take 100 352 B of the 102 400 an SM has — so for that one instantiation the
second argument is now advisory only, and `ptxas` accepts it without complaint. Removing it
would change the register allocation of the 2-stage instantiation as well, and every number above
was taken with it in place; if you would rather it were split per instantiation, say so and it
will be a separate diff with its own measurement.

`ctest`: **104 of 104 passed, 6 skipped**, on the base commit `ad0f3d38` (`raw/ctest_base.txt`,
whose header records `HEAD=ad0f3d38`, `tree=af48897f`, `dirty=0`) and on two predecessors of this
branch — `raw/ctest_v2.txt` (`HEAD=b4c1cfcf`, `dirty=2`) and `raw_v3/ctest_v3.txt`
(`HEAD=9d16aba6`, `tree=88ad9982`, `dirty=1`). The 6 are the real-model tests that need artifacts
this host does not carry, named one by one in `raw/ctest_base.txt`. **On `487f8977` that count is
7, not the 6 this sentence claimed for `master` before**: the suite gates a seventh test the same
way, `ninfer_qwen3_8_27b_dflash2_real_test`, which returns 77 unless
`NINFER_QWEN3_8_27B_DFLASH2_WEIGHTS` is set, and this host does not carry those weights either.
The seventh is read out of `tests/CMakeLists.txt` and out of that test's own `return 77`, not out
of a run - no `ctest` in this report was repeated on the new base.

**Neither branch log was taken on the submitted tree `7ff9ae95`, and all three ran with `ctest`'s
default parallelism rather than `-j 1`.** The submitted head differs from `9d16aba6` only in the
threshold constant and the grid bound, but that is an argument and not a run, so the branch side of
this line should be read as "on a predecessor of the submitted tree".

> **Corrected.** This read: *"`ctest`: **104 of 104 passed, 6 skipped**, on this branch and on the
> base commit `ad0f3d38` alike (`raw/ctest_v2.txt`, `raw/ctest_base.txt`)."* The log it named is
> from the head before the threshold moved and carries `dirty=2`, so it does not support "on this
> branch"; the newer `raw_v3/ctest_v3.txt` is also a predecessor. The suite result is unchanged on
> every arm that was run; what is corrected is which tree each log belongs to.

`clang-format` 23.1.0 reports **0 violations** on both touched files in the branch worktree and
**0** on the same two files in a separate worktree of the base commit (both sides real files on
disk, since reading through a pipe does not find the repository `.clang-format`).

## What was refuted on the way here

This change is what survived a campaign that started somewhere else, and the discarded parts are
worth more to a reviewer than the surviving one.

**The premise was wrong.** The work began from "about 74% of the n dimension of the routed tile is
padding, we are multiplying zeros". Measured on the real route at 256 tokens: executed columns
3024 against 2048 real ones, so padding is **32.3%**, not 74%. The 74% comes from dividing by the
tile width (32) rather than by the width actually executed. The MMA is closed by a warp-level
predicate with an 8-column step (`if (warp * WarpCols < cols)`), and a warp entirely past the tail
issues neither `ldmatrix` on B nor `mma`. The padded columns are staged with
`cp_async_zfill(..., col < cols ? 16 : 0)`, whose zero size issues no load at all, so they generate
no traffic either.

**Padding costs nothing, so there is nothing to reclaim.** A dose-response sweep at fixed traffic —
same touched-expert count, same token count, same route job count, same real columns, only the
executed width varying (`raw/campaign_2026-09-05/pad_*.csv`, `pad_fwd.txt`) — puts the slope at
**0.043** relative time units per relative unit of executed columns. The steepest pair is 128
experts at 256 tokens, 2048 executed columns at 333.824 µs against 2560 at 337.376 µs: +25%
width for +1.06% time. On the widest pair — 256 experts at 256 tokens, 2048 columns at 579.584 µs
against 3072 at 577.536 and 579.584 — +50% width is *negative or zero* inside the spread.
Removing all padding on the real route, 32.3% of executed columns, is worth **at most 1.4%**
(0.043 × 0.323).

**Three of the four shapes proposed for that premise are dead by construction, and two are already
implemented.** Sorting rows by expert: the scan already builds `expert_offsets` and `tile_bases`
and the index kernel writes `packed_index`, so an expert's rows are already contiguous. A
persistent kernel with a work queue: already there, both routed kernels are
`for (work = blockIdx.x; work < total_work; work += gridDim.x)`. Making the n dimension the expert
axis: structurally impossible, since operand A of a routed GEMM is one expert's weights shared by
every column of the tile. A narrow tail tile: the ≤1.4% ceiling above.

**And one refutation from this round.** The band where the unconditional depth was worth nothing
was first read as "the model's route at 450–700 tokens is concentrated onto few experts, and a
small working set fits in L2". The instrumented scan says otherwise: the touched-expert count
**rises** with length rather than concentrating — 77.5 at 76 tokens, 117.5 at 672, 137.5 at 1868,
with no fall anywhere larger than a single expert — and across the 450–700 band where the gain
was supposed to vanish it goes 100 → 117.5. What changes with length is the number of **jobs per
touched expert**, which crosses two at about 540 tokens. Two fixtures with the same 64 route jobs
and the same 256 tokens but 8 and 64 touched experts fall on opposite sides of the sign (+10.9% and
−5.1%), so the count of experts alone does not decide it either. The predicate compares the two
counts, because that is what the measurement says decides.

**The first constant was too high, and finding out how much cost three refutations of our own.**

*Refuted: that the crossing found on a warm operator fixture is the crossing the product has.*
It is not. The warm crossing is sharp and reproducible — [1.5625, 1.5833) for every one of four
expert counts — and a threshold placed there makes the **product slower**: −1.95% at 3/2 and
−1.99% at 25/16 against −2.09% at the old 2/1. The product matches the cold fixture instead. That
was settled by running five thresholds through the server, not by arguing about whether a layer's
experts fit in L2.

*Refuted: that the shallow gain between 400 and 750 prompt tokens is caused by the threshold.*
It is not. The gap between that band and the bins above the wide-plan bound is 0.95 points at the
old constant and 0.66 at the new one — a third of it closes, no more — and it is present at
**every** threshold swept, including 3/2, where the deep pipeline does not run in that band at
all. Whatever costs those prompts their share is something else, and this description does not
claim the constant fixes it.

*Refuted: our own counterexample to "the mean ratio is enough".* Three fixture shapes at the same
ratio of 1.5 read −0.65%, −1.45% and **+2.69%**, which looked like a sign flip at a fixed value of
the predicate. It is not: the +2.69% shape is at 640 tokens and the other two at 512. At a fixed
token count the six shapes available at that ratio run −3.6% to 0.0% and never change sign. What
does move with the token count is the size of the effect, not the crossing — the round-robin sweep
holds the crossing inside 0.02 across a 2.8× range of token counts.

## Second card

Everything above is from one RTX 5090. **Six of the eight operator cells** were repeated on a
second card in a different container of the same host, rebuilt from scratch on the same base
commit with the same two diffs applied, same two-pass protocol with its own witness
(`raw/standB/`). The 1024- and 4096-token cells were **not** repeated there. Two caveats this
table does not hide: the second stand's GPU identity is not recorded in the raw, only the
container and the port, and its per-cell witness windows are short enough to hold 1-3 samples at
the 1 s sampling rate against 16-18 on the `nsys` windows of card A:

| routing | tokens | card A, Δ | card B, Δ | difference |
|---|--:|--:|--:|--:|
| trace-like | 128 | −16.25% | −16.13% | 0.12 pp |
| trace-like | 256 | −19.16% | −19.33% | 0.17 pp |
| trace-like | 512 | −18.18% | −18.24% | 0.06 pp |
| trace-like | 640 | −15.80% | −15.98% | 0.18 pp |
| independent | 256 | −17.72% | −18.00% | 0.28 pp |
| all onto 8 experts | 256 | −2.39% | −2.45% | 0.06 pp |

The regression the third change removes reproduces there too: the unconditional depth is +6.12%
on the 8-expert route on card B against +6.43% on card A.

## Bench notes

RTX 5090, 525 W cap, driver 580.159.03, CUDA 13.1, `qwen3_6_35b_a3b.ninfer` (`groupwise-int`),
routed codec `q4-q5`. The card idles at 180 MHz and clock locking is not permitted on this host,
so every cell is a short capture with its own witness window and its own verdict, and a cell whose
window shows a foreign process is discarded and re-measured rather than averaged. **Two** of the
six `nsys` server profiles were discarded and re-run for exactly that reason — `base` at 460
filler words and `v1` at 110, both recorded as `attempt=2` in `raw/nsysmarker_*.txt`; the other
four passed on the first attempt.

**The witness has a false-positive mode and it fired, and the log keeps it.** On the numeric
oracle run (`raw/oracle_witness.txt`) one `cand` window was discarded for a genuine foreign
process, and then the `rebuild` arm was rejected **60 times in a row**. The cause was not the
card: the witness matches process paths against a regular expression, the rebuild binary was
invoked by a relative path, and `nvidia-smi` reported it in a form the expression did not
recognise as ours — so the arm was counting *itself* as a foreign process. Re-running with an
absolute path gave a clean window on the first attempt. Nothing in this description rests on a
window that the witness rejected, and the rejection direction here was the safe one, but a
reviewer should know the instrument can over-reject on a path form, and that all "clean" verdicts
in this package rest on that expression.

Provenance of the two ceilings: each is a direct measurement of the instruction or access pattern
in its product form on this card, two independent runs agreeing to within 0.2%. The benchmark in
this tree prints 1792.1 GB/s, the vendor figure; the percentages above use our measured 1689.4,
which is the less flattering of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
