### PR TITLE
perf(runtime): keep the Linear Attention state in L2 across the decode graph

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(ninfer_core STATIC
   core/layout.cpp
   core/tensor.cpp
   core/decode_graph.cpp
+  core/l2_persist.cpp
   runtime/engine/admission_policy.cpp
   runtime/engine/context_cost.cpp
   runtime/engine/context_cost_defaults.cpp

--- a/src/core/device.cu
+++ b/src/core/device.cu
@@ -86,7 +86,7 @@ DeviceContext::~DeviceContext() {
 
 DeviceContext::DeviceContext(DeviceContext&& other) noexcept
     : device(other.device), stream(other.stream), transfer_stream(other.transfer_stream),
-      props(other.props) {
+      props(other.props), persisting_l2(std::move(other.persisting_l2)) {
     other.stream          = nullptr;
     other.transfer_stream = nullptr;
 }
@@ -102,6 +102,7 @@ DeviceContext& DeviceContext::operator=(DeviceContext&& other) noexcept {
     props           = other.props;
     stream          = other.stream;
     transfer_stream = other.transfer_stream;
+    persisting_l2   = std::move(other.persisting_l2);
 
     other.stream          = nullptr;
     other.transfer_stream = nullptr;

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/l2_persist.h"
+
 #include <cuda_runtime.h>
 
 #include <cstddef>
@@ -23,6 +25,10 @@ struct DeviceContext {
     cudaStream_t stream          = nullptr;
     cudaStream_t transfer_stream = nullptr;
     cudaDeviceProp props{};
+    // Owns the device-wide persisting-L2 set-aside for as long as this context exists. The limit
+    // is context state and outlives both the stream attribute and the graph the window is baked
+    // into, so it is given back here rather than left standing for whatever runs next.
+    l2p::Reservation persisting_l2;
 
     explicit DeviceContext(int device_id = 0);
     ~DeviceContext();

--- a/src/core/l2_persist.cpp
+++ b/src/core/l2_persist.cpp
@@ -1,0 +1,70 @@
+#include "core/l2_persist.h"
+
+#include <atomic>
+#include <cstdio>
+
+namespace ninfer::l2p {
+
+bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes) {
+    if (base == nullptr || bytes == 0) { return false; }
+
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess) { return false; }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, device) != cudaSuccess) { return false; }
+    if (prop.persistingL2CacheMaxSize <= 0 || prop.accessPolicyMaxWindowSize <= 0) { return false; }
+
+    // An access policy window can never be longer than accessPolicyMaxWindowSize. A pool wider
+    // than that does not get a shorter window over the whole pool, it gets a window over the
+    // pool's prefix, while the device-wide reserve is taken in full and paid for everywhere,
+    // prefill included. On a target where that happens the reservation is a pure loss, so do
+    // nothing at all: no window, and no reserve either.
+    if (bytes > static_cast<std::size_t>(prop.accessPolicyMaxWindowSize)) {
+        // Nothing else reports this: the driver returns cudaSuccess whether the window covers
+        // the pool or a fraction of it, so a silently truncated window is indistinguishable
+        // from a working one. Say it once per process instead.
+        static std::atomic<bool> reported{false};
+        if (!reported.exchange(true)) {
+            std::fprintf(stderr,
+                         "ninfer: L2 persistence disabled: the %zu byte Linear Attention state "
+                         "pool is wider than the %zu byte access policy window of this device\n",
+                         bytes, static_cast<std::size_t>(prop.accessPolicyMaxWindowSize));
+        }
+        return false;
+    }
+
+    const std::size_t window = bytes;
+    std::size_t reserve      = window;
+    if (reserve > static_cast<std::size_t>(prop.persistingL2CacheMaxSize)) {
+        reserve = static_cast<std::size_t>(prop.persistingL2CacheMaxSize);
+    }
+    if (cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, reserve) != cudaSuccess) {
+        return false;
+    }
+
+    float hit_ratio = 1.0F;
+    if (window > reserve) {
+        hit_ratio = static_cast<float>(static_cast<double>(reserve) / static_cast<double>(window));
+    }
+
+    cudaStreamAttrValue value{};
+    value.accessPolicyWindow.base_ptr  = const_cast<void*>(base);
+    value.accessPolicyWindow.num_bytes = window;
+    value.accessPolicyWindow.hitRatio  = hit_ratio;
+    value.accessPolicyWindow.hitProp   = cudaAccessPropertyPersisting;
+    value.accessPolicyWindow.missProp  = cudaAccessPropertyNormal;
+    (void)cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow, &value);
+    return true;
+}
+
+void unpin(cudaStream_t stream) {
+    cudaStreamAttrValue value{};
+    value.accessPolicyWindow.base_ptr  = nullptr;
+    value.accessPolicyWindow.num_bytes = 0;
+    value.accessPolicyWindow.hitRatio  = 0.0F;
+    value.accessPolicyWindow.hitProp   = cudaAccessPropertyNormal;
+    value.accessPolicyWindow.missProp  = cudaAccessPropertyNormal;
+    (void)cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow, &value);
+}
+
+} // namespace ninfer::l2p

--- a/src/core/l2_persist.cpp
+++ b/src/core/l2_persist.cpp
@@ -2,10 +2,184 @@
 
 #include <atomic>
 #include <cstdio>
