### PR TITLE
perf(ops): prefetch the shared-expert down weights from the D1 tail

### DIFF
--- a/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
+++ b/src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu
@@ -69,7 +69,9 @@ __device__ __forceinline__ float router_row_dot(const __nv_bfloat16* x, const __
 
 __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ router,
-                                     float* __restrict__ scores) {
+                                     float* __restrict__ scores,
+                                     const char* __restrict__ shared_down_codes,
+                                     unsigned long long shared_down_bytes) {
     __shared__ float partial[kD1Warps];
     const int row   = static_cast<int>(blockIdx.x);
     const int warp  = static_cast<int>(threadIdx.x) >> 5;
@@ -81,6 +83,15 @@ __global__ void sparse_moe_d1_kernel(const __nv_bfloat16* __restrict__ x,
         float value = lane < kD1Warps ? partial[lane] : 0.0f;
         value       = warp_reduce_sum<kD1Warps>(value);
         if (lane == 0) { scores[row] = value; }
+    }
+    if (shared_down_codes != nullptr) {
+        // Warm L2 for the shared-expert down codes that D4's shared warp
+        // (the block's long pole) will stream at t~14.3us. Pure cache hint.
+        const unsigned long long offset =
+            (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
+        if (offset < shared_down_bytes) {
+            asm volatile("prefetch.global.L2 [%0];" ::"l"(shared_down_codes + offset));
+        }
     }
 }
 
@@ -480,12 +491,14 @@ __global__ void sparse_moe_d4_token_kernel(
     }
 }
 
