### PR TITLE
fix(build): include cuda_bf16.h in linear_topk q4_m64

### DIFF
--- a/src/ops/linear_topk/q4_m64.cu
+++ b/src/ops/linear_topk/q4_m64.cu
@@ -1,5 +1,6 @@
 #include "ops/linear_topk/linear_topk_launch.h"
 
+#include <cuda_bf16.h>
 #include "core/device.h"
 #include "ops/common/memory.cuh"
 #include "ops/common/mma.cuh"


### PR DESCRIPTION
## Linked Issue and scope

Closes #218. Scope as proposed in the Issue: one-line build fix — add the missing
`#include <cuda_bf16.h>` to `src/ops/linear_topk/q4_m64.cu`. No behavior, API, or
product-scope change.

Note: per `CONTRIBUTING.md` I filed the Issue first; I am opening this PR immediately
at the reporter's request rather than waiting for maintainer scope confirmation, so
please treat prior confirmation as pending and close without detailed review if you
would rather implement it independently.

## Design and fit

`q4_m64.cu` uses `__nv_bfloat16` / `__nv_bfloat162` / `__floats2bfloat162_rn` but never
includes the header that defines them. Sibling `w8_m64.cu` has an otherwise identical
include list plus `ops/linear/w8/w8_small_t_mma.cuh`, which is what transitively
provides `<cuda_bf16.h>` there. `q4_m64.cu` does not need the W8 MMA header, so the
correct fix within the current Op ownership boundary is the direct standard include,
matching every other bf16-using TU in the tree (`grep -rn cuda_bf16.h src/`). One
insertion, no other files touched.

Target: `master` (checked `origin/dev` — same commit `b88c0f6f`, same broken file, no
conflicting in-flight work).

## Affected behavior / contract

Build-only. No runtime, numeric, API, CLI, schema, or documentation change.

## Verification

```sh
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel   # exit 0
git diff --check                 # clean
```

- Without the fix (change stashed): build fails on `q4_m64.cu.o` with `incomplete type
  "__nv_bfloat162 [4]"`, `incomplete type "__nv_bfloat16 ..."`, and `identifier
  "__floats2bfloat162_rn" is undefined` (nvcc 13.3.73) — exact log in #218.
- With the fix: full build succeeds, exit 0; `build/apps/ninfer`,
  `build/apps/ninfer-serve`, `build/apps/ninfer-perplexity` link. The fixed TU was
  rebuilt from the failing state to the passing state in-tree (not just a fresh
  single-file compile).
- Hardware/toolchain: RTX 5090 (`sm_120a`, `CUDA_VISIBLE_DEVICES=0`), driver 610.57.04,
  CUDA UMD 13.3, nvcc 13.3.73, cmake 4.4.3, ninja 1.13.2, gcc 16.2.1.
- No performance claim; no benchmark run (nothing to measure — previously unbuildable).

## Checks not run and limitations

- Full `tests/` suite and `bench/` operator benchmarks not run: the change adds a
  missing standard CUDA header to one TU and alters no code, types, or launch
  geometry, so there is no numeric or performance surface to qualify; the material
  claim (it builds) is directly evidenced above.
- Maintainer-toolchain build (CUDA 13.1 per `AGENTS.md`) not verified — I only have
  CUDA 13.3 here. The added include is unconditional and already the tree-wide idiom,
  so regression risk on 13.1 is negligible, but I cannot demonstrate it.