+#include <map>
+#include <mutex>
+#include <set>
 
 namespace ninfer::l2p {
+namespace {
 
-bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes) {
+// The limit is one number per device, so its owners have to be reconciled in one place. Requests
+// are counted rather than replaced: withdrawing one owner must not shrink the set-aside another
+// owner is still replaying a graph under.
+struct Registry {
+    std::mutex mutex;
+    std::map<int, std::multiset<std::size_t>> live;
+    // The limit in force before the first request on that device, restored when the last one goes
+    // away. Recorded under the same lock that publishes the first request, so a second owner
+    // cannot record an already raised limit as the one to return to, and kept until a restore
+    // actually lands: a failed write must not lose the value it was going to write.
+    std::map<int, std::size_t> baseline;
+};
+
+// Deliberately never destroyed. A handle owned by an object with static storage duration would
+// otherwise reach a destroyed registry during exit, and the cost of the leak is one map.
+Registry& registry() {
+    static Registry* const instance = new Registry();
+    return *instance;
+}
+
+// cudaDeviceSetLimit writes the calling thread's current device, so a release has to name the
+// device its request was made against rather than whichever one happens to be bound. A failed
+// bind is reported rather than swallowed: writing the limit anyway would apply one device's
+// bookkeeping to another.
+class BoundDevice {
+public:
+    explicit BoundDevice(int device) {
+        int current = 0;
+        if (cudaGetDevice(&current) != cudaSuccess) { return; }
+        if (current == device) {
+            bound_ = true;
+            return;
+        }
+        if (cudaSetDevice(device) != cudaSuccess) { return; }
+        previous_ = current;
+        bound_    = true;
+    }
+
+    ~BoundDevice() {
+        if (previous_ >= 0) { (void)cudaSetDevice(previous_); }
+    }
+
+    [[nodiscard]] bool bound() const noexcept { return bound_; }
+
+    BoundDevice(const BoundDevice&)            = delete;
+    BoundDevice& operator=(const BoundDevice&) = delete;
+    BoundDevice(BoundDevice&&)                 = delete;
+    BoundDevice& operator=(BoundDevice&&)      = delete;
+
+private:
+    int previous_ = -1;
+    bool bound_   = false;
+};
+
+bool apply_limit(int device, std::size_t bytes) {
+    const BoundDevice bound(device);
+    if (!bound.bound()) { return false; }
+    return cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, bytes) == cudaSuccess;
+}
+
+// Drops one request and writes back what that device should hold now. Called with the lock held.
+// When that was the last request, the baseline is given up only once the restoring write lands, so
+// a device whose limit could not be written keeps the value it still owes a restore to. A device
+// that still has owners needs no such care: the next withdrawal recomputes the target from what
+// remains, so a write that did not land is corrected rather than remembered.
+void withdraw(Registry& reg, int device, std::size_t bytes) {
+    const auto slot = reg.live.find(device);
+    if (slot == reg.live.end()) { return; }
+    auto& live    = slot->second;
+    const auto it = live.find(bytes);
+    if (it == live.end()) { return; }
+    live.erase(it);
+
+    const auto base = reg.baseline.find(device);
+    if (!live.empty()) {
+        (void)apply_limit(device, *live.rbegin());
+        return;
+    }
+    if (base == reg.baseline.end()) {
+        // No recorded baseline means nothing is known to restore to; leaving the limit alone is
+        // the only honest option. Unreachable while a request was live, kept as a guard.
+        reg.live.erase(slot);
+        return;
+    }
+    if (apply_limit(device, base->second)) {
+        reg.live.erase(slot);
+        reg.baseline.erase(base);
+    }
+}
+
+} // namespace
+
+Reservation::Reservation(Reservation&& other) noexcept {
+    const std::lock_guard<std::mutex> guard(registry().mutex);
+    bytes_       = other.bytes_;
+    device_      = other.device_;
+    held_        = other.held_;
+    other.bytes_ = 0;
+    other.held_  = false;
+}
+
+Reservation& Reservation::operator=(Reservation&& other) noexcept {
+    if (this == &other) { return *this; }
+    Registry& reg = registry();
+    const std::lock_guard<std::mutex> guard(reg.mutex);
+    if (held_) { withdraw(reg, device_, bytes_); }
+    bytes_       = other.bytes_;
+    device_      = other.device_;
+    held_        = other.held_;
+    other.bytes_ = 0;
+    other.held_  = false;
+    return *this;
+}
+
+bool Reservation::request(std::size_t bytes) {
+    // Zero is not a release: a handle that asks for nothing still owes its graph the set-aside it
+    // already holds.
+    if (bytes == 0) { return false; }
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess) { return false; }
+
+    Registry& reg = registry();
+    const std::lock_guard<std::mutex> guard(reg.mutex);
+    if (held_ && device_ == device && bytes_ == bytes) { return true; }
+
+    auto& live = reg.live[device];
+    // A withdrawal whose write did not land leaves an empty request set behind but keeps the
+    // baseline it still owes a restore to, so an empty set is not proof that this call is the
+    // first owner. Only a call that records the baseline may take it back on failure.
+    const bool recorded_baseline = reg.baseline.find(device) == reg.baseline.end();
+    if (recorded_baseline) {
+        std::size_t current = 0;
+        const BoundDevice bound(device);
+        if (!bound.bound() ||
+            cudaDeviceGetLimit(&current, cudaLimitPersistingL2CacheSize) != cudaSuccess) {
+            if (live.empty()) { reg.live.erase(device); }
+            return false;
+        }
+        reg.baseline[device] = current;
+    }
+
+    // Put the new request in force before withdrawing the old one. A refusal must not leave a
+    // graph that is already captured running under a set-aside that has been handed back.
+    live.insert(bytes);
+    if (!apply_limit(device, *live.rbegin())) {
+        const auto it = live.find(bytes);
+        if (it != live.end()) { live.erase(it); }
+        if (live.empty()) {
+            reg.live.erase(device);
+            if (recorded_baseline) { reg.baseline.erase(device); }
+        }
+        return false;
+    }
+
+    if (held_) { withdraw(reg, device_, bytes_); }
+    bytes_  = bytes;
+    device_ = device;
+    held_   = true;
+    return true;
+}
+
+void Reservation::release() noexcept {
+    Registry& reg = registry();
+    const std::lock_guard<std::mutex> guard(reg.mutex);
+    if (!held_) { return; }
+    held_ = false;
+    withdraw(reg, device_, bytes_);
+    bytes_ = 0;
+}
+
+bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes, Reservation& reservation) {
     if (base == nullptr || bytes == 0) { return false; }
 
     int device = 0;
@@ -38,9 +212,7 @@ bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes) {
     if (reserve > static_cast<std::size_t>(prop.persistingL2CacheMaxSize)) {
         reserve = static_cast<std::size_t>(prop.persistingL2CacheMaxSize);
     }
-    if (cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, reserve) != cudaSuccess) {
-        return false;
-    }
+    if (!reservation.request(reserve)) { return false; }
 
     float hit_ratio = 1.0F;
     if (window > reserve) {

--- a/src/core/l2_persist.h
+++ b/src/core/l2_persist.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace ninfer::l2p {
+
+/**
+ * Pins a device range in L2 for the graph captured next on this stream.
+ *
+ * Must be called BEFORE cudaStreamBeginCapture: capture bakes the stream access policy window
+ * into every kernel node of the graph and does not re-read the stream attribute at replay.
+ * The reserve is clamped to cudaDeviceProp::persistingL2CacheMaxSize, and when the range is
+ * larger than the reserve the hit ratio is lowered to the fraction that physically fits, which
+ * is what CUDA requires: a window larger than the reserve at hitRatio 1 makes the lines evict
+ * each other.
+ *
+ * Does nothing - no window and no reserve - when the range is wider than
+ * cudaDeviceProp::accessPolicyMaxWindowSize, because past that limit the window covers only a
+ * prefix of the range while the reserve is still taken in full. Returns whether a window was
+ * installed, so the caller knows whether it has anything to take off the stream.
+ */
+bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes);
+
+/** Removes the window from the stream, so eager phases run under the default policy. */
+void unpin(cudaStream_t stream);
+
+} // namespace ninfer::l2p

--- a/src/core/l2_persist.h
+++ b/src/core/l2_persist.h
@@ -7,6 +7,52 @@
 namespace ninfer::l2p {
 
 /**
+ * Ownership handle for a device's persisting-L2 set-aside.
+ *
+ * cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize) is context state, not stream or graph state:
+ * it outlives both the access policy window that motivated it and the graph the window was baked
+ * into, so it needs an owner that gives it back. A handle registers one request against one
+ * device; the limit is held at the largest live request for that device, and returns to the limit
+ * that was in force before the first request once the last one is released. Without that, work
+ * started after the requesting owner is gone carries a set-aside while installing no window, which
+ * costs what an unused reserve costs and buys nothing.
+ *
+ * The limit is per device, not per process, so requests are reconciled per device ordinal and a
+ * release binds its own device before writing the limit back; a bind that fails is reported rather
+ * than written to whichever device happens to be current. Handles are safe to use from several
+ * threads.
+ */
+class Reservation {
+public:
+    Reservation() noexcept = default;
+
+    ~Reservation() { release(); }
+
+    Reservation(const Reservation&)            = delete;
+    Reservation& operator=(const Reservation&) = delete;
+    Reservation(Reservation&& other) noexcept;
+    Reservation& operator=(Reservation&& other) noexcept;
+
+    /**
+     * Requests `bytes` of set-aside on the calling thread's current device, replacing whatever
+     * this handle asked for before. The limit becomes the largest request live on that device.
+     *
+     * Returns whether the request is in force. A refused request changes nothing: the previous
+     * request of this handle stays live, because a graph may already be captured under it. A
+     * request of zero bytes is refused for the same reason, rather than treated as a release.
+     */
+    bool request(std::size_t bytes);
+
+    /** Withdraws this handle's request, lowering or restoring its device's limit accordingly. */
+    void release() noexcept;
+
+private:
+    std::size_t bytes_ = 0;
+    int device_        = 0;
+    bool held_         = false;
+};
+
+/**
  * Pins a device range in L2 for the graph captured next on this stream.
  *
  * Must be called BEFORE cudaStreamBeginCapture: capture bakes the stream access policy window
@@ -16,12 +62,16 @@ namespace ninfer::l2p {
  * is what CUDA requires: a window larger than the reserve at hitRatio 1 makes the lines evict
  * each other.
  *
+ * The set-aside is taken through `reservation`, which must outlive every graph captured under this
+ * window: the window is replayed from the graph long after this call returns, and the set-aside
+ * has to still be in force for it to mean anything.
+ *
  * Does nothing - no window and no reserve - when the range is wider than
  * cudaDeviceProp::accessPolicyMaxWindowSize, because past that limit the window covers only a
- * prefix of the range while the reserve is still taken in full. Returns whether a window was
- * installed, so the caller knows whether it has anything to take off the stream.
+ * prefix of the range while the device-wide reserve is still taken in full. Returns whether a
+ * window was installed, so the caller knows whether it has anything to take off the stream.
  */
-bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes);
+bool pin_range(cudaStream_t stream, const void* base, std::size_t bytes, Reservation& reservation);
 
 /** Removes the window from the stream, so eager phases run under the default policy. */
 void unpin(cudaStream_t stream);