-void launch_d1(const Tensor& x, const Weight& router_shared_gate,
+void launch_d1(const Tensor& x, const SparseMoeWeights& weights,
                const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
     sparse_moe_d1_kernel<<<kRouterRows, kD1Warps * 32, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data),
-        static_cast<const __nv_bfloat16*>(router_shared_gate.qdata),
-        static_cast<float*>(workspace.scratch.data));
+        static_cast<const __nv_bfloat16*>(weights.router_shared_gate.qdata),
+        static_cast<float*>(workspace.scratch.data),
+        static_cast<const char*>(weights.shared_down.qdata),
+        static_cast<unsigned long long>(kHidden) * kIntermediate);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -719,7 +732,7 @@ void sparse_moe_decode_launch_d4_small_t(const SparseMoeWeights& weights, Tensor
 
 void sparse_moe_decode_launch(const Tensor& x, const SparseMoeWeights& weights, Tensor& destination,
                               const SparseMoeDecodeWorkspace& workspace, cudaStream_t stream) {
-    launch_d1(x, weights.router_shared_gate, workspace, stream);
+    launch_d1(x, weights, workspace, stream);
     launch_d2_d3(x, weights, workspace, stream);
     launch_d4_dependent(weights, destination, workspace, stream);
 }


### PR DESCRIPTION
> ### Rebased onto `a16b6442`. Where the numbers below come from
>
> **Base.** This package was written against `ad0f3d38` and now targets upstream **`a16b6442`**
> (`docs: organize performance reports and update 35b results`). Its parent is **`487f8977`**
> (`perf(sparse_moe): one CTA per token in small-T S2, and a warp merge in place of eight
> dependent rounds`), which is the commit the rebase and every re-measurement below were carried
> out on; master moved one commit further while this was being prepared. That one commit touches
> **thirteen files, all of them documentation** - `README.md`, `docs/`, `eval/README.md`,
> `model-cards/`, `tools/bench/README.md` - and no source, header, kernel, test or bench file, so
> every code citation and every number in this report reads the same on `487f8977` and on
> `a16b6442`. `ad0f3d38` and the earlier heads still named throughout this report are the commits
> the original work was **done and measured on**. They are left standing rather than rewritten, so
> that every number below stays attached to the tree it was actually taken from.
>
> **Provenance of every number.** Except where a table says otherwise, every timing, ratio,
> percentage, bandwidth, TFLOP/s figure, register and shared-memory count and `ctest` line in this
> report was measured on `ad0f3d38`, or on an earlier head named at the point of use.
> **One thing has been re-measured on `487f8977`, and it is the headline: the operator delta at
> T = 1.** It came back at **-6.67 % (30.720 -> 28.672 us)** against the **-13.3 %
> (30.720 -> 26.624 us)** this report used to claim; the section "The headline number fell by half
> on the new base" below states what reproduced, what did not, and what is left unexplained. The
> bandwidth and roofline figures derived from it are recomputed there, with the arithmetic shown.
> **Nothing else here has been re-measured on `487f8977`** - in particular no end-to-end number, no
> `ctest` run and no register or shared-memory count. Two changes to the instrument itself bear on
> that, and are stated once here instead of being repeated at every table:
>
> * **The engine context cache changed sides.** On `487f8977` `ninfer_bench` switches it off
>   itself - `engine_options.context_cache.enabled = false`,
>   `bench/targets/qwen3_6_27b/ninfer_bench.cpp:157`, introduced upstream by `385b30ce`. On
>   `ad0f3d38` that line does not exist at all, so the bench inherited the engine default
>   `ContextCacheOptions::enabled = true` (`include/ninfer/types.h:130` there, `:132` here) and
>   every end-to-end run behind this report was taken with the cache **constructed**. Two bounds
>   on how far that reaches, both stated because the difference has **not** been measured. From
>   above: a live context cache can serve a prefix and shorten a prefill, which for prefill and
>   TTFT would be a first-order difference rather than a rounding one. From below: the bench also
>   sets `options.execution.allow_prefix_reuse = false` on every request
>   (`bench/targets/qwen3_6_27b/ninfer_bench.cpp:65`) - **byte-identical on both bases** - so no
>   request in these runs was eligible for a prefix hit at all, and what the old configuration
>   carried was a constructed-but-unused cache (host state slots and pinned host KV) rather than
>   served prefixes. Which bound is nearer the truth is an open question here; until it is
>   measured, read the prefill and TTFT figures as taken in a configuration the current bench no
>   longer builds.
> * **The bench flag was renamed.** `--mtp-draft-tokens` no longer exists anywhere in the tree.
>   The current spelling is `--spec mtp --draft-tokens N`
>   (`bench/targets/qwen3_6_27b/ninfer_bench_support.cpp:356-359`), the same pair the product CLI
>   takes (`apps/cli/options.cpp:141-145`). Every reproduction line below has been rewritten to the
>   current spelling; the runs behind the numbers used the old one. One trap in that rename is
>   worth naming: `--spec mtp --draft-tokens 0` is **rejected** - `validate_speculative_cli_options`
>   requires `[1,5]` for MTP (`src/product/speculative_options.h:41`) - so the zero-draft arm,
>   written `--mtp-draft-tokens 0` throughout the old text and called `mtp0` below, is spelled on
>   the current bench by passing **neither** flag, which is already the default
>   (`SpeculativeBackend::None`).
>
> **Registered tests.** `tests/CMakeLists.txt` moved as well. The suite that registered **104**
> targets on `ad0f3d38` registers **114** on `487f8977` (+10 targets), and one more of them is
> artifact-gated: **20** named targets now carry an explicit `SKIP_RETURN_CODE 77` against
> **19** on `ad0f3d38`, on top of the blanket rule inside `ninfer_add_op_test` that marks
> every op test skippable. The addition is `ninfer_qwen3_8_27b_dflash2_real_test`, gated on
> weights like the rest, so one further test skips on a host that carries none. Every `ctest` count printed below is consequently a
> statement about `ad0f3d38` or an earlier head, not about the current base; the counts are left
> in place rather than restated, with the base each belongs to named beside it.
>
> **No `ctest` run in this report has been repeated on `487f8977`, and no round "114 of 114" is
> claimed for it.** Two facts forbid that claim. `ninfer_attn_input_proj_test` is **red on the
> bare base** - an upstream defect, filed as issue #196, not something this branch introduces.
> And `ctest` and a direct run of the same test binary have been observed to disagree on this
> host, so a green `ctest` is not by itself evidence of anything. The only formulation this
> package will stand behind on the new base is the exact one: **the arm's result matched the
> base, and the single failure reproduces on bare `487f8977`.**
>
> **Line references re-checked against `487f8977`.** Every `file:line` citation in this report was
> opened on the new base. The ones that moved are corrected in place; the number each one used to
> carry is kept here so nothing is replaced silently.
>
> | citation | printed here before | on `487f8977` | what stands at the old number now |
> |---|---|---|---|
> | `src/targets/qwen3_6/impl/state/round_state.cpp`, the DFlash allocation gate | `:176` | **`:174`** | `:176` is inside the block, not its condition: `DFlashDecodeStateLayout& decode = layout.dflash_decode.emplace();` |
> | `include/ninfer/types.h`, the backend default | `:78` | **`:79`** | `:78` is the opening line `struct SpeculativeOptions {` |
> | `include/ninfer/types.h`, `ProposalHead::Full` | `:80` | **`:82`** | `:80` is the comment `// Startup-fixed K: MTP 1..5; DFlash and DFlash2 1..15 (query width K+1).` |
> | `src/serve/serve_options.h`, `SpeculativeOptions speculative;` | `:46` | `:46` | unchanged - re-checked, still correct |
>
> **The gate this report quotes no longer exists, and the real one is wider.** The text below
> quoted `if (layout.spec.enable_dflash)`. The field `enable_dflash` is gone from the tree
> entirely - `git grep enable_dflash origin/master` finds it only inside the frozen code samples
> under `eval/corpora/`. `round_state.cpp:174` now reads
> `if (is_masked_draft_backend(layout.spec.backend))`, and that predicate is
> `backend == SpeculativeBackend::DFlash || backend == SpeculativeBackend::DFlash2`
> (`src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h:7-9`). So the gate admits
> **both `--spec dflash` and `--spec dflash2`**, not `--spec dflash` alone, and the quotation and
> the "reachable only through `--spec dflash`" wording have been corrected wherever they appeared.
> The conclusion the paragraph draws is unaffected: the default is still
> `SpeculativeBackend::None`, and no measurement in this report passes either flag.

## Claim level

**Operator**, decode route of `sparse_moe` only. One mechanism, one commit, one file, 18 added
lines. The end-to-end figures are appended to the operator measurement, not substituted for it.

## Environment

One RTX 5090, `sm_120a`, driver 580.173.02, CUDA 13.1.115, gcc 13.3.0, Ubuntu 24.04.4, Release,
`-DCMAKE_CUDA_ARCHITECTURES=120a`, Ninja, 256 host cores. Every measured run goes through a `flock`
wrapper on `/var/lock/ninfer_gpu.lock` that also refuses to start while
`nvidia-smi --query-compute-apps` reports any process, or while more than 512 MiB of device memory
is occupied, so no two runs ever share the card.

The host is **not** exclusive: a second campaign began work on this machine partway through the
session. That does not touch the numbers reported here - all of them were taken before it started,
and the arms measured afterwards were checked against them - but one later measurement pass was
corrupted by its build and is reported as discarded rather than averaged in. Details are in the
package README.

Base `origin/master` @ **`ad0f3d38`**, checked 2026-09-05 (the packaged branch was built on
`e3aeaf8c` and has been rebased across all three intervening heads - `a140e7ae`, `b8786751`,
`ad0f3d38` - without conflict at any step). Artifact
`qwen3_6_35b_a3b.ninfer` (19.59 GiB resident weights),

> **The base moved twice. The current base is `ad0f3d38`, checked 2026-09-05.**
>
> *First step, 2026-09-04.* Upstream master went from `a140e7ae` to `b8786751`
> (`fix(runtime): correct aliased state ownership`), a direct child. This branch was rebased
> onto it: **no conflict**, and `patch-id --stable` of the change is unchanged. `ctest` on the
> bare `b8786751` is **104 of 104, 0 failed**, the same six artifact-gated tests skipped as
> before. A stock-against-stock control on `ninfer_bench` (four passes per arm, arms alternated,
> continuous card witness, 48 samples with no foreign process) puts that commit itself at
> **-0.05%, -0.04%, -0.04% and +0.01%** on pp1024 / pp4096 / pp8192 / tg128 - every one at or
> below the within-arm spread of 0.03-0.16%, so the end-to-end tables in this report carry
> across unchanged rather than being quietly re-labelled.
>
> *Second step, 2026-09-05.* Master moved on to **`ad0f3d38`**, two commits further:
> `863aa8a5` (`fix(dflash): allow vision prompts`) and `ad0f3d38` (`chore: add project funding
> information`). Rebased again: **no conflict**, and `patch-id --stable` of every commit on the
> branch is unchanged. No number in this report is re-taken because of them, and that is settled
> by a line of source rather than by the commit subject: everything the DFlash fix adds is
> allocated under `if (is_masked_draft_backend(layout.spec.backend))`
> (`src/targets/qwen3_6/impl/state/round_state.cpp:174`), behind a speculative backend whose
> default is `SpeculativeBackend::None` in every entry point (`include/ninfer/types.h:79`,
> `src/serve/serve_options.h:46`) and which is reached only through an explicit `--spec dflash` or `--spec dflash2`
> that no measurement in this report passes. `tests/CMakeLists.txt` is byte-identical on
> `a140e7ae`, `b8786751` and `ad0f3d38`, so the registered test count does not move either.
>
> Details: the two dated rebase notes shipped alongside this package (their file names are
> in Russian; they are the only two files there dated 2026-09-04 and 2026-09-05).

40 layers with a MoE post-mixer in every one, `kHidden = 2048`, `kExperts = 256`, `kTopK = 8`,
`kIntermediate = 512`, BF16 KV.

```bash
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CUDA_ARCHITECTURES=120a -DNINFER_BUILD_APPS=ON -DNINFER_BUILD_BENCHMARKS=ON
```

## Observation

The decode MoE step is four dependent kernels: D1 (router reduction, 257 blocks of 256 threads),
D2 (top-8 selection, one warp), D3 (gate/up, 512 blocks of 9 warps), D4 (down and residual, 2048
blocks of 9 warps). D4 is the long pole of the step, and inside a D4 block the long pole is the
ninth warp: eight warps handle the routed experts while the ninth streams the shared-expert down
codes through `dot_two_rows<W8Codec, kHidden>`.

Those codes are cold at that moment, and provably rather than presumably so: between two
consecutive MoE layers the model streams 19.59 GiB / 40 = about 501 MiB of weights, five times the
96 MiB L2 on this part. Nothing of the previous layer's copy survives. The ninth warp therefore
opens a dependent load chain on a DRAM miss, and the other eight warps of the block wait behind it
at the block barrier.

D1 sits at the head of the same step. It reads `x` and the router matrix, touches none of
`shared_down`, and its 257 blocks retire long before D4 is scheduled. The bytes D4 will need could
have been in L2 by then, and were not.

## Change

The tail of `sparse_moe_d1_kernel` issues one `prefetch.global.L2` per thread over the
`shared_down` code plane, at a stride of 128 bytes, guarded by the plane extent:

```cpp
if (shared_down_codes != nullptr) {
    const unsigned long long offset =
        (static_cast<unsigned long long>(blockIdx.x) * blockDim.x + threadIdx.x) * 128ull;
    if (offset < shared_down_bytes) {
        asm volatile("prefetch.global.L2 [%0];" ::"l"(shared_down_codes + offset));
    }
}
```

`launch_d1` takes `SparseMoeWeights` instead of the single router weight, so it can pass
`weights.shared_down.qdata` and the extent.

**The extent is not a magic number and cannot run past the tensor.** It is
`kHidden * kIntermediate`, and `validate_weights`, which runs before every launch on this route,
already requires exactly that shape and the W8 code type for this tensor:

```cpp
require_quantized(weights.shared_down, kHidden, kIntermediate, "shared_down", ranges);
```

so one byte per element is the whole plane and the guard cannot address past it. Those two
constants already fix every launch geometry in this file - `dim3(kIntermediate)` for D3,
`dim3(kHidden)` for D4 - so the change carries no assumption the file did not already carry.

**Why this is bit-exact.** `prefetch.global.L2` moves nothing into a register and has no
architectural effect beyond cache residency; PTX defines it as a hint a part may drop entirely.
No value is read, computed, reordered or written, and the rest of D1 is untouched.

## Effect

### Operator, which is where this should be judged

`ninfer_sparse_moe_bench --codec q4-q5 --sweep 1:8 --execution graph --cache both --warmup 10
--repeat 400 --seed 7`. All arms in one session, **eight passes with the traversal order reversed
on even passes**, a fresh process per arm, every run through the lock wrapper.

| T | route | master, cold us | this branch, cold us | delta |
|--:|---|--:|--:|--:|
| **1** | **decode** | **30.720** | ~~26.624~~ **28.672** | ~~-13.3%~~ **-6.67%** |
| 2 | small-T | 38.880 | 38.880 | 0.00% |
| 3 | small-T | 46.90 | 47.07 | -0.38% |
| 4 | small-T | 53.248 | 53.248 | 0.00% |
| 5 | small-T | 59.392 | 59.392 | 0.00% |
| 6 | small-T | 69.632 | 69.632 | 0.00% |
| 7 | small-T | 75.776 | 75.776 | 0.00% |
| 8 | small-T | 83.968 | 83.968 | 0.00% |

The struck-through cells are what this report claimed on `ad0f3d38`; the bold ones are the
re-measurement on `487f8977`, which is the base this PR targets. Both are kept so that nothing is
replaced silently. The rest of the table was not re-measured and is the `ad0f3d38` run throughout.

**On `ad0f3d38`: master returned the T=1 number to the last digit in all eight passes** - 30.720
eight times. This branch returned 26.624 in seven of the eight passes and 26.656 in the first, one
32 ns timer tick away.

Rows T=2..8 are the control, and they are the code speaking: `sparse_moe_uses_small_t` sends a
token count in [2,46] to a different launcher that never calls `launch_d1`, so a change inside
`launch_d1` cannot reach them - and it does not. Warm-L2 T=1 is -0.80% against a +-3.5% pass spread
on the baseline, i.e. nothing, which is the expected answer: a warm cache is the state this change
manufactures.

### The headline number fell by half on the new base, and I cannot explain why

This is the one measurement in this report that was repeated on the current base, and it did not
come back the same. Stated plainly, because it weakens the claim:

* **On `ad0f3d38` the operator delta was -13.3 % (30.720 -> 26.624 us).**
* **Re-measured on `487f8977` it is -6.67 % (30.720 -> 28.672 us).** The saving is
  **2.048 us per call, not 4.096 us**: half of what this report used to claim.
* **The base reproduced exactly.** `base` returned **30.720 us in 24 cells out of 24** across two
  independent runs - the same number, to the last digit, that the old measurement reported. So this
  is not a drifting host, a different clock or a different fixture: the arm moved and the base did
  not.
* **The candidate did not reproduce.** `cand` returned **28.672 us in 24 cells out of 24**. Not one
  cell of the re-run landed on the 26.624 the old text claims.
* **There is no explanation for the drop, and this report does not offer one.** The mechanism, the
  file and the eighteen added lines are unchanged; what upstream did to `sparse_moe` between the two
  bases is a plausible place to look, but it was not measured and is not asserted here.

Protocol of the re-run, so the number can be weighed: `ninfer_sparse_moe_bench`, two runs - one
with `--tokens 1`, one with the verbatim sweep command printed above - **400 repeats per cell**,
six passes with pass 0 discarded, **median over the five scoring passes**, arms alternated within
each pass, a fresh process per cell, each cell holding its own GPU lock with the card-witness
window opened **inside** the lock. **-6.667 % in all five scoring passes of both runs, without a
single exception.** Null arm - the same procedure, master against master - **0.000 %** in nine of
its ten scoring passes and +0.521 % in the tenth. Sixty cells out of sixty passed the witness;
none were discarded.

**A previous version of this note blamed the instrument, and that was wrong.** It said the two
numbers differ by "exactly one step of the bench's 2.048 us timer grid", implying the instrument
could not tell 26.624 from 28.672. **There is no 2.048 us grid.** Taken over all 60 cells of the
re-run, the medians this bench prints include `16.992`, `17.088`, `17.120`, `25.184`, `26.720`,
`30.336`, `30.880` - **not one of them is a multiple of 2.048, and every one of them is a multiple
of 0.032**. The same holds for the `min` and `p95` columns. **The instrument quantum is 32 ns**,
and it separates 26.624 from 28.672 with a factor of 64 to spare. That the T=1 medians of both arms
happen to land on multiples of 2.048 is a property of a sharply peaked distribution - `p95` sits one
32 ns tick off the median - and not of the timer. The drop is real and belongs to the code, not to
the clock.

**Why the median and not the minimum.** The unquantised `min` column is kinder to this branch:
**-12.0 % and -12.3 %** in the two runs, against a null arm at -0.37 %. It is not the honest
statistic here, and the raw spread says why. Across the 24 candidate cells `min` moves by
**0.064 us** in total (26.528 to 26.592, and it reads 26.592 in 23 of the 24): the arm has a rare
fast mode and 400 repeats are enough to hit its floor every time. Across the 24 base cells `min`
moves by **0.800 us** (29.792 to 30.592) and never settles: over 400 repeats the base does not
reach a floor at all. **Comparing an arm that has bottomed out against an arm that has not
systematically overstates the effect**, which is exactly where -12 % comes from. The median is
stable on both arms - 24 of 24 and 24 of 24 - so the median is what this PR claims.

### Instrument floor, measured rather than assumed

A further arm was carried through the identical protocol whose binaries are a byte-for-byte copy of
the baseline. Its operator numbers are 0.00% at every T; end to end it reads -0.22% to +0.01%
(mtp0) and +-0.01% (mtp3). That is what this harness calls zero.

### End to end

`ninfer_bench --weights qwen3_6_35b_a3b.ninfer -pg "128,128;1000,128;4095,128;12000,128"
-r 10 --warmup 2 --max-ctx 16384`, run once with no speculative flag - the `mtp0` arm - and once
with `--spec mtp --draft-tokens 3` appended. Seven arms in one session, four passes,
**traversal order reversed on even passes**, a fresh process per arm.

| context | master, tok/s | this branch | delta | null arm |
|--:|--:|--:|--:|--:|
| 128 | 374.81 | 386.78 | **+3.19%** | -0.22% |
| 1 000 | 372.50 | 384.72 | **+3.28%** | -0.07% |
| 4 095 | 359.50 | 370.25 | **+2.99%** | +0.01% |
| 12 000 | 341.76 | 351.59 | **+2.88%** | -0.02% |

Pass-to-pass spread inside an arm: at most 0.14% on the candidate, 0.13% on the baseline.

**The effect does not scale with context, and that is the point.** What gets warmed is a weight,
and a weight is the same size at 128 tokens and at 12000. A gain that grew with context would mean
something other than this change was being measured.

**Prefill is unchanged, and this is measured rather than argued.** The prefill route never enters
`launch_d1`, but this commit does grow `sparse_moe_d1_kernel`'s constant bank from 920 to 936 bytes
and relays the module, so the size of any knock-on effect is a measurement, not a corollary. The
estimator throughout is the pairwise within-pass ratio against the reference arm, averaged as
`(mean of forward passes + mean of backward passes) / 2`, and every figure quoted is between two
arms that occupy **the same pair of positions** in the traversal, so no positional correction is
needed at all.

Against master directly, in the pass where this branch and master share the position pair 1/6:
**+0.02 pp at 1000 tokens, +0.02 pp at 4095, +0.04 pp at 12000**. In a pure-prefill ladder with no
decode in the process, this branch against its inert twin over nine prompt lengths - 2048, 3072,
3584, 4095, 4096, 4608, 5120, 6144, 8192 - reads **-0.10 to +0.01 pp**, a flat line at zero, with
4095 and 4096 reading the same. Every one of those is inside the protocol's own floor.

Two controls set that floor. First, a **byte-identical null arm** - literally the same binary, one
md5 across six copies - run as six arms: after balancing the traversal direction the residual is
**+-0.10 pp**, while **within a single pass the spread by position alone reaches 0.52% forward and
0.82% backward** with no code difference whatever. A single pass over six arms therefore proves
nothing here. Second, an **inert arm** carrying this commit's exact kernel signature and constant
bank (936 bytes, identical mangled name) with only the `prefetch.global.L2` removed: it reads 0.00
against the null arm on a shared position pair, which is what shows the module relay itself costs
nothing.

Prefill at 4095 tokens deserves its own line, because an earlier ladder of mine read **-0.83%**
there. It does not reproduce. In that ladder the arm carrying this change stood **fourth of seven**,
and reversing a seven-arm order leaves the fourth arm exactly where it was - so the traversal
reversal, the only control that ladder had against a positional artefact, never moved this arm at
all. Re-measured with the arm placed both in the middle and at the edge of the order it reads
**-0.19%** and **+0.02%**, averaging to zero against the null arm; on the older base that ladder
used it reads **-0.05%**. **Net: decode +2.88 to +3.28%, prefill zero within +-0.1 pp.**

> **Retracted, 2026-09-04.** This paragraph used to read: "Prefill is unchanged: -0.09% to -0.32%
> across the four points, with the null arm moving -0.07% to -0.20% at the same points. Prefill
> cannot be affected - a chunk of 128 or more tokens takes the prefill route, which does not call
> this launcher." Three things were wrong with it and all three are fixed above. The range
> `-0.09%...-0.32%` is **not in the raw data** - no cell of either prefill table holds -0.09%.
> "Prefill cannot be affected" was **argued, not measured**, and the argument does not cover the
> constant-bank growth this commit causes. And the -0.83% regression an internal review raised
> against this commit is withdrawn on measurement rather than on argument: it is not a property of
> the code. What produced it on that host cannot be reconstructed from the saved raw data, and that
> is said here rather than replaced with a guess.

### The two measurements reconcile on `ad0f3d38`, and no longer do across bases

**On `ad0f3d38`, where both numbers were taken:** 40 MoE layers times 4.096 us is 163.8 us per
token, the whole isolated cold-flush benefit. End to end at context 1000 the step goes from 2684.6
to 2599.3 us, i.e. **85.3 us, 52% of that ceiling**. Below the isolated ceiling and in the right
direction: the engine's L2 is partly warm where the bench deliberately flushes 256 MiB before each
replay.

> **This reconciliation cannot be carried onto `487f8977`, and this report does not carry it.**
> The re-measured operator saving there is **2.048 us per call**, so the same arithmetic gives
> 40 x 2.048 = **81.9 us per token** as the isolated ceiling - and the end-to-end saving of 85.3 us,
> which was **not** re-measured, would then be **104 % of it**. A part exceeding its own whole is
> the arithmetic saying out loud what is true: **the two numbers now come from two different
> trees**, and mixing them is not a reconciliation. Restoring it needs the end-to-end ladder
> re-measured on the current base, which has not been done. Until it is, the operator figure
> (-6.67 %, measured on `487f8977`) and the end-to-end figures (+2.88 to +3.28 %, measured on
> `ad0f3d38`) stand as two separate statements about two separate bases, and neither is offered as
> evidence for the other.

**And the saving is stall, not traffic.** The warmed plane is 1 MiB per layer, 40 MiB per token; at
the read ceiling measured on this card (1689.4 GB/s) those bytes cost **24.8 us**. The measurement
saves **85.3 us, 3.4x more time than the data could possibly take from DRAM at peak**. So this is
not a bandwidth saving.

**The re-measured operator number says the same thing, and this form of the argument survives the
base change** because both of its terms live on `487f8977`. One layer's warmed plane is 1 MiB =
1 048 576 bytes; at 1689.4 GB/s those bytes cost **0.62 us**. The re-measured saving is
**2.048 us**, i.e. **3.3x more time than the data could take from DRAM at peak** - the same ratio
the end-to-end pair gave on the old base, 3.4x. The saving got smaller; its character did not.

What the change removes is the cold miss at the head of the ninth warp's dependent chain,
and with it the wait the block's other eight warps were serving.

### Roofline

The ceilings here are our own measurements of this card, not datasheet numbers: DRAM read
**1689.4 GB/s**, two independent runs agreeing to within 0.2%.

At T = 1 the decode MoE step moves its unique weight - **18 812 928 bytes**, the bench's own
`unique_weight` column - and the two arms move it in the times re-measured on `487f8977`:

| arm | time, us | GB/s | share of the 1689.4 GB/s measured read ceiling |
|---|--:|--:|--:|
| master | 30.720 | **612.4** | **36.2%** |
| this branch, re-measured on `487f8977` | **28.672** | **656.1** | **38.8%** |
| ~~this branch, as claimed on `ad0f3d38`~~ | ~~26.624~~ | ~~706.6~~ | ~~41.8%~~ |

**All three rates are the bench's own printed `unique_weight` values, and the arithmetic is shown
so nothing has to be taken on trust.** The re-run printed 612.4 GB/s on `base` and 656.1 GB/s on
`cand`; the shares of the ceiling are mine, one division each:

```
bytes  = 612.4 GB/s x 30.720 us = 18 812 928 B       (the bench's unique_weight at T=1)
check  = 18 812 928 B / 28.672 us = 656.14e9 B/s  -> 656.1 GB/s, matches the printed value
check  = 18 812 928 B / 26.624 us = 706.62e9 B/s  -> 706.6 GB/s, matches the old printed value
share  = 612.4 / 1689.4 = 0.36249                 -> 36.2%    (master)
share  = 656.1 / 1689.4 = 0.38837                 -> 38.8%    (this branch, re-measured)
share  = 706.6 / 1689.4 = 0.41825                 -> 41.8%    (this branch, as claimed before)
```

So the rates are **measured** - printed by the bench on both bases - and the three shares are
**derived**, one division apiece against a ceiling this project measured itself. The improvement
this branch buys against the read ceiling is **+2.6 percentage points**, where the old text claimed
+5.6.

The kernels of this step are **SIMT, not MMA**: the body is scalar `fmaf` over the code planes plus
a warp reduction, and there is no `mma` instruction anywhere in
`src/ops/sparse_moe/decode/sparse_moe_decode_kernels.cu` (19 `fmaf`, 5 `warp_reduce_sum`, zero
`mma`, on the base this branch targets). The measured MMA peaks (253.4 TFLOP/s f32-accumulator,
502.9 f16-accumulator) therefore do not describe this operation at all, and I am not quoting a
share of them. The only ceiling that applies is weight-read bandwidth, and the numbers above are
against it.

> **Retracted, 2026-09-04 - two defects, both in this block.** It read: "At T=1 the decode MoE step
> moves its unique weight at 611.8 GB/s on master - **34.1% of the 1792 GB/s theoretical GDDR7
> ceiling**, 36.2% of the 1689.4 GB/s read ceiling measured on this card. On this branch the same
> bytes arrive in 26.624 us: 706.0 GB/s, 41.8% of the measured read ceiling. Arithmetic is nowhere
> near binding - **1.88 TFLOP/s logical against the 253.4 TFLOP/s f32-accumulator `mma` peak**
> measured on this card."
>
> First, **1792 GB/s is the GDDR7 datasheet figure and has no business in a roofline denominator**;
> the measured read ceiling of this card is 1689.4 GB/s. That the datasheet number happened to
> flatter us *less* (34.1% instead of 36.2%) does not make it admissible. Second, **the tier was
> named wrongly**: this step never issues an `mma`, so a share of the MMA peak compares against an
> instruction that is not in the kernel - it describes no headroom at all. Third, and smaller:
> 611.8 and 706.0 GB/s were not traceable to the bench, which prints **612.4** and **706.6** (and
> 705.8 in the first pass); the printed values are used above.

## Correctness evidence

Bit-exact by construction, and gated in both speculation modes.

`apps/ninfer`, greedy, `--seed 1`, `--max-new 160`, **`--max-context 16384` given explicitly**, four
prompts (a short instruction, a code request, an arithmetic chain, and a 150-record log of about
7 500 tokens), five arms alternated - `origin/master` plus this branch and the other candidates of
the same campaign - two repetitions, each in both `mtp0` - no speculative flag - and
`--spec mtp --draft-tokens 3`. 80 runs, 64 candidate-to-baseline comparisons.

| | result |
|---|--:|
| candidate responses equal to master by length and MD5 | **64 of 64** |
| responses below the 40-byte floor | **0** (485 to 655 bytes) |
| baseline repeatability, repetition 1 against repetition 2 | 8 of 8 |

**The gate was checked for sensitivity, not only for agreement**, because a gate that cannot
separate things which really do differ proves nothing by agreeing:

- *Inside the battery*: the same binary at mtp0 and mtp3 produces different bytes on 3 of the 4
  prompts.
- *Against a deliberately different configuration*: the baseline binary run with `--kv-dtype int8`
  instead of `bf16` changes the output on every prompt tried (short: 651 B `0e8b6b28...` against
  625 B `037c1976...`), while `bf16` reproduces its own bytes exactly across repeats.
- *Against the known trap*: the same long prompt run **without** `--max-context` returns **0 bytes,
  twice** - the engine's 2048-token default truncates it - which is exactly the state in which two
  arms "agree" because neither produced anything. The 40-byte floor is what separates that from a
  pass.

That floor earned its place the hard way: an earlier run of this same battery returned 80 empty
responses, because `apps/ninfer` takes the artifact path positionally and it had been passed after
a flag. Every MD5 agreed. Only the length check noticed.

`ctest`: **104 tests, 104 passed, 0 failed** on `0c211d8e`, base `a140e7ae`. Release, `sm_120a`,
`BUILD_TESTING=ON`, `ninja -j 32`, run under the host's GPU lock, 355.35 s wall.
The tested commit is this branch cherry-picked onto today's `origin/master` `a140e7ae`; the packaged
branch sits on its parent `e3aeaf8c`, and the net change is the same object either way (identical
`git patch-id --stable`).

Two details worth stating rather than hiding:

- Six of the 104 are the real-weight engine tests, which `ctest` reports as skipped unless
  `NINFER_QWEN3_6_27B_WEIGHTS` / `NINFER_QWEN3_6_35B_A3B_WEIGHTS` are set. 98 ran and passed.
- Rerun with those two set, five of the six pass on this branch - including
  `ninfer_qwen3_6_35b_a3b_real_test` and `ninfer_qwen3_6_35b_a3b_dflash_real_test`, which are the
  ones that actually drive the changed decode path. `ninfer_qwen3_6_27b_load_plan_test` still
  skips, and `ninfer_qwen3_6_27b_prefix_real_test` fails with `normalized first response did not
  restore its response checkpoint: path=5 reused=267`. **That failure is not this branch**: bare
  `a140e7ae` with no patch at all fails the same test with the same message in the same time
  (49.41 s on the base vs 47.89 s here). It is the test `a140e7ae` itself added, over engine
  prefix reuse, and it may simply want artifacts this box does not have. Reported, not worked
  around; nothing was changed to make it pass.

> **Superseded on 2026-09-04 by upstream `b8786751`, and the correction runs the other way.**
> `b8786751` (`fix(runtime): correct aliased state ownership`) is the maintainer's fix for exactly
> that failure, and it grew that test file by 264 lines. Re-measured the same day on one host with
> the same artifacts: the test **fails on bare `a140e7ae` in 49.31 s** with that identical message
> and both counters (`path=5 reused=267`), and **passes on bare `b8786751` in 126.77 s**, together
> with the other five real-weight tests, 6 of 6. The sentence "that failure is not this branch,
> the bare base fails it too" **no longer holds on the base this branch targets**: on `b8786751` the
> bare base passes, so the test is a live check and a failure of it here would be this branch's. The
> paragraph above is kept as the record of what was true on `a140e7ae`; the arm's own run on
> `b8786751` is what governs. Guessing that the test "wants artifacts this box does not have" was
> also wrong, and is retracted: the artifacts were present in both runs, and what changed was the
> base.

## Tradeoffs and boundaries

- **Cost, measured.** `cuobjdump --dump-resource-usage` on `sparse_moe_d1_kernel`: registers
  20 -> 20, static shared 1056 -> 1056 bytes, stack 0, local 0, spills 0. Constant bank 0 grows
  920 -> 936 bytes, which is the two added kernel parameters. No workspace, no resident memory, no
  transfer, no graph node, no change of launch order.
- **It pays only in non-speculative decode.** With MTP the main forward runs at T = draft + 1,
  which takes the small-T route; only the one-layer draft head still uses this launcher. Measured
  with `--spec mtp --draft-tokens 3`: +0.05%, +0.05%, -0.00%, +0.00% at the four contexts against a null
  arm at +-0.01%. It is zero there, not negative. The same idea on the small-T route is untested
  and is not part of this PR.
- **It pays only on a MoE artifact.** The dense 27B never enters this launcher.
- **The 52% realisation is artifact-specific.** How much of `shared_down` is still resident when D1
  runs depends on the weight traffic the surrounding layer generates. Measured on one artifact; a
  model with a different weight-per-layer footprint lands somewhere else between 0 and the isolated
  ceiling. That ceiling is **81.9 us** on the submitted base (40 layers x 2.048 us); the figure
  `163.8 us` printed in earlier editions of this report was the `ad0f3d38` value (40 x 4.096 us)
  and is superseded together with the headline, see *Re-measured on master* above.
- **Prefetch is a hint.** Should a future part drop `prefetch.global.L2`, this becomes a no-op with
  the same output, not a defect.
- **Not measured.** No `ncu` counters: `RmProfilingAdminOnly` is set on this host, so the account of
  a cold miss on the dependent chain rests on the timed operator arms and the L2 capacity argument,
  not on measured DRAM sectors.

## Reproduction

```bash
# base
git checkout e3aeaf8c
cmake --build build -j --target ninfer_sparse_moe_bench ninfer_bench ninfer
# candidate: this commit on top of e3aeaf8c, same build directory, same flags

# operator; the cold column is the authoritative one
build/bench/ninfer_sparse_moe_bench --codec q4-q5 --sweep 1:8 --execution graph \
    --cache both --warmup 10 --repeat 400 --seed 7

# end to end, both modes
build/bench/ninfer_bench --weights qwen3_6_35b_a3b.ninfer \
    -pg "128,128;1000,128;4095,128;12000,128" -r 10 --warmup 2 --max-ctx 16384   # mtp0: no --spec
build/bench/ninfer_bench --weights qwen3_6_35b_a3b.ninfer \
    -pg "128,128;1000,128;4095,128;12000,128" --spec mtp --draft-tokens 3 -r 10 --warmup 2 --max-ctx 16384

# identity, both modes; --max-context must be set explicitly, the default 2048 silently
# truncates a long prompt and makes two empty outputs compare equal
build/apps/ninfer qwen3_6_35b_a3b.ninfer --prompt "$(cat prompt.txt)" \
    --max-context 16384 --max-new 160 --greedy --seed 1 --raw-output
```

## Speculation counters: how much of this number is round count, and how much is round speed

*Added 2026-09-06 after a dedicated audit of every decode headline I have prepared for this
project. That audit was run with my own harness outside this repository and is **not a file
of this package**; it is named only to say where the section came from, and nothing below
leans on it - its own logs can be supplied on request. The section answers, from this
package's own raw, the one question a throughput figure in tokens per second cannot answer
by itself.*

`ninfer_bench` reports decode as generated tokens over elapsed time. A change that alters the
numbers the model produces can alter **draft acceptance**, and with it the number of speculative
rounds spent on the same fixed output length. Such a change raises tokens per second without any
kernel running faster. The two effects separate exactly, because the bench prints the round count
itself:

    decode_time(base) / decode_time(arm)  =  [ rounds(base) / rounds(arm) ]  *  [ t(base) / t(arm) ]

where `t = decode_seconds_mean / spec_rounds` is the time of one round. `spec_rounds` is an exact
integer printed by the engine and `decode_seconds_mean` is the measured time, so the split is an
identity rather than a model.

**This package: the round count is identical across every arm, so the whole figure is round speed.**
Raw: `data/pg_main.txt` (and the clean-passes subset `data/pg_clean_passes123.txt`), which carries
the `spec acc` and `spec round/fb` columns for **7 arms x 4 points x 4 passes**.

* At `mtp0` - no speculative flag - the operating point of the headline, both counters read `n/a`: there
  are no speculative rounds at all, one target forward per generated token, and the round count is
  fixed by `n_gen` for every arm by construction.
* At `--spec mtp --draft-tokens 3` in the same file all seven arms print the same acceptance and the same
  round count at every point, to the last digit: `0.2955665025 / 680` (pp128), `0.3567567568 / 620`
  (pp1000), `1 / 320` (pp4095), `0.9595959596 / 330` (pp12000). That is the check that these
  counters are printed and do respond; the mtp0 rows are not silence from a dead column.

**Which proposal head this was taken at.** Every cell cited above ran at the product default
`ProposalHead::Full` (`include/ninfer/types.h:82`). The audit put the same question to
`--lm-head-draft`, the configuration `docs/performance.md` publishes in, on Qwen3.6-35B-A3B at
`-pg 2048,384 --prefill-chunk 8192 --spec mtp --draft-tokens 3`: a bit-exact arm and the base agree there
as well - **690 rounds and acceptance 0.7819767442 in both** - so the split is the same under
either head. A **non**-bit-exact arm measured beside them in the same ladder does move the count
(714 rounds, acceptance 0.7422969188), which is what shows the instrument would have caught a
substitution had there been one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
