### PR TITLE
MTP graph profiles carry no topology class, so one executable serves two attention routes and any draft window past five fails at startup

### DIFF
--- a/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/variant.cpp
@@ -7,6 +7,7 @@
 #include "ninfer/ops/sparse_moe.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 
 #define NINFER_QWEN36_VARIANT    ::ninfer::targets::qwen3_6_35b_a3b::detail::Variant
@@ -54,13 +55,38 @@ std::vector<GraphExecutionProfile> dflash_base_profiles(std::uint32_t capacity,
     return graph_profiles_through(max_frontier, ends);
 }
 
-bool dflash_target_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_t batch_size,
-                                        std::uint32_t max_visible_keys) {
+bool verify_uses_chunked_small_t(std::uint32_t draft_window, std::uint32_t batch_size,
+                                 std::uint32_t max_visible_keys) {
     const std::uint32_t tokens = draft_window + 1;
     if (tokens <= 6) { return false; }
     if (batch_size > 1) { return true; }
+    // At batch one the route only depends on the target while the width is inside the verify
+    // domain; past it causal_attention_resolve_route returns Prompt for every envelope. Without
+    // this line the mirror claims a target dependence the route does not have, which costs a
+    // second topology class at widths no verify path can request.
+    if (tokens > 16) { return false; }
     const std::uint32_t prompt_visible_limit = tokens <= 12 ? 512U : 1024U;
     return max_visible_keys > prompt_visible_limit;
+}
+
+// Largest target size that still resolves away from ChunkedSmallT for this verify width, or zero
+// when the route does not depend on the target at all. Found by bisecting
+// verify_uses_chunked_small_t itself, which is monotone in max_visible_keys, so a planner that
+// needs to break its frontier at the route flip never restates the route table to do it.
+std::uint32_t verify_route_flip_target(std::uint32_t draft_window) {
+    constexpr std::uint32_t kUnbounded = std::numeric_limits<std::uint32_t>::max();
+    if (!verify_uses_chunked_small_t(draft_window, 1U, kUnbounded)) { return 0U; }
+    std::uint32_t prompt_side  = 0U;
+    std::uint32_t chunked_side = kUnbounded;
+    while (chunked_side - prompt_side > 1U) {
+        const std::uint32_t mid = prompt_side + (chunked_side - prompt_side) / 2U;
+        if (verify_uses_chunked_small_t(draft_window, 1U, mid)) {
+            chunked_side = mid;
+        } else {
+            prompt_side = mid;
+        }
+    }
+    return prompt_side;
 }
 
 void run_sparse_moe(const Tensor& hidden, const ops::SparseMoeWeights& weights, Tensor& residual,
@@ -105,9 +131,25 @@ std::vector<GraphExecutionProfile> Variant::mtp_graph_profiles(std::uint32_t cap
     for (const std::uint32_t visible_end : {128U, 512U, 2048U, 4096U, 8198U, 16390U, 32768U}) {
         add_shifted(visible_end, 2 * draft_window);
     }
+    // Past a verify width of six the attention route stops being unconditional and starts turning
+    // on the envelope visible-key count, so the frontier has to break where the route flips: the
+    // two sides emit different node counts and cannot share one executable. The break is derived
+    // from the same predicate that sets topology_class below, so the boundary and the class it is
+    // meant to separate cannot drift apart, and it keeps holding above the window any verify path
+    // can request today.
+    const std::uint32_t flip_target = verify_route_flip_target(draft_window);
+    if (flip_target != 0U) { add_shifted(flip_target, draft_window + 1); }
     std::sort(ends.begin(), ends.end());
     ends.erase(std::unique(ends.begin(), ends.end()), ends.end());
-    return graph_profiles_through(capacity - 1, ends);
+
+    std::vector<GraphExecutionProfile> profiles = graph_profiles_through(capacity - 1, ends);
+    for (GraphExecutionProfile& profile : profiles) {
+        const std::uint32_t target_max = static_cast<std::uint32_t>(std::min<std::uint64_t>(
+            capacity, static_cast<std::uint64_t>(profile.max) + draft_window + 1ULL));
+        profile.topology_class =
+            verify_uses_chunked_small_t(draft_window, 1U, target_max) ? 1U : 0U;
+    }
+    return profiles;
 }
 
 std::vector<GraphExecutionProfile> Variant::dflash_graph_profiles(std::uint32_t capacity,
@@ -119,7 +161,7 @@ std::vector<GraphExecutionProfile> Variant::dflash_graph_profiles(std::uint32_t 
             capacity, static_cast<std::uint64_t>(profile.max) + draft_window + 1ULL));
         const bool split_swa           = profile.max > 96U;
         const bool chunked_target =
-            dflash_target_uses_chunked_small_t(draft_window, batch_size, target_max);
+            verify_uses_chunked_small_t(draft_window, batch_size, target_max);
         profile.topology_class = (chunked_target ? 2U : 0U) | (split_swa ? 1U : 0U);
     }
     return profiles;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,14 @@ ninfer_add_test(ninfer_qwen3_6_35b_a3b_dflash_real_test
   SOURCES targets/qwen3_6_35b_a3b/test_engine_dflash_real.cpp
   LIBRARIES ninfer_engine)
 set_tests_properties(ninfer_qwen3_6_35b_a3b_dflash_real_test PROPERTIES SKIP_RETURN_CODE 77)
+ninfer_add_test(ninfer_qwen3_6_35b_a3b_mtp_graph_profiles_test
+  SOURCES targets/qwen3_6_35b_a3b/test_mtp_graph_profiles.cpp
+  LIBRARIES ninfer_engine)
+target_include_directories(ninfer_qwen3_6_35b_a3b_mtp_graph_profiles_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+  ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6/export
+  ${PROJECT_SOURCE_DIR}/src/targets/qwen3_6_35b_a3b/export)
+target_link_libraries(ninfer_qwen3_6_35b_a3b_mtp_graph_profiles_test PRIVATE CUDA::cudart)
 ninfer_add_test(ninfer_qwen3_6_35b_a3b_dflash_load_plan_test
   SOURCES targets/qwen3_6_35b_a3b/test_dflash_load_plan.cpp
   NEEDS_SOURCE_DIR

--- a/tests/targets/qwen3_6_35b_a3b/test_mtp_graph_profiles.cpp
+++ b/tests/targets/qwen3_6_35b_a3b/test_mtp_graph_profiles.cpp
@@ -1,0 +1,124 @@
+// Contract of Variant::mtp_graph_profiles: profiles that resolve to different attention routes
+// must not share a topology class, because instantiate_graph_family instantiates one
+// cudaGraphExec_t per class and installs every other profile of that class through
+// cudaGraphExecUpdate, which cannot cross a change of node count.
+
+#include "ninfer/targets/qwen3_6/round_state.h"
+#include "ninfer/types.h"
+#include "ops/softmax_attention/dense/causal_cache/launch.h"
+#include "targets/qwen3_6_35b_a3b/impl/variant.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <vector>
+
+namespace {
+
+using ninfer::KvCacheStorage;
+using ninfer::ops::CausalAttentionExecutionEnvelope;
+using ninfer::ops::detail::causal_attention_resolve_route;
+using ninfer::ops::detail::causal_attention_route_name;
+using ninfer::ops::detail::CausalAttentionRoute;
+using Variant = ninfer::targets::qwen3_6_35b_a3b::detail::Variant;
+
+constexpr std::int32_t kQueryHeads =
+    ninfer::targets::qwen3_6_35b_a3b::detail::TextConfig::query_heads;
+
+// Every KV storage the engine can be configured with. The route table branches on storage, so a
+// planner that is right for one of them is not thereby right for the rest.
+constexpr KvCacheStorage kStorages[] = {
+    KvCacheStorage::BFloat16,     KvCacheStorage::Int8Group64,      KvCacheStorage::Fp8E4M3Row256,
+    KvCacheStorage::Nvfp4Group16, KvCacheStorage::Fp8KeyNvfp4Value,
+};
+
+CausalAttentionRoute route_at(std::uint32_t capacity, std::uint32_t draft_window,
+                              std::uint32_t frontier, KvCacheStorage storage) {
+    const std::uint64_t target =
+        std::min<std::uint64_t>(capacity, static_cast<std::uint64_t>(frontier) + draft_window + 1);
+    return causal_attention_resolve_route(
+        kQueryHeads, static_cast<std::int32_t>(draft_window) + 1, 1, storage,
+        CausalAttentionExecutionEnvelope{1U, static_cast<std::uint32_t>(target)});
+}
+
+int failures = 0;
+
+void check(std::uint32_t capacity, std::uint32_t draft_window, KvCacheStorage storage) {
+    const int kv        = static_cast<int>(storage);
+    const auto profiles = Variant::mtp_graph_profiles(capacity, draft_window);
+    if (profiles.empty()) {
+        std::cerr << "capacity=" << capacity << " k=" << draft_window << ": no profiles\n";
+        ++failures;
+        return;
+    }
+
+    std::uint32_t expected_min = 0;
+    for (const auto& profile : profiles) {
+        if (profile.min != expected_min || profile.max < profile.min) {
+            std::cerr << "capacity=" << capacity << " k=" << draft_window
+                      << ": frontier coverage has a hole at [" << profile.min << "," << profile.max
+                      << "]\n";
+            ++failures;
+        }
+        expected_min = profile.max + 1;
+    }
+    if (profiles.back().max != capacity - 1) {
+        std::cerr << "capacity=" << capacity << " k=" << draft_window << ": coverage stops at "
+                  << profiles.back().max << "\n";
+        ++failures;
+    }
+
+    // 1. one route per profile: the executable installed for a profile is replayed across the
+    //    whole frontier range of that profile.
+    for (const auto& profile : profiles) {
+        const CausalAttentionRoute lo = route_at(capacity, draft_window, profile.min, storage);
+        const CausalAttentionRoute hi = route_at(capacity, draft_window, profile.max, storage);
+        if (lo != hi) {
+            std::cerr << "capacity=" << capacity << " k=" << draft_window << " kv=" << kv
+                      << ": profile [" << profile.min << "," << profile.max << "] class "
+                      << profile.topology_class << " spans a route flip "
+                      << causal_attention_route_name(lo) << " -> "
+                      << causal_attention_route_name(hi) << "\n";
+            ++failures;
+        }
+    }
+
+    // 2. one class per route: profiles of different routes must not share an executable.
+    std::map<std::uint32_t, CausalAttentionRoute> route_of_class;
+    for (const auto& profile : profiles) {
+        const CausalAttentionRoute route = route_at(capacity, draft_window, profile.max, storage);
+        const auto [it, inserted]        = route_of_class.emplace(profile.topology_class, route);
+        if (!inserted && it->second != route) {
+            std::cerr << "capacity=" << capacity << " k=" << draft_window << " kv=" << kv
+                      << ": class " << profile.topology_class << " carries both "
+                      << causal_attention_route_name(it->second) << " and "
+                      << causal_attention_route_name(route) << " (profile [" << profile.min << ","
+                      << profile.max << "])\n";
+            ++failures;
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    // One past the widest window any registered verify path can request today
+    // (kMtpDecodeMaximumDrafts is 5, kDFlashDecodeMaximumDrafts is 15), so the guard that adds
+    // the route-flip boundary is itself covered rather than trusted.
+    constexpr std::uint32_t kSweptDraftWindows =
+        ninfer::targets::qwen3_6::kDFlashDecodeMaximumDrafts + 1U;
+    for (const std::uint32_t capacity : {2048U, 16384U, 65536U, 262144U}) {
+        for (std::uint32_t draft_window = 1; draft_window <= kSweptDraftWindows; ++draft_window) {
+            for (const KvCacheStorage storage : kStorages) {
+                check(capacity, draft_window, storage);
+            }
+        }
+    }
+    if (failures != 0) {
+        std::cerr << failures << " MTP graph-profile contract violation(s)\n";
+        return 1;
+    }
+    std::cout << "MTP graph profiles keep one attention route per topology class\n";
+    return 0;
+}


### PR DESCRIPTION
`instantiate_graph_family` builds one `cudaGraphExec_t` per topology class and installs every other
profile of that class through `cudaGraphExecUpdate`, which cannot cross a change of node count.

`dflash_graph_profiles` honours that twice: it breaks the frontier where the attention route flips
(`variant.cpp:49-51`) and derives `topology_class` from the same predicate (`:114-124`).
`mtp_graph_profiles`, three functions above it in the same file, does neither — every profile it
returns carries class 0.

## It is a hard failure, not a style point

Raising the MTP draft cap — four constants, no other change — on this build:

| draft tokens | master | with this change |
|---|---|---|
| 1–5 | ok | ok |
| **6, 7, 8, 11, 12, 15** | `error: startup failed \| preparing CUDA graphs`<br>`cudaErrorGraphExecUpdateFailure (update result 2)` | ok |

## Change

`mtp_graph_profiles` now breaks the frontier at the route flip and sets `topology_class` from the
same predicate `dflash_graph_profiles` uses.

* the predicate is renamed `verify_uses_chunked_small_t` because both planners read it now — a
  second copy is what would drift;
* it gains the width bound the real route has: `causal_attention_resolve_route` returns `Prompt` for
  every envelope past `kMaximumVerifyTokens`, so claiming a target dependence beyond width 16 costs
  a topology class no verify path can request;
* `verify_route_flip_target` locates the boundary by bisecting that predicate — monotone in
  `max_visible_keys` — rather than restating the route table, which is how the planner and the route
  could drift apart in the first place.

1 file, +46 / −4.

## Evidence

New contract test over capacities 2048 / 16384 / 65536 / 262144, draft windows 1..16, all five
`KvCacheStorage` values: no profile may span a route flip inside its own frontier range, and no
topology class may carry two routes.

| | `b88c0f6` | with this change |
|---|---:|---:|
| contract violations | **1150**, over 40 (capacity, k) pairs, k = 6..15 | **0** |
| `ctest` | 114/114 | 116/116 |

## At the shipped cap it is a no-op

At k ≤ 5 every width resolves to `SmallT`, so no class changes and the added boundary sits behind
`if (flip_target != 0)` — the profile list does not move by one element. Measured too: stock caps,
greedy, k = 1..5, two binaries of different `md5` print byte-identical token ids, 5 of 5, while the
same comparison separates k=1 from k=5.

`dflash_graph_profiles` is unchanged: the renamed predicate takes the same arguments, and the new
width bound cannot fire there because DFlash caps at 15.

This does not raise the MTP draft window and proposes no wider window — that needs its own case on
a workload. It removes the crash that meets anyone who raises it, and pins the contract with a test.

RTX 5090 `sm_120a`, CUDA 13.1, Release, `qwen3_6_35b_a3b.ninfer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