--- a/src/targets/qwen3_6/impl/runtime/graph_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/graph_impl.h
@@ -43,7 +43,8 @@ void capture_graph(Context& state, DecodeGraphDefinition& definition, Body&& bod
     // A target whose state pool does not fit an access policy window gets nothing installed,
     // and then there is nothing to take off the stream either.
     const bool pinned =
-        l2p::pin_range(state.execution.device.stream, reinterpret_cast<const void*>(low), span);
+        l2p::pin_range(state.execution.device.stream, reinterpret_cast<const void*>(low), span,
+                       state.execution.device.persisting_l2);
     definition.capture(state.execution.device.stream, body);
     if (pinned) { l2p::unpin(state.execution.device.stream); }
 }

--- a/src/targets/qwen3_6/impl/runtime/graph_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/graph_impl.h
@@ -1,8 +1,11 @@
 #include "targets/qwen3_6/impl/runtime/instance.h"
 #include "targets/qwen3_6/impl/runtime/schedule.h"
 
+#include "core/l2_persist.h"
 #include "core/nvtx.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 
 namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule {
@@ -23,7 +26,26 @@ void run_prepared(Context& state, DecodeGraphExecutable* executable, Body&& body
 template <class Context, class Body>
 void capture_graph(Context& state, DecodeGraphDefinition& definition, Body&& body) {
     state.execution.work.reset();
+    // Keep the Linear Attention continuation state resident in L2 for the captured decode
+    // graph. Every decode round reads the whole pool and writes it back at a fixed address,
+    // and recurrent_fold_kernel streams all of it in a single launch, so it is the one decode
+    // consumer with both a fixed footprint and enough reuse to be worth an L2 reservation.
+    // The window must be installed before capture: the graph bakes it into its kernel nodes
+    // and does not re-read the stream attribute at replay.
+    const LinearAttentionStateAllLayersView linear =
+        state.execution.linear_attention.all_layers_view();
+    const auto low = reinterpret_cast<std::uintptr_t>(linear.conv_layer0.data);
+    const auto span =
+        static_cast<std::size_t>(static_cast<std::uintptr_t>(linear.recurrent_layer_stride_bytes) *
+                                     (linear.spec.layers - 1U) +
+                                 reinterpret_cast<std::uintptr_t>(linear.recurrent_layer0.data) -
+                                 low + linear.recurrent_layer0.bytes());
+    // A target whose state pool does not fit an access policy window gets nothing installed,
+    // and then there is nothing to take off the stream either.
+    const bool pinned =
+        l2p::pin_range(state.execution.device.stream, reinterpret_cast<const void*>(low), span);
     definition.capture(state.execution.device.stream, body);
+    if (pinned) { l2p::unpin(state.execution.device.stream); }
 }
 
 } // namespace ninfer::targets::qwen3_6::detail::NINFER_QWEN36_RUNTIME_NS::schedule

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,8 @@ ninfer_add_test(ninfer_pretty_logging_test
   LIBRARIES ninfer_product_logging)
 ninfer_add_test(ninfer_device_test       SOURCES test_device.cpp)
 ninfer_add_test(ninfer_decode_graph_test SOURCES test_decode_graph.cpp)
+ninfer_add_test(ninfer_l2_reservation_test SOURCES test_l2_reservation.cpp)
+set_tests_properties(ninfer_l2_reservation_test PROPERTIES SKIP_RETURN_CODE 77)
 ninfer_add_test(ninfer_tensor_test       SOURCES test_tensor.cpp)
 ninfer_add_test(ninfer_arena_test        SOURCES test_arena.cpp)
 ninfer_add_test(ninfer_admission_policy_test SOURCES test_admission_policy.cpp)

--- a/tests/test_l2_reservation.cpp
+++ b/tests/test_l2_reservation.cpp
@@ -1,0 +1,242 @@
+// The persisting-L2 set-aside is device-context state that outlives the access policy window and
+// the graph the window is baked into. These cases pin the property that makes it safe to touch at
+// all: whatever the handles do, the device is left with the limit it had before the first request.
+#include "core/l2_persist.h"
+
+#include <cstddef>
+#include <cstdio>
+#include <iostream>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+std::size_t limit() {
+    std::size_t value = 0;
+    if (cudaDeviceGetLimit(&value, cudaLimitPersistingL2CacheSize) != cudaSuccess) {
+        return static_cast<std::size_t>(-1);
+    }
+    return value;
+}
+
+void expect_at_least(const char* what, std::size_t got, std::size_t want) {
+    if (got < want) {
+        std::cout << what << ": limit " << got << " does not cover " << want << '\n';
+        ++failures;
+    }
+}
+
+// The set-aside has to come down as well as go up, and on a card whose driver default already
+// exceeds a small request an "at least" check cannot see that. This is the direction that fails
+// when a withdrawal stops lowering the limit to the request that survived it.
+void expect_below(const char* what, std::size_t got, std::size_t want) {
+    if (got >= want) {
+        std::cout << what << ": limit " << got << " still carries " << want << '\n';
+        ++failures;
+    }
+}
+
+void expect_equal(const char* what, std::size_t got, std::size_t want) {
+    if (got != want) {
+        std::cout << what << ": limit " << got << ", expected " << want << '\n';
+        ++failures;
+    }
+}
+
+bool cuda_unavailable() {
+    int count = 0;
+    return cudaGetDeviceCount(&count) != cudaSuccess || count <= 0;
+}
+
+} // namespace
+
+int main() {
+    if (cuda_unavailable()) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess || prop.persistingL2CacheMaxSize <= 0) {
+        std::cout << "SKIP: device reserves no L2 for persisting accesses\n";
+        return 77;
+    }
+
+    // The driver rounds a set-aside up, so coverage is checked with >= and only the restored value
+    // is checked for equality - it is the one the driver itself produced.
+    const std::size_t ceiling = static_cast<std::size_t>(prop.persistingL2CacheMaxSize);
+    const std::size_t small   = ceiling / 8;
+    const std::size_t large   = ceiling / 2;
+    if (small == 0) {
+        std::cout << "SKIP: persisting L2 reserve too small to subdivide\n";
+        return 77;
+    }
+    const std::size_t baseline = limit();
+
+    {
+        ninfer::l2p::Reservation outer;
+        if (!outer.request(small)) {
+            std::cout << "a request the device advertises room for was refused\n";
+            return 1;
+        }
+        expect_at_least("one request covers what it asked for", limit(), small);
+        {
+            ninfer::l2p::Reservation inner;
+            if (!inner.request(large)) {
+                std::cout << "a nested request was refused\n";
+                return 1;
+            }
+            expect_at_least("the larger of two live requests is in force", limit(), large);
+        }
+        expect_at_least("the survivor of two requests keeps its own", limit(), small);
+        expect_below("the departed request is no longer in force", limit(), large);
+    }
+    expect_equal("the last release restores the limit it found", limit(), baseline);
+
+    // Two handles asking for the same size are two requests, not one: withdrawing either must
+    // leave the other covered. This is bookkeeping a set would get wrong and a multiset gets right.
+    {
+        ninfer::l2p::Reservation first;
+        ninfer::l2p::Reservation second;
+        if (!first.request(large) || !second.request(large)) {
+            std::cout << "two handles of equal size were not both admitted\n";
+            return 1;
+        }
+        first.release();
+        expect_at_least("equal-sized twin still covered after its peer leaves", limit(), large);
+    }
+    expect_equal("equal-sized twins restore the limit once both leave", limit(), baseline);
+
+    // Re-asking the same size must not ratchet the recorded baseline: it is read when the first
+    // request goes in, and a cycle of release and request reads it again.
+    {
+        ninfer::l2p::Reservation handle;
+        for (int cycle = 0; cycle < 32; ++cycle) {
+            if (!handle.request(large)) {
+                std::cout << "a repeated request was refused on cycle " << cycle << '\n';
+                return 1;
+            }
+            expect_at_least("a repeated request stays in force", limit(), large);
+            handle.release();
+        }
+    }
+    expect_equal("32 request/release cycles do not drift the baseline", limit(), baseline);
+
+    // Zero is not a release. A handle that is asked for nothing keeps what its graph is running
+    // under, and says it did not take the request.
+    {
+        ninfer::l2p::Reservation handle;
+        if (!handle.request(large)) {
+            std::cout << "a request before the zero case was refused\n";
+            return 1;
+        }
+        if (handle.request(0)) {
+            std::cout << "a zero-byte request was reported as taken\n";
+            ++failures;
+        }
+        expect_at_least("a zero-byte request leaves the live one alone", limit(), large);
+    }
+    expect_equal("the zero case restores the limit on release", limit(), baseline);
+
+    {
+        ninfer::l2p::Reservation source;
+        if (!source.request(large)) {
+            std::cout << "a request before the move case was refused\n";
+            return 1;
+        }
+        ninfer::l2p::Reservation sink(std::move(source));
+        expect_at_least("a moved handle carries its request", limit(), large);
+        source.release(); // The moved-from handle owns nothing and must not disturb the limit.
+        expect_at_least("releasing a moved-from handle changes nothing", limit(), large);
+    }
+    expect_equal("the moved-to handle restores the limit when it dies", limit(), baseline);
+
+    // A live handle asked for a different size replaces its own request rather than adding one.
+    // Nothing in the product exercises this today, but the header advertises it, and it is the
+    // subtlest path in the file: the new request goes in before the old one comes out.
+    {
+        ninfer::l2p::Reservation handle;
+        if (!handle.request(large) || !handle.request(small)) {
+            std::cout << "a handle could not replace its own request\n";
+            return 1;
+        }
+        expect_at_least("a replacement covers what it asked for", limit(), small);
+        expect_below("the replaced request is not left standing", limit(), large);
+    }
+    expect_equal("the replacement case restores the limit on release", limit(), baseline);
+
+    // A request the device cannot honour must be refused without disturbing a live one. This is
+    // the only case that reaches the rollback in request(), because nothing else here makes the
+    // write fail, and a rollback that gives back another owner's baseline is exactly the leak
+    // this file exists to prevent.
+    {
+        ninfer::l2p::Reservation live_one;
+        if (!live_one.request(large)) {
+            std::cout << "a request before the refusal case was refused\n";
+            return 1;
+        }
+        ninfer::l2p::Reservation refused;
+        if (refused.request(ceiling * 2)) {
+            std::cout << "a request beyond the device ceiling was reported as taken\n";
+            ++failures;
+        }
+        expect_at_least("a refused request leaves the live one covered", limit(), large);
+    }
+    expect_equal("a refused request leaves nothing behind", limit(), baseline);
+
+    // A refused request must not leave a baseline of its own behind. Nothing already here can see
+    // that it did: the registry looks the same either way and the limit never moved. It becomes
+    // visible only when the process already holds a set-aside of its own by the time the next
+    // request arrives - then a baseline stashed by the refusal is handed back instead of that one.
+    {
+        ninfer::l2p::Reservation refused_cold;
+        if (refused_cold.request(ceiling * 2)) {
+            std::cout << "a cold request beyond the device ceiling was reported as taken\n";
+            ++failures;
+        }
+    }
+    if (cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, large) == cudaSuccess) {
+        // Whatever the driver rounded that to is this process's own set-aside now, and it is what
+        // a later release owes back - not the limit that was in force before the refusal.
+        const std::size_t theirs = limit();
+        {
+            ninfer::l2p::Reservation ours;
+            if (!ours.request(small)) {
+                std::cout << "a request after the cold refusal was refused\n";
+                return 1;
+            }
+        }
+        expect_equal("a refused request does not stale the baseline", limit(), theirs);
+        (void)cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, baseline);
+    }
+    expect_equal("the cold refusal case leaves the limit as it found it", limit(), baseline);
+
+    // The handle's own fields are part of what the registry lock protects. Before that was true,
+    // two threads on one handle could publish two requests and withdraw one, stranding the device
+    // at a raised limit with no window installed - the exact state this file exists to prevent.
+    {
+        ninfer::l2p::Reservation shared;
+        std::vector<std::thread> threads;
+        threads.reserve(4);
+        for (int t = 0; t < 4; ++t) {
+            threads.emplace_back([&shared, large]() {
+                for (int i = 0; i < 2000; ++i) {
+                    (void)shared.request(large);
+                    shared.release();
+                }
+            });
+        }
+        for (std::thread& thread : threads) { thread.join(); }
+        shared.release();
+    }
+    expect_equal("concurrent use of one handle leaves no request behind", limit(), baseline);
+
+    if (failures != 0) {
+        std::cout << failures << " L2 reservation checks failed\n";
+        return 1;
+    }
+    std::cout << "ok\n";
+    return 0;
+}


