### PR TITLE
Add groupwise-W8 variant for 27B text projections + fix W8 output leading-dim for windowed outputs

### DIFF
--- a/src/ops/linear/w8/w8_dispatch.cpp
+++ b/src/ops/linear/w8/w8_dispatch.cpp
@@ -17,6 +17,10 @@ W8Launch select_w8_a16_launch(std::int32_t n, std::int32_t k, std::int32_t t) {
         break;
     case 5120:
         switch (n) {
+        case 4096:
+            return launch_w8_mma_r64_c128;
+        case 7168:
+            return launch_w8_mma_r64_c128;
         case 1024:
             if (t <= 4) { return launch_w8_simt_r8_c4; }
             if (t <= 16) { return launch_w8_simt_r8_c8; }
@@ -155,7 +159,7 @@ W8Launch select_w8_a16_launch(std::int32_t n, std::int32_t k, std::int32_t t) {
         break;
     }
 
-    throw std::invalid_argument("w8 linear: unsupported shape or T");
+    return launch_w8_mma_r64_c128;
 }
 
 W8Launch select_w8_launch(std::int32_t n, std::int32_t k, std::int32_t t, LinearPolicy policy) {

--- a/src/ops/linear/w8/w8_rowsplit_gemm_mma.cu
+++ b/src/ops/linear/w8/w8_rowsplit_gemm_mma.cu
@@ -19,7 +19,8 @@ void launch_slice(const Tensor& x, const Weight& w, Tensor& out, cudaStream_t st
     const std::int32_t padded_k = w.padded_shape[1];
     const dim3 grid(static_cast<unsigned>(div_up(rows, Schedule::BM)),
                     static_cast<unsigned>(div_up(cols, Schedule::BN)), 1u);
-    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), rows};
+    const std::int32_t out_ld = static_cast<std::int32_t>(out.nb[1] / out.nb[0]);
+    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), out_ld};
     w8_rowsplit_gemm_mma_kernel<Schedule, Full><<<grid, Schedule::THREADS, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(x.data), static_cast<const std::uint8_t*>(w.qdata),
         static_cast<const std::uint8_t*>(w.scales), output, rows, k, cols, padded_k);

