### PR TITLE
perf(nvfp4): rasterise the W4A4 TMA CTAs token-fastest, and fetch each activation-scale box once

### DIFF
--- a/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
+++ b/src/ops/linear/nvfp4/nvfp4_w4a4_tma.cuh
@@ -133,6 +133,21 @@ struct Nvfp4W4a4TmaSharedStorage {
     alignas(8) std::uint64_t empty[Schedule::kStages];
 };
 
+// The work distributor hands CTAs to SMs in linear order with blockIdx.x fastest, so the
+// stock grid -- x over weight-row tiles, y over token tiles -- puts a different weight tile
+// in every CTA that runs at the same time, and the whole weight matrix is re-read from
+// memory once per token tile. Walking the token index fastest instead makes the CTAs that
+// share a weight tile run together, and the matrix is read once. bf16_gemm_mma_kernel
+// already makes this choice; Bf16MmaRaster::TokenFast is the default for every bf16
+// schedule in the tree.
+__device__ __forceinline__ void nvfp4_tma_raster_blocks(int& block_x, int& block_y) {
+    const int rows = static_cast<int>(gridDim.y);
+    const int linear =
+        static_cast<int>(blockIdx.y) * static_cast<int>(gridDim.x) + static_cast<int>(blockIdx.x);
+    block_y = linear % rows;
+    block_x = linear / rows;
+}
+
 __device__ __forceinline__ void nvfp4_tma_load_2d(void* destination, const CUtensorMap* descriptor,
                                                   std::int32_t coordinate0,
                                                   std::int32_t coordinate1,
@@ -152,11 +167,15 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
     const __grid_constant__ Epilogue epilogue, const __grid_constant__ OutputPolicy output) {
     static_assert((Geometry::kInputRows % Schedule::kBlockK) == 0);
     static_assert((Geometry::kOutputRows % Schedule::kBlockN) == 0);
+    static_assert(Schedule::kStages >= 2, "the activation-scale buffer needs two slots");
 
     extern __shared__ __align__(128) unsigned char shared_bytes[];
-    auto& shared          = *reinterpret_cast<Nvfp4W4a4TmaSharedStorage<Schedule>*>(shared_bytes);
-    const int token_begin = static_cast<int>(blockIdx.y) * Schedule::kBlockM;
-    const int row_begin   = static_cast<int>(blockIdx.x) * Schedule::kBlockN;
+    auto& shared = *reinterpret_cast<Nvfp4W4a4TmaSharedStorage<Schedule>*>(shared_bytes);
+    int block_x  = 0;
+    int block_y  = 0;
+    nvfp4_tma_raster_blocks(block_x, block_y);
+    const int token_begin = block_y * Schedule::kBlockM;
+    const int row_begin   = block_x * Schedule::kBlockN;
 
     if (threadIdx.x == 0) {
 #pragma unroll
@@ -180,12 +199,19 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
                 const int stage                 = k_tile % Schedule::kStages;
                 const std::uint32_t empty_phase = 1U ^ ((k_tile / Schedule::kStages) & 1U);
                 cta_mbarrier_wait(&shared.empty[stage], empty_phase);
+                constexpr std::uint32_t kScaleBytes =
+                    Schedule::kBlockM * Schedule::kScaleWordsPerRow * 4;
                 constexpr std::uint32_t kTransactionBytes =
                     Schedule::kBlockM * Schedule::kCodeRowBytes +
-                    Schedule::kBlockN * Schedule::kCodeRowBytes +
-                    Schedule::kBlockM * Schedule::kScaleWordsPerRow * 4 +
+                    Schedule::kBlockN * Schedule::kCodeRowBytes + kScaleBytes +
                     Schedule::kBlockN * Schedule::kK64PerStage * 4;
-                cta_mbarrier_arrive_expect_tx(&shared.full[stage], kTransactionBytes);
+                // TMA's innermost box cannot be narrower than 16 bytes and 16 bytes of
+                // activation scales cover two K tiles, so the box is fetched on the even tile
+                // only and the odd tile expects that many bytes fewer.
+                const bool load_scales = (k_tile & 1) == 0;
+                cta_mbarrier_arrive_expect_tx(&shared.full[stage],
+                                              load_scales ? kTransactionBytes
+                                                          : kTransactionBytes - kScaleBytes);
 
                 auto& tensors = shared.scratch.tensors;
                 nvfp4_tma_load_2d(tensors.a_codes[stage], &descriptors.a_codes,
@@ -193,8 +219,10 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
                                   &shared.full[stage]);
                 nvfp4_tma_load_2d(tensors.b_codes[stage], &descriptors.b_codes,
                                   k_tile * Schedule::kCodeRowBytes, row_begin, &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.a_scale4[stage], &descriptors.a_scales, (k_tile / 2) * 16,
-                                  token_begin, &shared.full[stage]);
+                if (load_scales) {
+                    nvfp4_tma_load_2d(tensors.a_scale4[(k_tile / 2) & 1], &descriptors.a_scales,
+                                      (k_tile / 2) * 16, token_begin, &shared.full[stage]);
+                }
                 const int b_scale_row = ((row_begin / 128) * Geometry::kScaleTilesPerRow +
                                          k_tile * Schedule::kK64PerStage) *
                                         32;
@@ -249,8 +277,9 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_w4a4
                             a_fragments[mma_m][3], smem_addr(address));
                 const int scale_row = warp_m * Schedule::kWarpM + mma_m * 16 + sfa_row;
                 a_scales[mma_m] =
-                    tensors.a_scale4[stage][scale_row * Schedule::kScaleWordsPerRow +
-                                            (k_tile & 1) * Schedule::kK64PerStage + local_k64];
+                    tensors.a_scale4[(k_tile / 2) & 1][scale_row * Schedule::kScaleWordsPerRow +
+                                                       (k_tile & 1) * Schedule::kK64PerStage +
+                                                       local_k64];
             }
 
 #pragma unroll

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cuh
@@ -65,8 +65,12 @@ __global__ __launch_bounds__(
 
     extern __shared__ __align__(128) unsigned char shared_bytes[];
     auto& shared = *reinterpret_cast<Nvfp4LinearSwiGluTmaSharedStorage<Schedule>*>(shared_bytes);
-    const int token_begin = static_cast<int>(blockIdx.y) * Schedule::kBlockM;
-    const int pair_begin  = static_cast<int>(blockIdx.x) * kPairN;
+    static_assert(Schedule::kStages >= 2, "the activation-scale buffer needs two slots");
+    int block_x = 0;
+    int block_y = 0;
+    nvfp4_tma_raster_blocks(block_x, block_y);
+    const int token_begin = block_y * Schedule::kBlockM;
+    const int pair_begin  = block_x * kPairN;
 
     if (threadIdx.x == 0) {
 #pragma unroll
@@ -90,12 +94,19 @@ __global__ __launch_bounds__(
                 const int stage                 = k_tile % Schedule::kStages;
                 const std::uint32_t empty_phase = 1U ^ ((k_tile / Schedule::kStages) & 1U);
                 cta_mbarrier_wait(&shared.empty[stage], empty_phase);
+                constexpr std::uint32_t kScaleBytes =
+                    Schedule::kBlockM * Schedule::kScaleWordsPerRow * 4;
                 constexpr std::uint32_t kTransactionBytes =
                     Schedule::kBlockM * Schedule::kCodeRowBytes +
-                    Schedule::kBlockN * Schedule::kCodeRowBytes +
-                    Schedule::kBlockM * Schedule::kScaleWordsPerRow * 4 +
+                    Schedule::kBlockN * Schedule::kCodeRowBytes + kScaleBytes +
                     2 * Schedule::kBlockN * Schedule::kK64PerStage * 4;
-                cta_mbarrier_arrive_expect_tx(&shared.full[stage], kTransactionBytes);
+                // TMA's innermost box cannot be narrower than 16 bytes and 16 bytes of
+                // activation scales cover two K tiles, so the box is fetched on the even tile
+                // only and the odd tile expects that many bytes fewer.
+                const bool load_scales = (k_tile & 1) == 0;
+                cta_mbarrier_arrive_expect_tx(&shared.full[stage],
+                                              load_scales ? kTransactionBytes
+                                                          : kTransactionBytes - kScaleBytes);
 
                 auto& tensors = shared.scratch.tensors;
                 nvfp4_tma_load_2d(tensors.a_codes[stage], &descriptors.a_codes,
@@ -107,8 +118,10 @@ __global__ __launch_bounds__(
                 nvfp4_tma_load_2d(tensors.b_codes[stage] + kPairN * Schedule::kCodeRowBytes,
                                   &descriptors.b_codes, k_tile * Schedule::kCodeRowBytes,
                                   pair_begin + kIntermediate, &shared.full[stage]);
-                nvfp4_tma_load_2d(tensors.a_scale4[stage], &descriptors.a_scales, (k_tile / 2) * 16,
-                                  token_begin, &shared.full[stage]);
+                if (load_scales) {
+                    nvfp4_tma_load_2d(tensors.a_scale4[(k_tile / 2) & 1], &descriptors.a_scales,
+                                      (k_tile / 2) * 16, token_begin, &shared.full[stage]);
+                }
 
                 const int gate_scale_row = ((pair_begin / 128) * Geometry::kScaleTilesPerRow +
                                             k_tile * Schedule::kK64PerStage) *
@@ -171,8 +184,9 @@ __global__ __launch_bounds__(
                             a_fragments[mma_m][3], smem_addr(address));
                 const int scale_row = warp_m * Schedule::kWarpM + mma_m * 16 + sfa_row;
                 a_scales[mma_m] =
-                    tensors.a_scale4[stage][scale_row * Schedule::kScaleWordsPerRow +
-                                            (k_tile & 1) * Schedule::kK64PerStage + local_k64];
+                    tensors.a_scale4[(k_tile / 2) & 1][scale_row * Schedule::kScaleWordsPerRow +
+                                                       (k_tile & 1) * Schedule::kK64PerStage +
+                                                       local_k64];
             }
 
 #pragma unroll


### PR DESCRIPTION
> ### Rebased onto `a16b6442`. Where the numbers below come from
>
> **Base.** This package was written against `ad0f3d38` and now targets upstream **`a16b6442`**
> (`docs: organize performance reports and update 35b results`). Its parent is **`487f8977`**
> (`perf(sparse_moe): one CTA per token in small-T S2, and a warp merge in place of eight
> dependent rounds`), which is the commit the rebase and the operator re-measurement below were
> carried out on; master moved one commit further while this was being prepared. That one commit
> touches **thirteen files, all of them documentation** - `README.md`, `docs/`, `eval/README.md`,
> `model-cards/`, `tools/bench/README.md` - and no source, header, kernel, test or bench file, so
> every code citation and every number in this report reads the same on `487f8977` and on
> `a16b6442`. `ad0f3d38` and the earlier heads still named throughout this report are the commits
> the original work was **done and measured on**. They are left standing rather than rewritten, so
> that every number below stays attached to the tree it was actually taken from.
>
> **Provenance of every number.** Except where a table says otherwise, every timing, ratio,
> percentage, bandwidth, TFLOP/s figure, register and shared-memory count and `ctest` line in this
> report was measured on `ad0f3d38`, or on an earlier head named at the point of use.
> **One thing has been re-measured on `487f8977`: the operator sweep.** Its shape held and its top
> end did not - **x1.09 to x1.20** on the re-run against the **x1.08 to x1.25** this report claims
> below, with x1.25 at T = 8192 coming back as **x1.2036**. Both are printed side by side in
> "Operator, re-measured on the new base". **Nothing else here has been re-measured on `487f8977`**
> - no end-to-end number, no roofline figure, no `ctest` run and no bitwise gate. Two changes to
> the instrument itself bear on that, and are stated once here
> instead of being repeated at every table:
>
> * **The engine context cache changed sides.** On `487f8977` `ninfer_bench` switches it off
>   itself - `engine_options.context_cache.enabled = false`,
>   `bench/targets/qwen3_6_27b/ninfer_bench.cpp:157`, introduced upstream by `385b30ce`. On
>   `ad0f3d38` that line does not exist at all, so the bench inherited the engine default
>   `ContextCacheOptions::enabled = true` (`include/ninfer/types.h:130` there, `:132` here) and
>   every end-to-end run behind this report was taken with the cache **constructed**. Two bounds
>   on how far that reaches, both stated because the difference has **not** been measured. From
>   above: a live context cache can serve a prefix and shorten a prefill, which for prefill and
>   TTFT would be a first-order difference rather than a rounding one. From below: the bench also
>   sets `options.execution.allow_prefix_reuse = false` on every request
>   (`bench/targets/qwen3_6_27b/ninfer_bench.cpp:65`) - **byte-identical on both bases** - so no
>   request in these runs was eligible for a prefix hit at all, and what the old configuration
>   carried was a constructed-but-unused cache (host state slots and pinned host KV) rather than
>   served prefixes. Which bound is nearer the truth is an open question here; until it is
>   measured, read the prefill and TTFT figures as taken in a configuration the current bench no
>   longer builds.
> * **The bench flag was renamed.** `--mtp-draft-tokens` no longer exists anywhere in the tree.
>   The current spelling is `--spec mtp --draft-tokens N`
>   (`bench/targets/qwen3_6_27b/ninfer_bench_support.cpp:356-359`), the same pair the product CLI
>   takes (`apps/cli/options.cpp:141-145`). Every reproduction line below has been rewritten to the
>   current spelling; the runs behind the numbers used the old one. One trap in that rename is
>   worth naming: `--spec mtp --draft-tokens 0` is **rejected** - `validate_speculative_cli_options`
>   requires `[1,5]` for MTP (`src/product/speculative_options.h:41`) - so the zero-draft arm,
>   written `--mtp-draft-tokens 0` throughout the old text and called `mtp0` below, is spelled on
>   the current bench by passing **neither** flag, which is already the default
>   (`SpeculativeBackend::None`).
>
> **Registered tests.** `tests/CMakeLists.txt` moved as well. The suite that registered **104**
> targets on `ad0f3d38` registers **114** on `487f8977` (+10 targets), and one more of them is
> artifact-gated: **20** named targets now carry an explicit `SKIP_RETURN_CODE 77` against
> **19** on `ad0f3d38`, on top of the blanket rule inside `ninfer_add_op_test` that marks
> every op test skippable. The addition is `ninfer_qwen3_8_27b_dflash2_real_test`, gated on
> weights like the rest, so one further test skips on a host that carries none. Every `ctest` count printed below is consequently a
> statement about `ad0f3d38` or an earlier head, not about the current base; the counts are left
> in place rather than restated, with the base each belongs to named beside it.
>
> **No `ctest` run in this report has been repeated on `487f8977`, and no round "114 of 114" is
> claimed for it.** Two facts forbid that claim. `ninfer_attn_input_proj_test` is **red on the
> bare base** - an upstream defect, filed as issue #196, not something this branch introduces.
> And `ctest` and a direct run of the same test binary have been observed to disagree on this
> host, so a green `ctest` is not by itself evidence of anything. The only formulation this
> package will stand behind on the new base is the exact one: **the arm's result matched the
> base, and the single failure reproduces on bare `487f8977`.**
>
> **Line references re-checked against `487f8977`.** Every `file:line` citation in this report was
> opened on the new base. The ones that moved are corrected in place; the number each one used to
> carry is kept here so nothing is replaced silently.
>
> | citation | printed here before | on `487f8977` | what stands at the old number now |
> |---|---|---|---|
> | `src/targets/qwen3_6/impl/state/round_state.cpp`, the DFlash allocation gate | `:176` | **`:174`** | `:176` is inside the block, not its condition: `DFlashDecodeStateLayout& decode = layout.dflash_decode.emplace();` |
> | `include/ninfer/types.h`, the backend default | `:78` | **`:79`** | `:78` is the opening line `struct SpeculativeOptions {` |
> | `src/serve/serve_options.h`, `SpeculativeOptions speculative;` | `:46` | `:46` | unchanged - re-checked, still correct |
>
> **The gate this report quotes no longer exists, and the real one is wider.** The text below
> quoted `if (layout.spec.enable_dflash)`. The field `enable_dflash` is gone from the tree
> entirely - `git grep enable_dflash origin/master` finds it only inside the frozen code samples
> under `eval/corpora/`. `round_state.cpp:174` now reads
> `if (is_masked_draft_backend(layout.spec.backend))`, and that predicate is
> `backend == SpeculativeBackend::DFlash || backend == SpeculativeBackend::DFlash2`
> (`src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h:7-9`). So the gate admits
> **both `--spec dflash` and `--spec dflash2`**, not `--spec dflash` alone, and the quotation and
> the "reachable only through `--spec dflash`" wording have been corrected wherever they appeared.
> The conclusion the paragraph draws is unaffected: the default is still
> `SpeculativeBackend::None`, and no measurement in this report passes either flag.

## Base

Base `origin/master` @ **`ad0f3d38`** (`chore: add project funding information`),
checked **2026-09-05** with `git ls-remote https://github.com/Neroued/ninfer.git
refs/heads/master` rather than through a clone's `origin`, which can point at a stale local
mirror. The branch has been rebased across every intervening head - `a140e7ae` -> `b8786751`
(2026-09-04) -> `ad0f3d38` (2026-09-05) - with **no conflict at either step** and
`patch-id --stable` of the change unchanged throughout. `ctest` on the bare `b8786751` is
**104 of 104, 0 failed**, with the same six artifact-gated tests skipped;
`tests/CMakeLists.txt` is byte-identical on all three bases, so the registered count does not
move. Note that `master` and `dev` no longer agree: `dev` is one commit behind, at `863aa8a5`.

The two commits added since `b8786751` are `863aa8a5` (`fix(dflash): allow vision prompts`) and
`ad0f3d38` (`chore: add project funding information`). Nothing in them is re-measured here, and
that is settled by a line of source rather than by the commit subject: everything the DFlash fix
adds is allocated under `if (is_masked_draft_backend(layout.spec.backend))`
(`src/targets/qwen3_6/impl/state/round_state.cpp:174`), behind a speculative backend whose
default is `SpeculativeBackend::None` in every entry point (`include/ninfer/types.h:79`,
`src/serve/serve_options.h:46`), reachable only through an explicit `--spec dflash` or `--spec dflash2` that no
measurement in this report passes.

The end-to-end tables below were taken on `a140e7ae` and are carried across rather than
re-taken, and that is measured rather than assumed: a stock-against-stock control on
`ninfer_bench` (both binaries stock, four passes per arm, arms alternated, continuous card
witness reporting 48 samples with no foreign process) puts the upstream commit itself at
**-0.05%, -0.04%, -0.04% and +0.01%** on pp1024 / pp4096 / pp8192 / tg128, every one at or
below the within-arm spread of 0.03-0.16%. The commit also touches no file under `src/ops/`,
`apps/`, `bench/` or `src/serve/`, and both `ninfer_bench` and the CLI disable the
compatible-prefix cache this commit re-accounts (`bench/README.md`, `apps/cli/main.cpp:281`).

> **Note, against the block at the top of this report.** The "compatible-prefix cache" this
> sentence names is **per-request prefix reuse** - `bench/README.md:36`, and
> `options.execution.allow_prefix_reuse = false` at
> `bench/targets/qwen3_6_27b/ninfer_bench.cpp:65`, a line that is byte-identical on `a140e7ae`,
> `ad0f3d38` and `487f8977`. That is a different switch from the **engine context cache**
> (`engine_options.context_cache.enabled`), which `ninfer_bench` began setting to `false` only on
> `487f8977`. This sentence is correct as printed on every base named in it; the block at the top
> is about the other switch.


## Scope

One mechanism, one commit, two kernel headers. The NVFP4 W4A4 TMA GEMM reads more bytes than it
needs to, in two independent ways that live in the same two kernels and the same two lines of the
producer loop. Output is bit-for-bit unchanged.

The long-form analysis behind this - why the kernel is worth touching at all, where its ceiling is,
and what is left in it afterwards - is in `ISSUE_BODY.md` in this package; everything needed to
review the change is below.

## Design, and why it fits

**Block order.** Both kernels launched `grid(kOutputRows / kBlockN, tokens / kBlockM)` and read
`blockIdx.x` as the weight-row tile. CTAs are dispatched x-fastest, so concurrent CTAs never shared a
weight tile and the weight matrix was re-read once per token tile. `nvfp4_tma_raster_blocks` takes
both indices out of the linear CTA id with the token index fastest. This is the same choice
`bf16_gemm_mma_kernel` already makes for every bf16 schedule in the tree
(`Bf16MmaRaster::TokenFast`), so it introduces no new concept - it gives the NVFP4 kernels the
rasterisation the bf16 family already has.

**Activation-scale box.** TMA cannot address a box narrower than 16 bytes and 16 bytes of scales
cover two K tiles, so the load at `(k_tile / 2) * 16` was issued twice for the same bytes - 2048 of
the 29696 a K tile of the generic kernel moves, and of the 30720 the SwiGLU kernel moves, which
carries a second weight-scale box. It now runs on the even tile only, into two slots indexed
`(k_tile / 2) & 1`, with the odd tile's barrier expecting `kTransactionBytes - kScaleBytes`.

The two-slot lifetime is the only new invariant. A slot written for tile pair *p* is read by tiles
*2p* and *2p+1* and rewritten at tile *2p+4*; the producer for *2p+4* must first wait on
`empty[(2p+4) % kStages]`, which the consumer releases at the end of tile *2p+1* for `kStages == 3`
and at the end of *2p+2* for `kStages == 2`. The rewrite therefore cannot overtake the last read for
either instantiated stage count, and a `static_assert(Schedule::kStages >= 2)` states the
requirement in both kernels.

## Affected behavior and ownership

- Two kernel headers, `nvfp4_w4a4_tma.cuh` and `nvfp4_linear_swiglu_w4a4_tma.cuh`. No launcher, no
  route, no plan, no public signature changes.
- No workspace, resident-memory, transfer or graph-node change. The shared-memory request is
  identical: part 2 makes one of the three scale stages redundant but does not remove it.
- No new mutable global or thread-local state; the helper is a pure function of `blockIdx`/`gridDim`.
- Output is bit-for-bit unchanged. Part 1 only reassigns which CTA computes which output tile - the
  accumulation order inside a CTA is untouched. Part 2 delivers the identical bytes.

## Verification

Hardware and toolchain: one RTX 5090, `sm_120a`, driver 580.105.08, CUDA 13.1.115, gcc 13.3,
Ubuntu 24.04, Release, `-DCMAKE_CUDA_ARCHITECTURES=120a`, Ninja. Dedicated host, no other tenant; a
`flock` wrapper refuses to start a run while any process holds the card. Both arms built in the same
build directory; the same two binaries throughout each campaign. A table taken on a second host says
so in its own lead-in; everything else is this host.

Four bases, one line per fact. The numbers in this report were measured on `e3aeaf8c`. The branch
has since been rebased three times - onto `a140e7ae`, then `b8786751` (2026-09-04), then
**`ad0f3d38`** (2026-09-05), which is where it sits now - each time with no conflict and all four
`patch-id --stable` unchanged. They were not re-taken on the
new base. Where a section below names the second host, those arms were built and measured on
`a140e7ae` itself. `ctest` is 104 of 104 on `a140e7ae`; the full statement, and why the
count is quoted against a hash, is at the end of this section.

**Operator** (`ninfer_nvfp4_linear_swiglu_bench`, `N = 34816`, `K = 5120`, median of 20 after 5
warm-ups):

```bash
build/bench/ninfer_nvfp4_linear_swiglu_bench --policy a4 \
  --t-sweep 256,512,1024,2048,4096,8192 --warmup 5 --repeat 20
```

**Measured on `ad0f3d38`. Re-measured on `487f8977` the top of this range does not come back; the
re-run is the next subsection and the two are printed side by side.**

| T | master, us | this branch, us | ratio |
|--:|--:|--:|--:|
| 256 | 141.31 | 131.07 | x1.08 |
| 512 | 235.52 | 203.78 | x1.16 |
| 1024 | 423.94 | 350.21 | x1.21 |
| 2048 | 772.10 | 637.95 | x1.21 |
| 4096 | 1469.44 | 1190.91 | x1.23 |
| 8192 | 2879.49 | 2302.96 | x1.25 |

Both arms on the same base, two alternating passes each; raw output in `op_abab.txt`. Six of the
twelve cells read the same time in both passes, five differ by exactly 2.048 us
(1.0% at T=512, 0.32% at 2048 and 0.17% at 4096 on the branch arm; 0.14% and 0.07% at 4096 and 8192
on master) and the twelfth by 0.032 us. **That 2.048 us step is not a timer quantum**, and an
earlier version of this sentence called it one: the twelfth cell moving by 0.032 us is itself the
proof, and 0.032 us - 32 ns - is this instrument's actual resolution. What the 2.048 us steps
describe is a sharply peaked run-time distribution, not a grid the timer imposes.

### Operator, re-measured on the new base

Same command, same sweep, on `487f8977`: three arms - `base`, this branch, and a second copy of
`base` as a null control - six passes with pass 0 discarded, arms alternated within each pass,
a fresh process per cell.

| T | claimed above, on `ad0f3d38` | re-measured on `487f8977` | per-pass spread | null control |
|--:|--:|--:|--:|--:|
| 256 | x1.08 | **x1.0917** | 1.0792-1.0939 | x1.0012 |
| 512 | x1.16 | **x1.1510** | 1.1426-1.1520 | x1.0000 |
| 1024 | x1.21 | **x1.2024** | 1.1780-1.2065 | x1.0030 |
| 2048 | x1.21 | **x1.1878** | 1.1820-1.1935 | x1.0012 |
| 4096 | x1.23 | **x1.1837** | 1.1763-1.1868 | x0.9995 |
| 8192 | **x1.25** | **x1.2036** | 1.1948-1.2078 | x1.0028 |

**The shape reproduced; the top of the range did not.** The re-run reads **x1.09 to x1.20**, against
the **x1.08 to x1.25** claimed above. Every point except T = 256 comes back a little lower, and the
headline **x1.25 at T = 8192 is not reproducible - it is x1.20 there.** Where a range is quoted for
this commit from here on, both are given and the new one is the one this PR stands behind.

Noise floor: the null arm's medians sit at **x0.9995 to x1.0030**, i.e. within +-0.3%, so a 9 to 20%
effect clears it by an order of magnitude. One honest blemish: a **single per-pass** null point at
T = 8192 reads **1.0808**, and T = 8192 is exactly the cell carrying the headline x1.20. The median
of that null cell is x1.0028 and the candidate's own per-pass spread there (1.1948-1.2078) never
approaches the null outlier, but the outlier is named rather than dropped.

**Absolute microseconds from the re-run are deliberately not printed.** It was taken on a different
card from the one the table above used - a 575 W part behind WDDM with a desktop compositor on it -
whose absolute times run 15 to 30% above the bench figures (167.0 us against 141.3 us at T = 256).
Ratios measured within one run transfer; absolute times from that card do not go into a table
alongside bench numbers, so they are withheld rather than mixed in.

### The two parts separated, first-party

Measured on `ad0f3d38`; this split has **not** been re-taken on the new base.

A third binary was built with only the rasterisation half of
this commit applied, so the split is measured rather than asserted. Same tree, three binaries built in
turn, median of 20 after 5 warm-ups, two alternating passes:

Cells are the mean of the two passes; raw output in `split.txt`.

| T | master, us | rasterisation only, us | both, us | rasterisation alone | scale fetch alone |
|--:|--:|--:|--:|--:|--:|
| **256** | 141.31 | 142.34 | 132.10 | **x0.99** | x1.08 |
| 512 | 235.52 | 218.11 | 203.78 | x1.08 | x1.07 |
| 1024 | 421.89 | 386.05 | 350.21 | x1.09 | x1.10 |
| 2048 | 766.98 | 703.49 | 635.90 | x1.09 | x1.11 |
| 4096 | 1456.11 | 1320.96 | 1180.67 | x1.10 | x1.12 |
| 8192 | 2845.70 | 2590.21 | 2278.40 | x1.10 | x1.14 |

**The T=256 row is the control, and it behaves as the code says it must - but the timing is measured,
not deduced.** With one token tile the grid is one deep, so
`linear = blockIdx.y * gridDim.x + blockIdx.x` reduces to `blockIdx.x`, `block_y` to 0 and `block_x`
back to `blockIdx.x` - byte for byte the assignment the old code made. The block layout is therefore
provably identical; the run time is not, and it was measured rather than asserted. The two passes read
141.312 us and 143.360 us on the rasterisation-only arm against 141.312 us twice on master, so that
arm is between exactly equal and 2.048 us slower - one step of that peaked distribution, not one
tick of the timer, whose resolution is 32 ns: the cost of a few extra integer
instructions, visible precisely where the change cannot help. All of the x1.08 measured at 256 comes
from the scale fetch.

Above 512 rasterisation alone is worth x1.08 to x1.10 and the scale fetch x1.07 to x1.14; together
they compose to the x1.16 to x1.25 of the first table above - the `ad0f3d38` figures, which is the
base this split was taken on. Composed against the re-run instead they would have to reach x1.15 to
x1.20, and the split was not re-taken, so no claim is made that the two halves still divide the
smaller total in the same proportion.

**Roofline.** Two denominators are used, and both are our own direct measurements on this card rather
than vendor or benchmark constants: DRAM read **1689.4 GB/s**, and the arithmetic tier
**2003.9 TFLOP/s**, taken with the exact instruction these kernels issue -
`mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3`,
which appears in SASS as `OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X` - with operands resident in
registers, two independent runs agreeing to within 0.63% and the lower one taken. Provenance: this is
a direct measurement of the instruction in its product register form on this card, more honest than
quoting a constant compiled into a benchmark, but it is our own measurement, not a vendor figure. The
probe builds as `nvcc -O3 -gencode arch=compute_120a,code=sm_120a`; `-arch=sm_120a` alone is not
enough, ptxas then gets `.target sm_120` and rejects `kind::mxf4nvf4`.

At T=8192 on this geometry the kernel does `2 * 8192 * 34816 * 5120` = **2.92 TFLOP** (this used to
be printed as "2.92 PFLOP" - a unit slip; the digits and every figure derived from them are right,
the unit was not). In 2302.96 us that
is **1268 TFLOP/s, 63.3% of the tier**, against 2879.49 us and **1014 TFLOP/s, 50.6%**, on master.
That is where the change shows, and neither arm is anywhere near the tier.

**Both shares are `ad0f3d38` figures and are not restated for the new base.** They are computed from
the two absolute times of the first operator table, and the re-run that lowered the T = 8192 ratio to
x1.2036 was taken on a card whose absolute times do not transfer (see the note above). Carrying the
re-measured ratio onto the same master arm would put this branch at **1221 TFLOP/s, 60.9% of the
tier** - 2879.49 / 1.2036 = 2392.2 us, and 2.92 TFLOP / 2392.2 us = 1221 TFLOP/s - but that mixes a
time from one card
with a ratio from another, so it is offered as an order of magnitude and not as a measurement. The
measured statement is the ratio: **x1.20 at T = 8192 on `487f8977`.**

The byte side is reported as a traffic reduction rather than as a fraction of a ceiling, because what
this commit removes is L2-to-shared tile traffic and not DRAM traffic: 272 x 32 CTAs x 40 K tiles x
28672 bytes = 9.98 GB, against 10.70 GB before, **-6.7%**. Dividing that by the DRAM read ceiling
would be a category error, and the tile-delivery rate it used to be divided by is not one of the
measured card ceilings, so no fraction is quoted for it.

**End to end** (`ninfer_bench`, four arms interleaved, three passes each, fresh process per arm,
prefill chunk 4096, 5 measured repetitions after 2 discarded):

```bash
build/bench/ninfer_bench --weights qwen3_6_27b_nvfp4.ninfer \
  -p 1024,4096,8192 -n 128 -r 5 --warmup 2 --prefill-chunk 4096
```

prefill +9.29% at 1024 tokens, +8.13% at 4096, +7.65% at 8192; decode -0.1%, which is the thermal
drift visible in every arm. Pass-to-pass spread inside the baseline arm is 1.0-1.1%.

**Re-gated on the current base, this commit alone.** Upstream `a140e7ae` (`fix(engine): preserve
exact agent prefix reuse`) landed while this was being prepared and changes one of the four fixed
tasks' output on master itself. That makes the gate worth repeating per commit rather than for the
branch as a whole:

| arm | the task upstream moved |
|---|---|
| `origin/master` @ `a140e7ae` | len 96, md5 `a05c0fbe...` - twice |
| **+ this commit** | **len 96, md5 `a05c0fbe...` - twice, identical on all four tasks** |
| + the next commit (partial M tile) | len 132, md5 `2bdb77dd...` |

> **Retracted on 2026-09-04, and replaced by a measurement.** The three rows above were taken with
> `ninfer-serve`'s compatible-prefix cache at its shipped default, which is on. Re-taken on
> `b8786751` with `--no-prefix-reuse` on every arm, stepping the series one commit at a time
> (bare base, +this commit, +partial M tile, +route floor, +schedule thresholds, two rounds with the
> order reversed): **all five steps return the same bytes on all four tasks**, and the `long` task
> reads len 132 / md5 `2bdb77dd...` on the **bare base** as well. The 96-to-132 move is what the
> cache does, not what the route commit does, and attributing it to that commit is withdrawn.
>
> What this does **not** establish is that the route commit is bit-identical. The identity corpus is
> four short tasks; if their length sits below the TMA route floor (1024 tokens before the floor
> commit, 640 after) the partial-tile change is not on their path at all, and five matching steps
> would follow from any truth about it. Prompt lengths in tokens were not recorded in that run. The
> route commit remains declared non-bitwise, and this report no longer offers this table as evidence
> either way.

So the bitwise identity of this commit holds on the current base. The sentence that used to follow -
that the output change further down the branch belongs to the route commit - is withdrawn by the
note above; the route commit is still declared non-bitwise and still carries its own quality gate,
but this table is no longer offered as the evidence for it. Quality battery: see the re-taken verdict below.

**What the batteries below are, and what they are not.** They are a smoke test that the two arms
behave the same end to end. **They are not evidence that the numbers are right, and this report does
not offer them as such** - the load-bearing evidence for this commit is the bitwise identity of the
output, the three-math-mode gate with its cross-mode control, and the SASS census, all further down.
The reason for saying so is measured rather than assumed. On a twelve-rung corruption ladder built
by coarsening an activation quantiser from 127 levels down to 3, a long-needle battery of the same
shape reads **40 of 40 with word-for-word identical answers on every single rung**, including the
rung coarsened 42-fold, which the project's own FP64 operator oracle fails at **4.88x its limit**
(that ladder is a separate campaign of mine - **not files of this package and not in this
repository**, so this sentence is my report rather than something checkable from here; its two
summary files, one per instrument, can be supplied on request. It was built on the 35B W8-A8
route, so what transfers is the instrument's resolution, not the route). A needle battery
compares **40 words over the whole grid**. A 50-task score compares a score. Neither
can distinguish a correct arm from a badly corrupted one, so neither is quoted here as if it could.

What the batteries do establish, and it is worth having, is that the arms **agree with each other**
under one fixed configuration and that nothing degenerate happens - no empty answers, no truncation,
no divergence in answer length.

**Quality battery, re-taken on the submitted base with compatible-prefix reuse disabled.**
The verdict this report used to quote was taken against a master arm built from the head that
preceded the base this branch declares, so it did not compare against the base being submitted.
It has been re-taken on `b8786751` with `--no-prefix-reuse` on every arm, the control included:
four arms in the order master / this branch / master / this branch, all four identity tasks equal
by MD5 and by length in every arm, **44 of 50** on the quality battery with the miss set
`arith00, arith02, arith07, arith12, arith17, arith19` **identical in every arm**, 15/15 on the
long-needle battery, and zero empty responses anywhere. The card had a continuous witness sampling
every 5 s: 50 samples across the window, none with a foreign process.

> **Retracted 2026-09-05 - how this paragraph used to be offered.** The two figures above,
> `44 of 50` and `15/15`, stood in this report as part of the correctness case, in the same list as
> the bitwise gate. That framing is withdrawn for the reason measured on the ladder above: both
> instruments read clean on a build that fails the FP64 oracle four times out of four. The figures
> themselves are unchanged and are kept, because arm-to-arm agreement is still worth reporting; only
> the claim they were carrying is removed. The correctness case for this commit rests on the bitwise
> identity, the math-mode gate and the census, and nowhere on these two numbers.

**Two things about that number, both measured rather than argued.**

*The base is not what moves it.* A 2x2 on one host - `a140e7ae` against `b8786751`, each under
default flags and under `--no-prefix-reuse`, two rounds with the arm order reversed - returns
**byte-identical answers between the two bases in both flag settings**. So the stale-base defect in
the old verdict was a defect of process with no effect on the reading, and that is stated here
rather than dressed up as a discovered discrepancy.

*The flag is what moves it, and the battery has no headroom.* Switching that one shipped default -
`ninfer-serve` enables compatible-prefix reuse by default (`src/serve/serve_options.h:50`) - changes
2 of the 4 identity answers and takes the quality score from 42/50 to 44/50 **with a different miss
set**. The score is therefore quoted with its base, its flags and its host attached: what these arms
establish is that they agree with each other under one fixed configuration, not that the instrument
has room to spare. The flag is not an extra precaution of ours either - `bench/README.md` and
`docs/performance.md` say the project's own published measurements run with prefix reuse disabled.

**The identity is structural, not an artefact of one toolchain.** A bitwise claim that rests on a
single set of compiler flags is only an empirical one: a different math mode can re-associate an
unpinned multiply and pull the two arms apart. Both arms were therefore rebuilt under three math
modes and gated in each:

| mode | four fixed tasks, master vs this branch |
|---|---|
| default | identical, all four |
| `--use_fast_math` | identical, all four |
| `-fmad=false` | identical, all four |

The control that makes this worth reporting is the cross-mode comparison: on the master arm alone,
`default` and `--use_fast_math` differ on **3 of the 4** tasks, and so do `default` and
`-fmad=false`. The gate is sensitive to exactly the kind of re-association it is meant to detect -
and inside each mode the two arms still land on the same bytes.

That is expected from the change rather than lucky. **No arithmetic operation is added, removed or
reordered by either half.** The first half only reassigns which CTA computes which output tile; the
accumulation order inside a CTA is untouched. The second half delivers the same scale bytes, fetched
once instead of twice. There is no new expression for a compiler to fold.

**Resource and instruction census** (`cuobjdump`, whole series against `origin/master`, both arms
built from the same tree in turn):

| | `nvfp4_w4a4_tma` (9 instantiations) | `nvfp4_linear_swiglu_w4a4_tma` (1) |
|---|---|---|
| registers | 168 -> 168, every instantiation | 168 -> 168 |
| static shared | 1024 -> 1024 B | 1024 -> 1024 B |
| stack / local / spills | 0 -> 0 | 0 -> 0 |
| constant bank 0 | +4 B | +4 B |
| SASS instructions | 6968 -> 7352 (+5.5%) | 2424 -> 2464 (+1.7%) |
| `OMMA` | **576 -> 576** | **64 -> 64** |
| `LDSM` | **216 -> 216** | **24 -> 24** |
| `STS` / `LDS` | **576 / 405 unchanged** | **32 / 45 unchanged** |
| `BAR` / `FFMA` / `STG` | **unchanged** | **unchanged** |

The tensor-core stream and everything feeding it are byte-identical; what grows is index arithmetic -
the integer division that turns the linear CTA id into two tile indices (`UIMAD.WIDE`, `MUFU.RCP`,
`UF2I`) and the token-count guard (`ISETP`, `VIMNMX`). The four constant bytes are the added
`int token_count` kernel parameter. Raw: `census_summary.txt` in the series folder.

**This commit's own end-to-end increment.** The series is four dependent commits, so a
master-to-head table would credit each of them with all four. Instead a binary was built at every
step - `origin/master`, then each commit in turn - and all five arms run in one measurement, three
passes each, 4 measured repetitions after 2 discarded, prefill chunk 8192. The column below is this
commit against the step before it; raw data in `ladder5.txt`.

| prompt tokens | step before | this commit | delta |
|--:|--:|--:|--:|
| 256 | 8214 | 8415 | **+2.4%** |
| 512 | 11621 | 12065 | **+3.8%** |
| **4096** | 13050 | 14253 | **+9.2%** |
| 32 / 112 / 128 | | | +0.3 to +0.5% |
| 160 / 192 / 224 / 300 / 352 | | | +0.3% |
| 400 / 700 / 1023 / 2047 / 4095 / 8191 | | | -0.1 to +0.9% |

**Read that carefully: end to end this commit pays only at prompt lengths that are multiples of 256.**
That is not a weakness of the change, it is the defect the next commit in the series fixes: on
`master` a prompt whose length is not a multiple of 256 does not take this route at all, so a change
inside these kernels cannot reach it. Where the route is already taken - 256, 512, 4096 - the gain is
+2.4%, +3.8% and +9.2%, and it rises with length exactly as the operator table does. The operator
benchmark above is where this change should be judged; this table says who sees it in production
today.

**Where this does not help, measured rather than assumed.** A prefill kernel speed-up shows up in
request throughput only in proportion to prefill's share of a request. Two five-minute soak runs per
arm, one build, one load generator, four workers, only the environment differing: on a chat-shaped
mix (prompts 20..1800 words skewed short, 48 generated tokens per answer) the series moves throughput
from 6.221 to 6.199 requests/s - **-0.4% against a +/-1.05% run-to-run spread, i.e. zero** - because
prefill of a ~200-token prompt is about 25 ms of a ~640 ms request, near 4%. On a prefill-heavy mix
(unique prompts 600..4000 words, 8 generated tokens) the same binaries go from 3.777 to 4.508
requests/s, **+19.4%**. On a shared-prefix mix, where the prefix cache serves most of the prompt, they
give **+0.3%** - there is no prefill left to speed up. No errors in any arm.

So this work is worth taking for document processing, extraction, reranking and long-prompt
short-answer traffic, and worth nothing for chat-shaped traffic. The end-to-end prefill numbers above
should be read with that in mind. These three profiles measure the series as a whole; this commit's
own share of it is the increment reported above.

**Not specific to the KV codec.** Measured with `bf16`, `int8` and `fp8` KV at p = 256 / 1000 / 4095:
the candidate/baseline ratios agree to within 0.5% across all three (at p = 4095: 11354 -> 14259,
11305 -> 14218, 11337 -> 14312 tok/s). Decode is unchanged in all three (87.77 -> 87.74,
88.16 -> 88.14, 88.23 -> 88.20).

**Correctness**: four fixed tasks, greedy, `max_tokens = 96`, four arms in the order baseline /
part 2 / both / baseline - **16 of 16 responses equal by MD5 and length**. An earlier run of the same
battery on part 1 alone was likewise 16 of 16. The full four-report series was additionally gated
with the master binary and this branch's binary alternated twice: identical MD5 on all four identity
tasks in every arm, and 15/15 on a long-needle battery over 4.5k..28k-token haystacks. The
50-task quality battery read 42/50 with an identical miss set in that run; it has since been
re-taken on `b8786751` with `--no-prefix-reuse` and reads 44/50, again identical in every arm -
see the re-taken verdict above for why both numbers are quoted with their configuration.
The needle and the 50-task score are reported as **arm-to-arm agreement only**, not as evidence
about the numbers: a measured corruption ladder reads 40/40 on a needle of this shape at every rung,
including one the FP64 oracle fails at 4.88x its limit. The correctness claim here is the bitwise
identity of the output plus the math-mode gate and the SASS census; see the paragraph above.

`ctest`: **104 tests, 104 passed, 0 failed** on `a140e7ae`, run on the submitted branch
(`a91b113e`). The bases, one line per fact: the performance numbers above were measured on the
earlier base `e3aeaf8c`; the branch was rebased onto `a140e7ae` with all four `patch-id` carried
across unchanged, and the four values today are `d9511975aa02`, `7b70182ecd62`, `ea14f244ebbb` and
`5ba595122d9d` - the third moved after the rebase, when a stale figure in a comment of the floor
commit was corrected against the sweep this report prints, which changed no code line and therefore
nothing that was measured; the numbers were not re-taken on the new base; the one class of exception is the sections above that say they were reproduced on a second
host, whose arms were built and measured on `a140e7ae` itself. The test count differs between the two
bases because `a140e7ae` adds one registration, which is why it is quoted against a hash - the same
suite is 103 of 103 on `e3aeaf8c`. The suite cannot be run the usual way on this host - the test
executables are ~184 MB each and 104 of them do not fit next to the 18 GB artifact on a 32 GB disk -
so each test was built, run and deleted in turn. 100 of the registered names are ninja targets; the
remaining four are variant registrations of two executables and were run through their parents.

> **A weakness of the witness in this ladder, named rather than left to be found.** Two cells
> (`raw/ladder.txt` lines 10 and 13 - `base2` pass 3 and `base` pass 4) were recorded as clean
> while the witness collected **zero samples**: the harness kept the first line of its output
> with `| head -1`, which cannot tell "no other tenant" from "no reading taken". Both cells sit
> in counted passes and both feed the medians the re-measured figure rests on. They are not
> discarded, because discarding them would move the medians without evidence that anything was
> wrong; they are disclosed so the number can be weighed knowing it.

## Checks not run, and the resulting limitations

- **No `ncu` hardware counters.** `RmProfilingAdminOnly` is set on this host, so the byte-traffic
  argument rests on timed diagnostic variants of the kernels (TMA pipeline with the consumer removed)
  and on `nsys` kernel durations, not on measured DRAM sectors. The claim that the kernel is
  feed-bound is inferred from those timings.
- **One artifact.** Only `Qwen3.6-27B` NVFP4 takes this route on this box, so there is no second
  geometry set behind the numbers.
- **L2 assumption.** Part 1's benefit assumes the activation tile set fits in L2; measured at
  23.6 MiB against 96 MiB for the largest chunk this project uses, and the gain at T=8192 equals the
  gain at T=4096, but a larger chunk than 8192 was not tested.
- **Other quantisation families untested beyond W8.** The same grid shape exists in the q4/q5/q6/fp8
  launchers. I measured only W8 (0.0 to 1.3%, inside the noise, and explained by that kernel being
  compute-bound); the others are unmeasured and this PR does not touch them.
- **`docs/performance.md`** publishes no NVFP4 prefill figure for this artifact, so nothing there
  moves. If you would like the serve-corpus harness re-run for a published table, say so and I will
  do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