### PR DESCRIPTION
> ### Rebased onto `487f8977`. Where the numbers below come from
>
> **Base.** This package was written against `ad0f3d38` and now targets upstream **`487f8977`**
> (`perf(sparse_moe): one CTA per token in small-T S2, and a warp merge in place of eight
> dependent rounds`), 83 commits further on. `ad0f3d38` and the earlier heads still named
> throughout this report are the commits the work was **done and measured on**. They are left
> standing rather than rewritten, so that every number below stays attached to the tree it was
> actually taken from.
>
> **Provenance of every number.** Every timing, ratio, percentage, bandwidth, TFLOP/s figure,
> register and shared-memory count and `ctest` line in this report was measured on `ad0f3d38`, or
> on an earlier head named at the point of use. **Nothing here has been re-measured on
> `487f8977`.** Two changes to the instrument itself bear on that, and are stated once here
> instead of being repeated at every table:
>
> * **The engine context cache changed sides.** On `487f8977` `ninfer_bench` switches it off
>   itself - `engine_options.context_cache.enabled = false`,
>   `bench/targets/qwen3_6_27b/ninfer_bench.cpp:157`, introduced upstream by `385b30ce`. On
>   `ad0f3d38` that line does not exist at all, so the bench inherited the engine default
>   `ContextCacheOptions::enabled = true` (`include/ninfer/types.h:130` there, `:132` here) and
>   every end-to-end run behind this report was taken with the cache **constructed**. Two bounds
>   on how far that reaches, both stated because the difference has **not** been measured. From
>   above: a live context cache can serve a prefix and shorten a prefill, which for prefill and
>   TTFT would be a first-order difference rather than a rounding one. From below: the bench also
>   sets `options.execution.allow_prefix_reuse = false` on every request
>   (`bench/targets/qwen3_6_27b/ninfer_bench.cpp:65`) - **byte-identical on both bases** - so no
>   request in these runs was eligible for a prefix hit at all, and what the old configuration
>   carried was a constructed-but-unused cache (host state slots and pinned host KV) rather than
>   served prefixes. Which bound is nearer the truth is an open question here; until it is
>   measured, read the prefill and TTFT figures as taken in a configuration the current bench no
>   longer builds.
> * **The bench flag was renamed.** `--mtp-draft-tokens` no longer exists anywhere in the tree.
>   The current spelling is `--spec mtp --draft-tokens N`
>   (`bench/targets/qwen3_6_27b/ninfer_bench_support.cpp:356-359`), the same pair the product CLI
>   takes (`apps/cli/options.cpp:141-145`). Every reproduction line below has been rewritten to the
>   current spelling; the runs behind the numbers used the old one. One trap in that rename is
>   worth naming: `--spec mtp --draft-tokens 0` is **rejected** - `validate_speculative_cli_options`
>   requires `[1,5]` for MTP (`src/product/speculative_options.h:41`) - so the zero-draft arm,
>   written `--mtp-draft-tokens 0` throughout the old text and called `mtp0` below, is spelled on
>   the current bench by passing **neither** flag, which is already the default
>   (`SpeculativeBackend::None`).
>
> **Registered tests.** `tests/CMakeLists.txt` moved as well. The suite that registered **104**
> targets on `ad0f3d38` registers **114** on `487f8977` (+10 targets), and one more of them is
> artifact-gated: **20** named targets now carry an explicit `SKIP_RETURN_CODE 77` against
> **19** on `ad0f3d38`, on top of the blanket rule inside `ninfer_add_op_test` that marks
> every op test skippable. The addition is `ninfer_qwen3_8_27b_dflash2_real_test`, gated on
> weights like the rest, so one further test skips on a host that carries none. Every `ctest` count printed below is consequently a
> statement about `ad0f3d38` or an earlier head, not about the current base; the counts are left
> in place rather than restated, with the base each belongs to named beside it.
>
> **No `ctest` run in this report has been repeated on `487f8977`, and no round "114 of 114" is
> claimed for it.** Two facts forbid that claim. `ninfer_attn_input_proj_test` is **red on the
> bare base** - an upstream defect, filed as issue #196, not something this branch introduces.
> And `ctest` and a direct run of the same test binary have been observed to disagree on this
> host, so a green `ctest` is not by itself evidence of anything. The only formulation this
> package will stand behind on the new base is the exact one: **the arm's result matched the
> base, and the single failure reproduces on bare `487f8977`.**
>
> **Line references re-checked against `487f8977`.** Every `file:line` citation in this report was
> opened on the new base. The ones that moved are corrected in place; the number each one used to
> carry is kept here so nothing is replaced silently.
>
> | citation | printed here before | on `487f8977` | what stands at the old number now |
> |---|---|---|---|
> | `include/ninfer/types.h`, `ProposalHead::Full` | `:80` | **`:82`** | `:80` is the comment `// Startup-fixed K: MTP 1..5; DFlash and DFlash2 1..15 (query width K+1).` |