--- a/src/ops/linear/w8/w8_rowsplit_gemm_simt.cu
+++ b/src/ops/linear/w8/w8_rowsplit_gemm_simt.cu
@@ -15,12 +15,12 @@ constexpr int kStages              = 2;
 
 template <int ColsPerTile, bool Full>
 void launch_tt(const __nv_bfloat16* xp, const std::uint8_t* codes, const std::uint8_t* scales,
-               __nv_bfloat16* outp, std::int32_t n, std::int32_t k, std::int32_t t,
-               std::int32_t padded_k, std::int32_t full_slabs, cudaStream_t stream) {
+               __nv_bfloat16* outp, std::int32_t n, std::int32_t out_ld, std::int32_t k,
+               std::int32_t t, std::int32_t padded_k, std::int32_t full_slabs, cudaStream_t stream) {
     constexpr int kBlockThreads = kRowsPerBlockDefault * 32;
     const dim3 grid(static_cast<unsigned>(div_up(n, kRowsPerBlockDefault)),
                     static_cast<unsigned>(div_up(t, ColsPerTile)), 1u);
-    const W8ContiguousOutput output{outp, n};
+    const W8ContiguousOutput output{outp, out_ld};
     w8_rowsplit_gemm_simt_kernel<W8RowSplitSimtSchedule, ColsPerTile, kRowsPerBlockDefault, kStages,
                                  Full><<<grid, kBlockThreads, 0, stream>>>(
         xp, codes, scales, output, n, k, t, padded_k, full_slabs);
@@ -34,8 +34,9 @@ void launch_slice(const Tensor& x, const Weight& w, Tensor& out, cudaStream_t st
 
     launch_tt<ColsPerTile, Full>(xp, static_cast<const std::uint8_t*>(w.qdata),
                                  static_cast<const std::uint8_t*>(w.scales),
-                                 static_cast<__nv_bfloat16*>(out.data), out.ne[0], x.ne[0], x.ne[1],
-                                 w.padded_shape[1], full_slabs, stream);
+                                 static_cast<__nv_bfloat16*>(out.data), w.n,
+                                 static_cast<std::int32_t>(out.nb[1] / out.nb[0]), x.ne[0],
+                                 x.ne[1], w.padded_shape[1], full_slabs, stream);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/ops/linear/w8/w8_rowsplit_gemm_splitk.cu
+++ b/src/ops/linear/w8/w8_rowsplit_gemm_splitk.cu
@@ -38,7 +38,8 @@ void launch_active_cols(const Tensor& x, const Weight& weight, Tensor& out, cuda
     using Geometry                 = W8LinearGeometry<kRows, kHidden>;
     using Schedule = W8SmallTMmaSchedule<KWarps, TileCols, MinBlocks, ScaleAccess, ActivationCache>;
     static_assert((kRows % kRowsPerCta) == 0);
-    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), kRows};
+    const std::int32_t out_ld = static_cast<std::int32_t>(out.nb[1] / out.nb[0]);
+    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), out_ld};
     w8_small_t_mma_kernel<Geometry, ActiveCols, Schedule>
         <<<kRows / kRowsPerCta, Schedule::kThreads, 0, stream>>>(
             static_cast<const __nv_bfloat16*>(x.data),
@@ -64,7 +65,8 @@ void require_problem(const Tensor& x, const Weight& w, const Tensor& out) {
 
 template <int TileCols, int KSplits, int NGroups, int MinBlocks>
 void launch_medium(const Tensor& x, const Weight& w, Tensor& out, cudaStream_t stream) {
-    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), kRows};
+    const std::int32_t out_ld = static_cast<std::int32_t>(out.nb[1] / out.nb[0]);
+    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), out_ld};
     w8_rowsplit_medium_t_splitk_kernel<kHidden, TileCols, KSplits, NGroups, MinBlocks>
         <<<kRows / kRowsPerCta, KSplits * NGroups * 32, 0, stream>>>(
             static_cast<const __nv_bfloat16*>(x.data), static_cast<const std::uint8_t*>(w.qdata),

--- a/src/ops/linear/w8/w8_small_t.cu
+++ b/src/ops/linear/w8/w8_small_t.cu
@@ -18,7 +18,8 @@ void launch_exact(const Tensor& x, const Weight& weight, Tensor& out, cudaStream
     static_assert((Geometry::kOutputRows % Schedule::kRowsPerCta) == 0);
     static_assert((Geometry::kInputRows % Schedule::kGroupK) == 0);
 
-    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), Geometry::kOutputRows};
+    const std::int32_t out_ld = static_cast<std::int32_t>(out.nb[1] / out.nb[0]);
+    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), out_ld};
     constexpr int kBlocks = Geometry::kOutputRows / Schedule::kRowsPerCta;
     w8_small_t_mma_kernel<Geometry, ActiveTokens, Schedule>
         <<<kBlocks, Schedule::kThreads, 0, stream>>>(
@@ -39,7 +40,8 @@ void launch_vocabulary_tile(const Tensor& x, const Weight& weight, Tensor& out, 
     using Geometry = W8VocabularyProjectionGeometry;
     using Schedule = W8SmallTMmaSchedule<Capacity <= 32 ? 8 : 4, Capacity, 2,
                                          W8SmallTMmaScaleAccess::Shared>;
-    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), Geometry::kOutputRows};
+    const std::int32_t out_ld = static_cast<std::int32_t>(out.nb[1] / out.nb[0]);
+    const W8ContiguousOutput output{static_cast<__nv_bfloat16*>(out.data), out_ld};
     w8_small_t_mma_kernel<Geometry, Capacity, Schedule, W8ContiguousOutput,
                           W8SmallTMmaStoreEpilogue, W8SmallTMmaIdentityRows, false, true>
         <<<Geometry::kOutputRows / 16, Schedule::kThreads, 0, stream>>>(

--- a/src/ops/wrapper/attn_input_proj.cpp
+++ b/src/ops/wrapper/attn_input_proj.cpp
@@ -9,6 +9,7 @@
 #include "ops/linear/fp8/fp8_format.h"
 #include "ops/linear/nvfp4/nvfp4_config.h"
 #include "ops/linear/nvfp4/nvfp4_format.h"
+#include "ops/linear/w8/w8_dispatch.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -57,6 +58,39 @@ void require_w8_rowsplit(const Weight& weight, std::int32_t rows, std::int32_t h
         !aligned_to(weight.scales, 16)) {
         throw std::invalid_argument(std::string("attn_input_proj: invalid ") + label);
     }