## What this does

The captured decode graph now carries a CUDA access policy window over the Linear Attention
continuation state pool, with `hitProp = cudaAccessPropertyPersisting`, so that state stays
resident in L2 between decode rounds.

Every decode round reads the whole pool and writes it back at a fixed address.
`recurrent_fold_kernel` streams all of it in a single launch. That makes it the one decode
consumer with both a fixed footprint and enough reuse to be worth an L2 reservation — and, as
the profile below shows, the one that was already leaning on L2 opportunistically.

Two details are load-bearing:

* The window is installed **before** `cudaStreamBeginCapture` and removed from the stream right
  after the capture ends. Capture bakes the stream window into every kernel node and does not
  re-read the attribute at replay, so this is the only placement that reaches graph kernels while
  still leaving eager phases under the default *access policy window*. The device-wide reserve is
  a separate setting and is deliberately **not** restored: it stays in force outside the graph
  too, and that is exactly where the prefill cost reported below comes from. Verified by walking
  the finished graph on an instrumented build: **520 of 520 kernel nodes** carry a non-empty
  window with `hitProp = Persisting`, and zero do on stock.
* When the pool is larger than `persistingL2CacheMaxSize`, `hitRatio` is lowered to the fraction
  that physically fits instead of being left at 1. Leaving it at 1 makes the lines evict each
  other. Read off this device: `l2CacheSize` 96.00 MiB, `persistingL2CacheMaxSize` 60.00 MiB
  (62 914 560 B), `accessPolicyMaxWindowSize` 128.00 MiB, default persisting limit 18.00 MiB.
  The pool is 122.81 MiB, so the window is the whole pool (it fits under the 128 MiB window
  cap), the reserve clamps to 60.00 MiB, and the ratio is 0.4885 — which is exactly the
  configuration the numbers below were taken at.
* **Nothing is installed at all — no window and no reserve — when the pool is wider than
  `accessPolicyMaxWindowSize`.** That is a different limit from the reserve limit, and the
  difference matters: on this target the window is 122.81 MiB against a 60.00 MiB reserve, so a
  guard written against the reserve limit would switch off the configuration that was measured
  as the best one. Above the *window* limit a window stops being a window over the pool and
  becomes a window over its prefix, while the device-wide reserve is still taken in full and
  still paid for in prefill. The threshold is read from `cudaDeviceProp`, not compiled in. See
  the second target below for what that costs when it is not guarded.

## Numbers

`Qwen3.6-35B-A3B`, RTX 5090, `-pg 2048,384 -r 6 --warmup 2 --prefill-chunk 8192
--spec mtp --draft-tokens 3`. Eight alternating passes, pass 0 dropped as warm-up, arm order rotated
each pass, delta taken as pairs **inside** a pass, median over the remaining seven. Two different
cards — two 5090s in the same host, so the GPUs are independent but the CPU is shared. Three
ladders in all: one on card A, two on card B.

| | card A | card B |
|---|--:|--:|
| **decode throughput** | **+0.789 %** (sem 0.043 %, n=7) | **+0.539 %** (sem 0.072 %, n=7) |
| prefill throughput | −0.709 % (sem 0.054 %) | not measured |
| **total wall time, `pp2048+tg384`** | **+0.581 %** (sem 0.035 %) | not measured |

Instrument noise floor in these runs: base standard deviation across passes 0.164 % on card A
and 0.161 % on card B. A null-control arm — the mechanism compiled in and armed, but installing
no window and no reserve — reads **−0.082 %** (sem 0.059) on card A and **+0.009 %** (sem 0.077)
on card B, i.e. zero on both to within the noise floor.

Every ladder here is one connected run: a single process, its own tag, its own output file. That
is checked rather than assumed — the harness can emit exactly one arm order, so each file is
replayed against it cell for cell, and all three match 48 of 48 with no gaps, no repeats and
monotone timestamps.

A **second** clean ladder was then taken on card B, same binary, same conditions, half an hour
later, for one purpose: to size the run-to-run spread. It reads **+0.660 %** (sem 0.145, n=7),
null control +0.015 %, base standard deviation 0.141 %. Two clean ladders on the same card, the
same day, therefore differ from each other by 0.121 pp.

Two further clean ladders on card B (`raw/abab_h3.txt`, `raw/abab_h6.txt`), taken later to check
the guard described below, put the same arm at **+0.752 %** and **+0.674 %** and the guarded arm —
the one this PR submits — at **+0.778 %** and **+0.777 %**, on base spreads of 0.053 % and
0.066 %. That widens the same-card spread of a single arm from 0.121 pp to **0.213 pp** and leaves
the reading below unchanged: a range, not a point.

Those two ladders are the **only** measurement of the guarded arm, so their cells are the whole
evidence for the submitted number. They are in this package: 32 cells each, arms
`off / x@nr / n60w30@nr / g60w30@nr`, replayable with
`scripts/analyze2.py raw/abab_h3.txt` and the same on `h6`.

**Read the absolute figure as a range, not a point.** The sem inside one ladder understates the
real uncertainty, and the ladders show by how much. A sibling arm of identical geometry appears in
**six** single-run ladders across the two cards and comes out at
+0.386 / +0.288 / +0.257 / +0.425 / +0.187 / +0.363 % — a spread of 0.238 pp against within-run
sems of 0.013–0.099. Those six, in that order, are `raw/abab_r3.txt`, `abab_r6.txt`,
`abab_r7.txt`, `abab_a8.txt`, `abab_rb1.txt`, `abab_rb2.txt`, arm `n60w30`. (Two of those six ran
while the card had a foreign tenant, which is what their wider base standard deviation reflects;
all six are single connected runs, checked as above. A seventh ladder,
`raw/abab_a9_disqualified_control.txt`, put the arm at +0.012 %, but that one is disqualified by
its own internal control and is quoted here only so the discard is visible; it is shipped under
that name so the discard cannot be mistaken for a clean ladder.) The headline arm reads
+0.789 % on card A and +0.539 % / +0.660 % on card B. So the honest reading of this change is
**+0.5 to +0.8 % of decode throughput**, not "+0.789 % exactly".

**The absolute level does not replicate across cards** to the 0.15 pp we treat as the limit for
calling a cross-card replication successful: +0.789 % against +0.539 % is **0.250 pp** apart. The
second card B ladder, +0.660 %, sits 0.129 pp from card A and would pass that limit — and that is
the point rather than a rescue. The two card B ladders are 0.121 pp apart from each other, so the
limit is smaller than the spread a single ladder carries, and no single pair of ladders can settle
the question either way. We are not claiming the absolute figure replicates across cards.

One contrast inside these ladders does reproduce tightly: the same window with the prefill cache
reset put back, which accounts for 45 %, 67 % and 63 % of the gain on the three ladders. It reads
−0.354 % (sem 0.059) on card A against −0.363 % (sem 0.088) and −0.414 % (sem 0.146) on card B —
0.009 pp and 0.060 pp apart, a spread of 0.060 pp across the three ladders against the headline's
0.250 pp. Of the fifteen arm-to-arm quantities the three ladders have in common, that contrast is
the tightest and the headline delta is the second widest. Both rest on exactly these three
ladders, so that is a like-for-like comparison; the six-ladder cross-check quoted above exists
only for the sibling arm, since the other three ladders carry no arm this contrast could be taken
against.

That is a fact about those two arms, not a general property of pairing, and it is not offered
instead of the headline. Every figure quoted here is already a pair taken inside one pass, the
headline included, and their cross-ladder spreads run from 0.060 pp to 0.489 pp — the widest of the
fifteen contains no baseline arm at all, while baseline against the null control is third tightest
at 0.097 pp. Nor does the contrast measure what this PR does: both of its arms carry the change and
master carries neither. What the change is worth against master is the +0.5 to +0.8 % above, and
that is the figure whose absolute level does not replicate across cards.

**How the arms were switched.** All arms in a ladder come from **one** binary, with the arm
selected by an environment variable, so no build-to-build difference can leak into a delta. The
code submitted here has that arm compiled in unconditionally. The submitted build was compiled
and tested (below), but its *throughput* was not measured separately from the arm-switching
build; the two differ only in whether the same call is behind an `if`.

**Prefill pays, and the trade depends on the mix.** The reservation is also in force while a
prefill chunk streams through L2, and the profile names the kernel that pays for it. At this
prompt and generation length the decode gain more than covers it; a prefill-dominated workload
would not be a good trade. That is a deliberate choice, not an oversight, and the numbers for
both halves are above.

## The second target, and why the guard is in the code

`capture_graph` is shared, so this change reaches every target of this runtime. It was measured
on a second one, `Qwen3.8-27B` NVFP4, and there it was a pure loss — which is what the guard
above exists to stop.

That target's state pool is **307 888 128 B**, 2.29× the 134 217 728 B window limit. The window
therefore covered 43.6 % of the pool while the reserve was taken and paid for in full. Nothing
reported this: `cudaDeviceSetLimit` and `cudaStreamSetAttribute` both returned `cudaSuccess`,
the requested limit was granted exactly, and the truncation happened in our own code before the
call. Measured cost of that silence, same protocol, two clean ladders per column, four in all,
one binary, arms switched by environment variable:

| | without the guard | with the guard |
|---|--:|--:|
| decode throughput | −0.039 % / −0.041 % | **−0.013 % / −0.008 %** |
| prefill throughput | **−0.550 % / −0.521 %** | **−0.001 % / +0.005 %** |
| total wall time | −0.089 % / −0.108 % | **−0.013 % / −0.018 %** |
| base spread of the ladder | 0.027 % / 0.062 % | same ladders |

Half a percent of prefill for nothing in decode, and after the guard nothing either way: every
figure in the right column is inside the base spread of its own ladder. Walking the captured
graph says the same thing without reference to timing — **0 of 811 kernel nodes** carry a
window with the guard, against 811 of 811 without it, and the persisting limit stays at the
18 874 368 B driver default instead of being raised to 60 MiB. The mechanism is off, not
weakened.

The reason it gains nothing there is structural rather than a matter of degree: the window
covers 43.6 % of the pool, of which half is the second state slot that nothing reads, so about
20 % of the live state ends up resident against 49 % on the target above. And there is little
for it to give back — a kernel census on the nearest neighbour of that target (`Qwen3.6-27B`
NVFP4: same target code, different weights) puts `recurrent_fold_kernel` at 0.9 % of decode
kernel time and weight GEMMs at 89.8 %, already running at 89.7 % of the measured read ceiling.
Arithmetic straight off the submitted target's own benchmark row agrees on the second half of
that: 20 826 889 216 B of weights per round in 17.98 ms is 1158.5 GB/s, 68.6 % of the measured
read ceiling, and that is a lower bound.

**On `Qwen3.6-35B-A3B` the guard does not fire and changes nothing.** That is the control
against a false trip, and it is checked two ways. By audit: the instrumented build prints
identical geometry with and without the guard — 520 of 520 kernel nodes windowed, window
128 778 240 B, reserve 62 914 560 B, `hitRatio` 0.4885 — on every cell of both ladders. And by
ladder: taken as pairs inside a pass, the guarded arm against the unguarded one reads
**+0.030 pp** and **−0.072 pp** of decode, 0.080 pp and 0.052 pp of prefill, and 0.002 pp and
0.016 pp of total wall time, on ladders whose base spread is 0.053 % and 0.066 %. The sign of
the decode difference flips between the two ladders, which is how a quantity whose true value
is zero behaves.

Three of seven ladders taken for this were **discarded by their own pre-registered noise
control** (base spread 1.436 %, 1.562 %, 0.217 % against a 0.20 % limit written down before the
runs); the card witness was clean on all of them and no foreign process was on the card, so the
excursions are unexplained. They are quoted nowhere above. For the record they agree in sign
with the four that qualified.

Because nothing in the driver reports the truncation, the guard says so once per process on
stderr when it fires, rather than switching the mechanism off silently — silent truncation is
the failure being fixed here, and a silent guard would reproduce it. Checked on the submitted
binary itself, not only on the instrumented one: the 35B artifact prints nothing, and a 27B
NVFP4 artifact prints exactly one line naming both sizes.

## Where the time moves