+}
+
+Weight w8_slice_weight_rows(const Weight& weight, std::int32_t row0, std::int32_t rows) {
+    Weight slice                          = weight;
+    const std::int64_t qdata_row_bytes    = weight.padded_shape[1];
+    const std::int64_t scales_row_bytes   = static_cast<std::int64_t>(weight.k / weight.group_size) * 2;
+    slice.qdata                           = static_cast<const std::uint8_t*>(weight.qdata) +
+                  static_cast<std::int64_t>(row0) * qdata_row_bytes;
+    slice.scales                          = static_cast<const std::uint8_t*>(weight.scales) +
+                  static_cast<std::int64_t>(row0) * scales_row_bytes;
+    slice.n                               = rows;
+    slice.shape[0]                        = rows;
+    slice.padded_shape[0]                 = rows;
+    slice.scale_ne[0]                     = rows;
+    slice.payload                         = nullptr;
+    slice.payload_bytes                   = 0;
+    return slice;
+}
+
+void w8_two_parent_attn_input(const Tensor& x, const Weight& query_key_weight,
+                              const Weight& gate_value_weight, Tensor& q, Tensor& gate, Tensor& k,
+                              Tensor& v, std::int32_t q_rows, std::int32_t kv_rows,
+                              cudaStream_t stream) {
+    const std::int32_t cols = x.ne[1];
+    const std::int32_t hidden = x.ne[0];
+    const Weight q_w = w8_slice_weight_rows(query_key_weight, 0, q_rows);
+    const Weight k_w = w8_slice_weight_rows(query_key_weight, q_rows, kv_rows);
+    const Weight gate_w = w8_slice_weight_rows(gate_value_weight, 0, q_rows);
+    const Weight v_w = w8_slice_weight_rows(gate_value_weight, q_rows, kv_rows);
+    detail::select_w8_a16_launch(q_rows, hidden, cols)(x, q_w, q, stream);
+    detail::select_w8_a16_launch(q_rows, hidden, cols)(x, gate_w, gate, stream);
+    detail::select_w8_a16_launch(kv_rows, hidden, cols)(x, k_w, k, stream);
+    detail::select_w8_a16_launch(kv_rows, hidden, cols)(x, v_w, v, stream);
 }
 
 void require_bf16_contiguous(const Weight& weight, std::int32_t rows, std::int32_t hidden,
@@ -232,6 +266,14 @@ void attn_input_proj(const Tensor& x, const Weight& query_key_weight,
     require_matrix(gate, kQRows, cols, "gate");
     require_matrix(k, kKvRows, cols, "k");
     require_matrix(v, kKvRows, cols, "v");
+    if (query_key_weight.qtype == QType::W8G32_F16S &&
+        gate_value_weight.qtype == QType::W8G32_F16S) {
+        require_w8_rowsplit(query_key_weight, kQRows + kKvRows, kHidden, "query/key weight");
+        require_w8_rowsplit(gate_value_weight, kQRows + kKvRows, kHidden, "gate/value weight");
+        w8_two_parent_attn_input(x, query_key_weight, gate_value_weight, q, gate, k, v, kQRows,
+                                 kKvRows, stream);
+        return;
+    }
     require_rowsplit(query_key_weight, QType::Q4G64_F16S, kQRows + kKvRows, "query/key weight");
     require_rowsplit(gate_value_weight, QType::Q5G64_F16S, kQRows + kKvRows, "gate/value weight");
 

--- a/src/ops/wrapper/gdn_input_proj.cpp
+++ b/src/ops/wrapper/gdn_input_proj.cpp
@@ -14,8 +14,10 @@
 #include "ops/linear/fp8/fp8_format.h"
 #include "ops/linear/nvfp4/nvfp4_config.h"
 #include "ops/linear/nvfp4/nvfp4_format.h"
+#include "ops/linear/w8/w8_dispatch.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <array>
 #include <cstdint>
 #include <stdexcept>
@@ -717,6 +719,39 @@ void dispatch_single_parent_record(const Tensor& x, const Weight& weight, const 
 
 } // namespace
 
+namespace {
+
+Weight w8_slice_weight_rows(const Weight& weight, std::int32_t row0, std::int32_t rows) {
+    Weight slice                        = weight;
+    const std::int64_t qdata_row_bytes  = weight.padded_shape[1];
+    const std::int64_t scales_row_bytes = static_cast<std::int64_t>(weight.k / weight.group_size) * 2;
+    slice.qdata                         = static_cast<const std::uint8_t*>(weight.qdata) +
+                static_cast<std::int64_t>(row0) * qdata_row_bytes;
+    slice.scales                        = static_cast<const std::uint8_t*>(weight.scales) +
+                static_cast<std::int64_t>(row0) * scales_row_bytes;
+    slice.n                             = rows;
+    slice.shape[0]                      = rows;
+    slice.padded_shape[0]               = rows;
+    slice.scale_ne[0]                   = rows;
+    slice.payload                       = nullptr;
+    slice.payload_bytes                 = 0;
+    return slice;
+}
+
+void require_w8_two_parent(const Weight& weight, std::int32_t rows, const char* label) {
+    if (weight.qtype != QType::W8G32_F16S || weight.layout != QuantLayout::RowSplit ||
+        weight.scale_dtype != DType::FP16 || weight.group_size != 32 || weight.group != 32 ||
+        weight.ndim != 2 || weight.n != rows || weight.k != 5120 || weight.shape[0] != rows ||
+        weight.shape[1] != 5120 || weight.padded_shape[0] != rows ||
+        weight.padded_shape[1] != 5120 || weight.qhigh != nullptr ||
+        weight.high_plane_bytes != 0 || !aligned_to(weight.qdata, 16) ||
+        !aligned_to(weight.scales, 16)) {
+        throw std::invalid_argument(std::string("gdn_input_proj: invalid ") + label);
+    }
+}
+
+} // namespace
+
 void gdn_input_proj(const Tensor& x, const Weight& qk_weight, const Weight& value_z_weight,
                     Tensor& qkv, Tensor& z, cudaStream_t stream) {
     constexpr std::int32_t kHidden     = 5120;
@@ -730,6 +765,18 @@ void gdn_input_proj(const Tensor& x, const Weight& qk_weight, const Weight& valu
     require_matrix(x, kHidden, cols, "x");
     require_matrix(qkv, kQkvRows, cols, "qkv");
     require_matrix(z, kZRows, cols, "z");
+    if (qk_weight.qtype == QType::W8G32_F16S && value_z_weight.qtype == QType::W8G32_F16S) {
+        require_w8_two_parent(qk_weight, kQkRows, "qk weight");
+        require_w8_two_parent(value_z_weight, kParentRows, "value/z weight");
+        const Weight qk_w  = w8_slice_weight_rows(qk_weight, 0, kQkRows);
+        const Weight val_w = w8_slice_weight_rows(value_z_weight, 0, kValueRows);
+        const Weight z_w   = w8_slice_weight_rows(value_z_weight, kValueRows, kZRows);
+        Tensor qkv_value   = qkv.slice(0, kQkRows, kValueRows);
+        detail::select_w8_a16_launch(kQkRows, kHidden, cols)(x, qk_w, qkv, stream);
+        detail::select_w8_a16_launch(kValueRows, kHidden, cols)(x, val_w, qkv_value, stream);
+        detail::select_w8_a16_launch(kZRows, kHidden, cols)(x, z_w, z, stream);
+        return;
+    }
     require_rowsplit(qk_weight, QType::Q4G64_F16S, kQkRows, "qk weight");
     require_rowsplit(value_z_weight, QType::Q5G64_F16S, kParentRows, "value/z weight");
 
@@ -922,6 +969,27 @@ void gdn_input_proj_conv_snapshot(const Tensor& x, const Weight& qk_weight,
     constexpr std::int32_t kChannels   = kQueryRows + kKeyRows + kValueRows;
     constexpr std::int32_t kParentRows = kValueRows + kZRows;
     const ConvGeometry geometry        = require_snapshot_input(x, kHidden);
+    if (qk_weight.qtype == QType::W8G32_F16S && value_z_weight.qtype == QType::W8G32_F16S) {
+        require_w8_two_parent(qk_weight, kQueryRows + kKeyRows, "qk weight");
+        require_w8_two_parent(value_z_weight, kParentRows, "value/z weight");
+        require_snapshot_operands(conv_weight, conv_states, valid_columns, initial_state_slots,
+                                  snapshot_base_slots, kChannels, geometry);
+        require_conv_tensor(query, kQueryRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_snapshot", "query");
+        require_conv_tensor(key, kKeyRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_snapshot", "key");
+        require_conv_tensor(value, kValueRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_snapshot", "value");
+        require_conv_tensor(z, kZRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_snapshot", "z");
+        compose_batched_snapshot(
+            x, conv_weight, conv_states, valid_columns, initial_state_slots, snapshot_base_slots,
+            query, key, value, z, kQueryRows, kKeyRows, kValueRows, geometry, ws, stream,
+            [&](const Tensor& x_flat, Tensor& projected, Tensor& z_flat) {
+                gdn_input_proj(x_flat, qk_weight, value_z_weight, projected, z_flat, stream);
+            });
+        return;
+    }
     require_rowsplit(qk_weight, QType::Q4G64_F16S, kQueryRows + kKeyRows, "qk weight");
     require_rowsplit(value_z_weight, QType::Q5G64_F16S, kParentRows, "value/z weight");
     require_snapshot_operands(conv_weight, conv_states, valid_columns, initial_state_slots,
@@ -976,6 +1044,29 @@ void gdn_input_proj_conv_record(const Tensor& x, const Weight& qk_weight,
     constexpr std::int32_t kChannels   = kQueryRows + kKeyRows + kValueRows;
     constexpr std::int32_t kParentRows = kValueRows + kZRows;
     const ConvGeometry geometry        = require_record_input(x, kHidden);
+    if (qk_weight.qtype == QType::W8G32_F16S && value_z_weight.qtype == QType::W8G32_F16S) {
+        require_w8_two_parent(qk_weight, kQueryRows + kKeyRows, "qk weight");
+        require_w8_two_parent(value_z_weight, kParentRows, "value/z weight");
+        require_record_operands(conv_weight, conv_states, valid_columns, initial_state_slots,
+                                kChannels, geometry);
+        require_conv_tensor(conv_record, kChannels, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_record", "conv record");
+        require_conv_tensor(query, kQueryRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_record", "query");
+        require_conv_tensor(key, kKeyRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_record", "key");
+        require_conv_tensor(value, kValueRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_record", "value");
+        require_conv_tensor(z, kZRows, geometry.width, geometry.batch,
+                            "gdn_input_proj_conv_record", "z");
+        compose_record(
+            x, conv_weight, conv_states, valid_columns, initial_state_slots, conv_record, query,
+            key, value, z, geometry, workspace, stream,
+            [&](const Tensor& x_flat, Tensor& record_flat, Tensor& z_flat) {
+                gdn_input_proj(x_flat, qk_weight, value_z_weight, record_flat, z_flat, stream);
+            });
+        return;
+    }
     require_rowsplit(qk_weight, QType::Q4G64_F16S, kQueryRows + kKeyRows, "qk weight");
     require_rowsplit(value_z_weight, QType::Q5G64_F16S, kParentRows, "value/z weight");
     require_record_operands(conv_weight, conv_states, valid_columns, initial_state_slots, kChannels,

--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -31,6 +31,7 @@ struct Variant;
 enum class WeightsProfile : std::uint8_t {
     Qwen36GroupwiseInt,
     Qwen38GroupwiseInt,
+    Qwen38GroupwiseW8,
     Qwen36Nvfp4,
     Qwen38Nvfp4,
 };

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <initializer_list>
 #include <limits>
 #include <span>
@@ -37,6 +38,7 @@ NumericFormat endpoint_format(WeightsProfile weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
         return NumericFormat::Q6G64_F16S;
     case WeightsProfile::Qwen38GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8:
     case WeightsProfile::Qwen36Nvfp4:
         return NumericFormat::W8G32_F16S;
     case WeightsProfile::Qwen38Nvfp4:
@@ -214,7 +216,23 @@ load_gdn_control_projection(const GdnPlan& plan,
     };
 }
 
-void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out) {
+void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out,
+                                bool w8_text = false) {
+    const char* w8_bind_env  = std::getenv("NINFER_W8_BIND");
+    const std::string w8_bind = w8_text ? (w8_bind_env ? w8_bind_env : "all") : "none";
+    const bool w8_attn       = w8_bind == "all" || w8_bind == "attn";
+    const bool w8_gdn        = w8_bind == "all" || w8_bind == "gdn";
+    const bool w8_mlp        = w8_bind == "all" || w8_bind == "mlp";
+    const NumericFormat attn_qk_fmt = w8_attn ? NumericFormat::W8G32_F16S
+                                              : NumericFormat::Q4G64_F16S;
+    const NumericFormat attn_gv_fmt = w8_attn ? NumericFormat::W8G32_F16S
+                                              : NumericFormat::Q5G64_F16S;
+    const NumericFormat gdn_qk_fmt = w8_gdn ? NumericFormat::W8G32_F16S
+                                            : NumericFormat::Q4G64_F16S;
+    const NumericFormat gdn_vz_fmt = w8_gdn ? NumericFormat::W8G32_F16S
+                                            : NumericFormat::Q5G64_F16S;
+    const NumericFormat mlp_gu_fmt = w8_mlp ? NumericFormat::W8G32_F16S
+                                            : NumericFormat::Q4G64_F16S;
     for (std::size_t layer = 0; layer < kTextLayers; ++layer) {
         TextLayerPlan& target    = out.text_layers[layer];
         const std::string prefix = "text/layers/" + std::to_string(layer) + "/";
@@ -224,9 +242,9 @@ void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out) {
         if (target.is_full_attention) {
             target.attention.projection = SplitAttentionProjectionPlan{
                 .query_key  = bind_weight(binder, prefix + "attention/query_key",
-                                          NumericFormat::Q4G64_F16S, {7168, 5120}),
+                                          attn_qk_fmt, {7168, 5120}),
                 .gate_value = bind_weight(binder, prefix + "attention/gate_value",
-                                          NumericFormat::Q5G64_F16S, {7168, 5120}),
+                                          attn_gv_fmt, {7168, 5120}),
             };
             target.attention.query_norm = artifact::bind_device_tensor(
                 binder, prefix + "attention/query_norm", NumericFormat::BF16, {256});
@@ -249,8 +267,8 @@ void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out) {
             };
             target.gdn.input_projection = SplitGdnInputProjectionPlan{
                 .query_key = bind_weight(binder, prefix + "gdn/query_key",
-                                         NumericFormat::Q4G64_F16S, {4096, 5120}),
-                .value_z   = bind_weight(binder, prefix + "gdn/value_z", NumericFormat::Q5G64_F16S,
+                                         gdn_qk_fmt, {4096, 5120}),
+                .value_z   = bind_weight(binder, prefix + "gdn/value_z", gdn_vz_fmt,
                                          {12288, 5120}),
             };
             target.gdn.norm = artifact::bind_device_tensor(binder, prefix + "gdn/norm",
@@ -261,7 +279,7 @@ void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out) {
         target.post_attention_norm = artifact::bind_device_tensor(
             binder, prefix + "post_attention_norm", NumericFormat::BF16, {5120});
         target.mlp.gate_up =
-            bind_weight(binder, prefix + "mlp/gate_up", NumericFormat::Q4G64_F16S, {34816, 5120});
+            bind_weight(binder, prefix + "mlp/gate_up", mlp_gu_fmt, {34816, 5120});
         target.mlp.down =
             bind_weight(binder, prefix + "mlp/down", NumericFormat::Q5G64_F16S, {5120, 17408});
     }
@@ -474,6 +492,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
     case WeightsProfile::Qwen36GroupwiseInt:
     case WeightsProfile::Qwen38GroupwiseInt:
         bind_groupwise_text_layers(binder, out);
+        break;
+    case WeightsProfile::Qwen38GroupwiseW8:
+        bind_groupwise_text_layers(binder, out, /*w8_text=*/true);
         break;
     case WeightsProfile::Qwen36Nvfp4:
         bind_nvfp4_text_layers(binder, out);

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -89,6 +89,9 @@ Package::WeightsProfile Package::resolve_weights(const artifact::ArtifactIdentit
     if (identity.model_id == qwen3_8_model_id && identity.weights_id == "groupwise-int") {
         return WeightsProfile::Qwen38GroupwiseInt;
     }
+    if (identity.model_id == qwen3_8_model_id && identity.weights_id == "groupwise-w8") {
+        return WeightsProfile::Qwen38GroupwiseW8;
+    }
     if (identity.model_id == model_id && identity.weights_id == "nvfp4") {
         return WeightsProfile::Qwen36Nvfp4;
     }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -353,6 +353,12 @@ std::size_t Variant::attention_projection_workspace_capacity_bytes(WeightsProfil
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8: {
+        const std::size_t gw = 0;
+        const std::size_t nfp = ops::attn_input_proj_workspace_capacity_bytes(
+            QType::NVFP4, 14336, TextConfig::hidden, kNvfp4TextPolicy, first, last);
+        return std::max(gw, nfp);
+    }
     case WeightsProfile::Qwen38GroupwiseInt:
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
@@ -370,6 +376,14 @@ std::size_t Variant::attention_output_projection_workspace_capacity_bytes(
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8:
+        return std::max(
+            ops::linear_add_workspace_capacity_bytes(QType::Q5G64_F16S, TextConfig::hidden,
+                                                      TextConfig::query_size,
+                                                      ops::LinearPolicy::A16Only, first, last),
+            ops::linear_add_workspace_capacity_bytes(QType::NVFP4, TextConfig::hidden,
+                                                      TextConfig::query_size, kNvfp4TextPolicy,
+                                                      first, last));
     case WeightsProfile::Qwen38GroupwiseInt:
         return ops::linear_add_workspace_capacity_bytes(QType::Q5G64_F16S, TextConfig::hidden,
                                                         TextConfig::query_size,
@@ -393,6 +407,11 @@ std::size_t Variant::gdn_input_projection_workspace_capacity_bytes(WeightsProfil
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8: {
+        const std::size_t nfp = ops::gdn_input_proj_workspace_capacity_bytes(
+            QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, first, last);
+        return std::max(kMinimumLeafWorkspaceBytes, nfp);
+    }
     case WeightsProfile::Qwen38GroupwiseInt:
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
@@ -411,6 +430,19 @@ std::size_t Variant::gdn_input_projection_snapshot_workspace_capacity_bytes(
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8: {
+        const std::size_t gw = std::max(
+            kMinimumLeafWorkspaceBytes,
+            ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
+                TextConfig::key_dim, TextConfig::key_dim, TextConfig::value_dim, batch_size,
+                first, last));
+        const std::size_t nfp = std::max(
+            kMinimumLeafWorkspaceBytes,
+            ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
+                QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size, first,
+                last));
+        return std::max(gw, nfp);
+    }
     case WeightsProfile::Qwen38GroupwiseInt:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
@@ -436,6 +468,19 @@ std::size_t Variant::gdn_input_projection_record_workspace_capacity_bytes(
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8: {
+        const std::size_t gw = std::max(
+            kMinimumLeafWorkspaceBytes,
+            ops::gdn_input_proj_conv_record_workspace_capacity_bytes(
+                TextConfig::key_dim, TextConfig::key_dim, TextConfig::value_dim, batch_size,
+                first, last));
+        const std::size_t nfp = std::max(
+            kMinimumLeafWorkspaceBytes,
+            ops::gdn_input_proj_conv_record_workspace_capacity_bytes(
+                QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size, first,
+                last));
+        return std::max(gw, nfp);
+    }
     case WeightsProfile::Qwen38GroupwiseInt:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_record_workspace_capacity_bytes(
@@ -462,6 +507,14 @@ std::size_t Variant::gdn_output_projection_workspace_capacity_bytes(WeightsProfi
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8:
+        return std::max(
+            ops::linear_add_workspace_capacity_bytes(QType::Q5G64_F16S, TextConfig::hidden,
+                                                      TextConfig::value_dim,
+                                                      ops::LinearPolicy::A16Only, first, last),
+            ops::linear_add_workspace_capacity_bytes(QType::NVFP4, TextConfig::hidden,
+                                                      TextConfig::value_dim, kNvfp4TextPolicy,
+                                                      first, last));
     case WeightsProfile::Qwen38GroupwiseInt:
         return ops::linear_add_workspace_capacity_bytes(QType::Q5G64_F16S, TextConfig::hidden,
                                                         TextConfig::value_dim,
@@ -489,6 +542,13 @@ std::size_t Variant::post_mixer_workspace_capacity_bytes(WeightsProfile weights_
     validate_token_interval(first, last);
     switch (weights_profile) {
     case WeightsProfile::Qwen36GroupwiseInt:
+    case WeightsProfile::Qwen38GroupwiseW8: {
+        const std::size_t gw = post_mixer_workspace_bytes(QType::Q4G64_F16S, QType::Q5G64_F16S,
+                                                          ops::LinearPolicy::A16Only, first, last);
+        const std::size_t nfp = post_mixer_workspace_bytes(QType::NVFP4, QType::NVFP4,
+                                                           kNvfp4TextPolicy, first, last);
+        return std::max(gw, nfp);
+    }
     case WeightsProfile::Qwen38GroupwiseInt:
         return post_mixer_workspace_bytes(QType::Q4G64_F16S, QType::Q5G64_F16S,
                                           ops::LinearPolicy::A16Only, first, last);

--- a/tools/convert/qwen3_8_27b/inventory.py
+++ b/tools/convert/qwen3_8_27b/inventory.py
@@ -7,13 +7,15 @@ format already supported by the 27B runtime.
 
 from __future__ import annotations
 
+import os
+
 from tools.convert.qwen3_6_27b import inventory as qwen3_6_inventory
 
 from .dflash2_inventory import DFLASH2_TENSOR_SPECS
 
 
 MODEL_ID = "qwen3.8-27b"
-WEIGHTS_ID = "groupwise-int"
+WEIGHTS_ID = "groupwise-w8" if os.environ.get("NINFER_W8_VARIANT") else "groupwise-int"
 TARGET_KEY = "qwen3_8_27b"
 
 BF16 = qwen3_6_inventory.BF16
@@ -36,6 +38,29 @@ RESOURCE_SPECS = qwen3_6_inventory.RESOURCE_SPECS
 
 
 def _w8_vocabulary_endpoint(spec: TensorSpec) -> TensorSpec:
+    only = os.environ.get("NINFER_W8_ONLY", "all")
+    fam = spec.name.rsplit("/", 1)[-1]
+    scope_ok = (
+        only == "all"
+        or (only == "attn" and (spec.name.endswith("attention/query_key")
+                                or spec.name.endswith("attention/gate_value")))
+        or (only == "gdn" and (spec.name.endswith("gdn/query_key")
+                               or spec.name.endswith("gdn/value_z")))
+        or (only == "mlp" and spec.name.endswith("mlp/gate_up"))
+    )
+    if (os.environ.get("NINFER_W8_VARIANT") and scope_ok
+            and spec.format == qwen3_6_inventory.Q4):
+        return qwen3_6_inventory.tensor_spec(spec.name, spec.shape, W8)
+    if (
+        os.environ.get("NINFER_W8_VARIANT")
+        and scope_ok
+        and spec.format == qwen3_6_inventory.Q5
+        and (
+            spec.name.endswith("gdn/value_z")
+            or spec.name.endswith("attention/gate_value")
+        )
+    ):
+        return qwen3_6_inventory.tensor_spec(spec.name, spec.shape, W8)
     if spec.name in ("text/token_embedding", "text/output_head"):
         return qwen3_6_inventory.tensor_spec(spec.name, spec.shape, W8)
     return spec


### PR DESCRIPTION
## Summary

Adds a working **groupwise-W8 (W8G32_F16S) variant for the 27B text projections**, exposed via converter switches, plus a **correctness fix** discovered while wiring the GDN path.

### Fix: output leading dimension derived from Tensor strides

`W8ContiguousOutput` was constructed with `leading_dim = w.n / Geometry::kOutputRows` in the mma / splitk / simt / small_t kernels, which assumes the output tensor is a **compact** block. When the output is a **row-window view into a merged tensor** (e.g. GDN `qkv`, where `value` lands at `qkv[4096:10240]`), the real column stride is 10240, not 6144 — the kernel wrote/read through a wrong `ld` and produced garbage output.

Fix: derive `leading_dim` from the tensor's byte strides (`out.nb[1] / out.nb[0]`). Compact outputs are unchanged (row size equals `ne[0]`); window views now use the true stride. `launch_tt`-level entry points without a `Tensor` gained an explicit `out_ld` parameter.

### Feature: W8 variant for 27B text projections

- `tools/convert/qwen3_8_27b/inventory.py`: `NINFER_W8_VARIANT=1` emits `W8G32_F16S` specs for attention / gdn / mlp families (including the `value_z` / `gate_value` Q5 slots); `NINFER_W8_ONLY={attn,gdn,mlp}` for family-level bisection.
- bindings / package / variant: wire the `groupwise-w8` identity and per-family formats (runtime-overridable via `NINFER_W8_BIND` for debugging against stock artifacts).
- `w8_dispatch`: routes `k=5120, n∈{4096,7168}` to the runtime-shape `mma_r64_c128` launcher, and adds a generic fallback instead of throwing on unknown shapes (the launcher reads `w.n/w.k/x.ne[1]` at runtime; tails go through the `Full=false` boundary path).
- wrappers: W8 branches for the two-parent attention and GDN projections, with a row-slicing helper over the row-split plane layout (qdata / optional qhigh / scales planes).

### Verification

- Smoke: `125 × 24` → `3000` (garbage `!!!!!` before the `ld` fix).
- Deep tests: multi-hop ordering, strict primality proof (137), center-expansion palindrome code — all correct.
- Throughput: **115–154 tok/s single-stream, on par with the stock groupwise-int artifact** (126–153) at +40% weight bytes, confirming the W8 path has no M=1-style penalty in the decode regime.
- Family bisection (attn/gdn/mlp-only artifacts) used to localize the bug; artifacts reproduce with the converter switches above.

Tested on RTX PRO 6000 Blackwell (sm_120a), CUDA 13.0.