`nsys profile -t cuda --cuda-graph-trace=node`, no capture range. `ncu` counters are closed on
this host, so there is no direct L2 hit counter here. Instead the mechanism rests on two things.
First a structural-zero control. In one ladder (base standard deviation 0.132 %), a window of
**identical geometry** — same reserve, same size, same hit ratio — pointed at a buffer nothing
reads measures **−1.082 %** (sem 0.065) against stock, while the real window in the same ladder
measures **+0.257 %** (sem 0.053). Same cost, opposite sign: the gain is not an artefact of
taking a reserve or of installing a window, it comes from pinning *this* range. (Both arms of
that ladder also carried an extra cache-reset call that the submitted code does not have, which
is why +0.257 % sits below the headline; the two carry it equally, so the contrast is unaffected.)
Second, the roofline below.

| kernel | launches | median, stock → patched |
|---|--:|---|
| `gated_delta_net::recurrent_fold_kernel` | 231 | 54 944 → **41 216 ns (−25.0 %)** |
| `gated_delta_net::recurrent_record_kernel` | 6 990 | 5 344 → **4 737 ns (−11.4 %)** |
| `gated_delta_net::recurrent_bf16_direct_kernel` | 30 | 2 656 → 2 096 ns (−21.1 %) |
| `sparse_moe_prefill_reduce_kernel` (prefill) | 80 | 38 193 → 48 288.5 ns (**+26.4 %**) |
| `sparse_moe_d4_nine_warp_kernel` | 37 | 10 912 → 11 808 ns (+8.2 %) |
| `rmsnorm_warp_bf16x2_kernel` (this instantiation) | 60 | 19 904 → 21 328 ns (+7.2 %) |
| `sparse_moe_d3_path_tiled_kernel` (this instantiation) | 233 | 49 089 → 51 105 ns (+4.1 %) |
| every other kernel | | no median moves by more than 3.1 % |

The table is the full picture, not a top-N: both runs contain the same 84 distinct kernels, none
appears or disappears, and every one of the 84 was compared. The largest regression,
`sparse_moe_prefill_reduce_kernel`, is a prefill kernel, which is consistent with prefill
throughput being the half that pays — though that attribution is by kernel name and launch
count, not by a per-phase timeline. Summed over the whole `pp2048+tg384` run, total kernel time
still drops: 1434.0 → 1430.3 ms.

The reservation is not free, and it is instructive who pays for it. With the reserve taken but
**nothing pinned**, `recurrent_fold_kernel` goes 54 944 → 73 921 ns (+34.5 %) and accounts for
**115 % of the entire slowdown**, while the high-launch-count MoE streaming kernels
(`sparse_moe_d3_path_tiled`, 9 320 launches; `sparse_moe_d4_token`, 8 621) do not move at all —
+0.00 % median on both. The kernel that pays for the reservation is the same kernel the
reservation is for: it was already served in part by L2, the carve-out takes that away, and the
window gives it back with interest.

## Roofline, against ceilings measured on this card

The ceilings below are direct measurements of this card, each from two independent runs agreeing
to within 0.2 %: DRAM copy 1503.4 GB/s, DRAM pure read 1689.4 GB/s, L2 aggregate read
7132–7461 GB/s. That is more honest than quoting a constant compiled into a benchmark, but it is
our own measurement, not a vendor figure.

Per launch, `recurrent_fold_kernel` reads and rewrites the live slot of all 30 layers:
30 × (49 152 + 2 097 152) = 64 389 120 B each way, 128 778 240 B of traffic.

| | launch time | read+write rate | vs DRAM copy ceiling | read-only rate | vs DRAM read ceiling |
|---|--:|--:|--:|--:|--:|
| stock | 54 944 ns | 2343.8 GB/s | **1.56×** | 1171.9 GB/s | 69.4 % |
| reserve taken, nothing pinned | 73 921 ns | 1742.1 GB/s | 1.16× | 871.0 GB/s | 51.6 % |
| **patched** | **41 216 ns** | **3124.5 GB/s** | **2.08×** | 1562.2 GB/s | 92.5 % |

The kernel exceeds the measured DRAM copy ceiling already on stock and by 2.08× when pinned.
That traffic cannot be coming from DRAM, which is arithmetic rather than interpretation: with no
hit counter available, exceeding one medium's ceiling is what establishes that another medium is
carrying the difference. Against the aggregate L2 read ceiling the patched kernel takes 21.9 %.

`recurrent_record_kernel` reads one layer (2 097 152 B) per launch: 392.4 GB/s = 23.2 % of the
read ceiling on stock, 442.7 GB/s = 26.2 % patched. That one is latency-bound, not
bandwidth-bound, which is why its gain is half the size.

## Correctness

Output is bit-identical. Greedy decoding through the CLI (where prefix reuse is off in code),
`--spec mtp --draft-tokens 3 --prefill-chunk 8192 --max-new 192`, three prompts, seven arms
including the exact configuration submitted here (reserve 60 MiB, window over the whole pool,
`missProp = Normal`). The reflexive comparison — stock against stock — was taken first, because
a gate that does not agree with itself proves nothing in either direction.

```
21 of 21 comparisons IDENTICAL; exactly 3 distinct digests, one per prompt
```

That was taken on the revision before the guard. It was re-run with the guard in place, on both
targets, arms `off` (twice, reflexive first), the armed-but-inert control, the unguarded window
and the guarded window:

```
Qwen3.6-35B-A3B   12 of 12 IDENTICAL; 3 distinct digests   (guard does not fire)
Qwen3.8-27B       12 of 12 IDENTICAL; 3 distinct digests   (guard fires)
```

Independently, `spec_acceptance_rate` and `spec_rounds` agree to the last digit across every
clean measurement cell of every ladder — the patch does not change a single accepted draft.

`ctest`: 104/104 pass on both arms from the same build directory — base 464.9 s, branch 460.5 s.
Both arms are on `ad0f3d38`, the base this branch sits on, whose `tests/CMakeLists.txt` registers
exactly those 104 targets; `487f8977` registers 114 and neither arm was re-run there.

Worth being explicit about one thing: six of those 104 are opt-in real-artifact tests that skip
unless their weights variable is set, and they are the only ones in the suite that reach the code
this change touches. So they were run explicitly against real artifacts:
`ninfer_qwen3_6_35b_a3b_real_test` (36.9 s), `ninfer_qwen3_6_35b_a3b_dflash_real_test` (62.4 s)
and `ninfer_qwen3_6_27b_prefix_real_test` (103.2 s) all pass. The first two build the engine with
`use_cuda_graph = true`, so the captured decode graph — and with it the window installed in
`capture_graph` — is actually exercised; the third runs on a target whose pool is 307 888 128 B,
so it exercises the guarded path instead. Without those, a green `ctest` here would have meant
very little.

`clang-format` (23.1.0, repository config) reports zero findings on all three touched C++ files,
and zero on the pre-existing one at the base commit as well — checked from a separate worktree at
the base rather than through a pipe, because `clang-format` does not find the repository config
when reading stdin — so no formatting of existing code is mixed into this change.

The change touches cache policy only; it does not alter arithmetic, kernels, register or shared
memory usage, or any launch geometry.

## What was measured and rejected on the way here

Recording these so the choice of parameters is not mistaken for a guess:

* **Reserve size is not a tuning knob with an interior optimum.** Sweeping the reserve from 6 to
  60 MiB at a fixed window gives a monotone curve — −0.418 %, −0.185 %, −0.040 %, +0.093 %,
  +0.270 %, +0.386 % (n=6 per point) — so the best reserve is the card's maximum, and the card's
  maximum is the 60.00 MiB read out of `persistingL2CacheMaxSize` above. Measured in a run whose
  base standard deviation was 0.071 %.
* **Narrowing the window hurts.** A window over 14 layers at `hitRatio` 1.0 is 0.297 % (sem
  0.103 %) worse than the whole pool at `hitRatio` 0.4885.
* **There are no hot layers to prefer.** Pinning the lowest 14 layers and the highest 14 layers
  differ by −0.011 % (sem 0.081 %).
* **The card's non-zero default reserve is nothing to reclaim.** Setting the limit explicitly to
  0 and to its 18 MiB default come out at +0.019 % — but the band on that one is sem 0.140 %,
  wide enough to hide an effect the size of the ones above, so read it as "no evidence of a
  difference", not as a demonstrated zero.

Two caveats on that list, both worth stating rather than leaving to be found. The last three
items come from ladders taken while the card had a second tenant (base standard deviation
0.243 % and 0.132 %, against 0.164 %, 0.161 % and 0.141 % for the three clean ladders the
headline numbers come from), which is why they are quoted only as pairs taken inside a pass,
so that the raised base level does not enter the delta. (That keeps the pass baseline out of each
number; it is not a claim that pairing makes a quantity reproduce across ladders — see the spread
of the fifteen above.) And every arm on that list — the reserve sweep included — still carried an extra
`cudaCtxResetPersistingL2Cache` call on the prefill path that this change does not have. It sits
in both halves of each pair equally, so the comparisons hold; it does mean the absolute values
there are not directly comparable to the headline.

## Known limitations

The reserve stays in force during prefill, which is where the −0.709 % comes from. Dropping the
limit before a prefill chunk and restoring it afterwards may recover part of that; the cost of
`cudaDeviceSetLimit` in a hot path has not been measured, so it is not in this change.

About half the reserve is spent on bytes nothing reads. In this configuration the state pool
holds two slots per layer, laid out `[conv s0][conv s1][rec s0][rec s1]`, so live and dead bytes
alternate with a 2 MiB stride inside every layer — and an access policy window, being a single
contiguous range with no stride, cannot tell them apart. Laying the pool out by slot rather than
by layer would roughly double the share of the reserve that holds live bytes; whether that
converts into gain has not been measured, and in any case it is a change to the state allocator
rather than to cache policy, so it is not part of this PR.

The guard is a size test, not a benefit test. It switches the mechanism off where it provably
cannot work — a window that cannot span the pool — and it says nothing about targets whose pool
does fit but whose decode has no reuse to recover. Two targets have been measured, one on each
side of the limit; a third has not. If a fitting target ever turns out not to benefit, the answer
would be a per-target opt-out rather than a wider size test, and there is no evidence today that
one is needed.

`Qwen3.8-27B` was measured on one card only. For a result that is a zero, and whose main evidence
is a graph audit showing no window installed at all, a second card would move the digits and not
the conclusion.

## Speculation counters: how much of this number is round count, and how much is round speed

*Added 2026-09-06 after a dedicated audit of every decode headline I have prepared for this
project. That audit was run with my own harness outside this repository and is **not a file
of this package**; it is named only to say where the section came from, and nothing below
leans on it — its own logs can be supplied on request. The section answers, from this
package's own raw, the one question a throughput figure in tokens per second cannot answer
by itself.*

`ninfer_bench` reports decode as generated tokens over elapsed time. A change that alters the
numbers the model produces can alter **draft acceptance**, and with it the number of speculative
rounds spent on the same fixed output length. Such a change raises tokens per second without any
kernel running faster. The two effects separate exactly, because the bench prints the round count
itself:

    decode_time(base) / decode_time(arm)  =  [ rounds(base) / rounds(arm) ]  *  [ t(base) / t(arm) ]

where `t = decode_seconds_mean / spec_rounds` is the time of one round. `spec_rounds` is an exact
integer printed by the engine and `decode_seconds_mean` is the measured time, so the split is an
identity rather than a model.

**This package: the round count is identical across every arm, so the whole figure is round speed.**
Raw, all of it in this package - **twelve ladders, 522 cells**, each cell a full CSV row:

| file | cells | arms | model | `spec_rounds` / `spec_acceptance_rate` in every cell | what it carries |
|---|--:|--:|---|---|---|
| `raw/abab_a8.txt` | 48 | 6 | 35B | 678 / 0.7994100295 | headline card A, +0.789 %; null control −0.082 % |
| `raw/abab_r3.txt` | 49 | 7 | 35B | 678 / 0.7994100295 | window-length sweep; sibling arm +0.386 % |
| `raw/abab_r6.txt` | 56 | 7 | 35B | 678 / 0.7994100295 | sibling arm +0.288 % |
| `raw/abab_r7.txt` | 48 | 6 | 35B | 678 / 0.7994100295 | sibling arm +0.257 % |
| `raw/abab_r8.txt` | 65 | 6 | 35B | 678 / 0.7994100295 | +0.597 %; **the one file here that is not a single connected run** - two `start` headers, 30 cells written after `done`; split and re-analysed in `raw/reanalyze_r8_split.txt` |
| `raw/abab_rb1.txt` | 48 | 6 | 35B | 678 / 0.7994100295 | headline card B, +0.539 % |
| `raw/abab_rb2.txt` | 48 | 6 | 35B | 678 / 0.7994100295 | second card B ladder, +0.660 % |
| `raw/abab_h3.txt` | 32 | 4 | 35B | 678 / 0.7994100295 | **guarded arm +0.778 %** |
| `raw/abab_h6.txt` | 32 | 4 | 35B | 678 / 0.7994100295 | **guarded arm +0.777 %** |
| `raw/abab_a9_disqualified_control.txt` | 32 | 4 | 35B | 678 / 0.7994100295 | discarded ladder, +0.012 %, kept so the discard is visible |
| `raw/abab_h2.txt` | 32 | 4 | 27B | 576 / 1 | second target, guard check |
| `raw/abab_h7.txt` | 32 | 4 | 27B | 576 / 1 | second target, guard check |

In every one of the **458** cells of the ten 35B ladders the engine prints the same three
counters: `spec_rounds` **678**, `spec_fallback_steps` **0**, `spec_acceptance_rate`
**0.7994100295**. The two 27B ladders are a different target and print **576 / 0 / 1** in all
64 of their cells - also constant across arms, which is the property that matters here.

Each of the twelve files is replayed cell for cell against the one arm order the harness can
emit; the witness for all twelve is `raw/verify_all_ladders_2026-09-06.txt`. Eleven come back
"one connected run, no gaps, no repeats, monotone timestamps". `abab_r8.txt` does not, and is
reported as such rather than quietly dropped: it carries two `start` headers and 30 cells
appended after its `done` line, and the split is worked through in `raw/reanalyze_r8_split.txt`.
No headline number in this PR rests on it.

The measurement runs at `--spec mtp --draft-tokens 3`, which is where a round-count substitution could
hide. With the round count equal in all 458 35B cells, `+0.789%` on stand A and `+0.539%` on stand
B are the time of one round and nothing else, and so is the submitted `+0.778%` / `+0.777%`.

This is what a bit-exact change has to do, and it is stated here because the identity gate alone
would **not** settle it: under greedy verification the emitted text is the target model's greedy
sequence whatever the acceptance rate, so equal output does not by itself imply an equal number of
rounds. The counters do.

**Which proposal head this was taken at.** Every cell cited above ran at the product default
`ProposalHead::Full` (`include/ninfer/types.h:82`). The audit put the same question to
`--lm-head-draft`, the configuration `docs/performance.md` publishes in, on Qwen3.6-35B-A3B at
`-pg 2048,384 --prefill-chunk 8192 --spec mtp --draft-tokens 3`: a bit-exact arm and the base agree there
as well - **690 rounds and acceptance 0.7819767442 in both** - so the split is the same under
either head. A **non**-bit-exact arm measured beside them in the same ladder does move the count
(714 rounds, acceptance 0.7422969188), which is what shows the instrument would have caught a
substitution had there been one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
